### PR TITLE
Sentraliser påminnelse-logikk og rydd utils

### DIFF
--- a/app/(app)/arrangementer/[id]/Chat.tsx
+++ b/app/(app)/arrangementer/[id]/Chat.tsx
@@ -47,6 +47,7 @@ export default function Chat({
 
   const profilMap = useRef(new Map(profiler.map(p => [p.id, p.navn ?? 'Ukjent']))).current
   const andreProfiler = useRef(profiler.filter(p => p.id !== brukerId && p.navn)).current
+  const supabase = useRef(createClient()).current
 
   // Finn @mention-forslag basert på tekst etter siste @
   const mentionForslag = mentionSøk !== null
@@ -109,7 +110,6 @@ export default function Chat({
   // Realtime-subscription
   useEffect(() => {
     let cancelled = false
-    const supabase = createClient()
 
     async function startSubscription() {
       const { data: { session } } = await supabase.auth.getSession()
@@ -154,13 +154,12 @@ export default function Chat({
       cancelled = true
       if (channelRef) supabase.removeChannel(channelRef)
     }
-  }, [arrangementId])
+  }, [arrangementId, supabase])
 
   // Re-fetch ved visibilitychange (iOS PWA dropper WebSocket i bakgrunnen)
   useEffect(() => {
     async function reFetch() {
       if (document.visibilityState !== 'visible') return
-      const supabase = createClient()
       const { data } = await supabase
         .from('arrangement_chat')
         .select('id, profil_id, innhold, opprettet')
@@ -172,7 +171,7 @@ export default function Chat({
 
     document.addEventListener('visibilitychange', reFetch)
     return () => document.removeEventListener('visibilitychange', reFetch)
-  }, [arrangementId])
+  }, [arrangementId, supabase])
 
   async function handleSend() {
     const melding = tekst.trim()
@@ -205,7 +204,6 @@ export default function Chat({
     try {
       await slettMelding(id)
     } catch {
-      const supabase = createClient()
       const { data } = await supabase
         .from('arrangement_chat')
         .select('id, profil_id, innhold, opprettet')

--- a/app/(app)/innstillinger/actions.ts
+++ b/app/(app)/innstillinger/actions.ts
@@ -1,20 +1,14 @@
 'use server'
 
-import { createServerClient } from '@/lib/supabase/server'
-import { sendPaaminneVarsler, sendPurringVarsler } from '@/lib/varsler'
-import { norskDatoNaa } from '@/lib/dato'
-import { addDays } from 'date-fns'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { getProfil } from '@/lib/auth-cache'
+import { kjorPaaminnelser } from '@/lib/actions/paaminnelser'
 import { revalidatePath } from 'next/cache'
 
 export async function oppdaterVarselInnstilling(noekkel: string, aktiv: boolean) {
-  const supabase = await createServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) return
-
-  const { data: profil } = await supabase.from('profiles').select('rolle').eq('id', user.id).single()
+  const profil = await getProfil()
   if (profil?.rolle !== 'admin') return
 
-  const { createAdminClient } = await import('@/lib/supabase/admin')
   const admin = createAdminClient()
   await admin
     .from('varsel_innstillinger')
@@ -25,30 +19,10 @@ export async function oppdaterVarselInnstilling(noekkel: string, aktiv: boolean)
 }
 
 export async function kjorPaaminnerManuelt(): Promise<boolean> {
-  const supabase = await createServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) return false
-
-  const { data: profil } = await supabase.from('profiles').select('rolle').eq('id', user.id).single()
+  const profil = await getProfil()
   if (profil?.rolle !== 'admin') return false
 
-  const { createAdminClient } = await import('@/lib/supabase/admin')
   const admin = createAdminClient()
-
-  const idag = norskDatoNaa()
-  const dag7 = addDays(idag, 7).toISOString().slice(0, 10)
-  const dag1 = addDays(idag, 1).toISOString().slice(0, 10)
-  const dag3 = addDays(idag, 3).toISOString().slice(0, 10)
-
-  const [{ data: arr_7 }, { data: arr_1 }, { data: arr_3 }] = await Promise.all([
-    admin.from('arrangementer').select('id, tittel, start_tidspunkt').gte('start_tidspunkt', `${dag7}T00:00:00`).lt('start_tidspunkt', `${dag7}T23:59:59`),
-    admin.from('arrangementer').select('id, tittel, start_tidspunkt').gte('start_tidspunkt', `${dag1}T00:00:00`).lt('start_tidspunkt', `${dag1}T23:59:59`),
-    admin.from('arrangementer').select('id, tittel, start_tidspunkt').gte('start_tidspunkt', `${dag3}T00:00:00`).lt('start_tidspunkt', `${dag3}T23:59:59`),
-  ])
-
-  for (const a of arr_7 ?? []) await sendPaaminneVarsler({ arrangementId: a.id, tittel: a.tittel, startTidspunkt: a.start_tidspunkt, type: 'paaminne_7' })
-  for (const a of arr_1 ?? []) await sendPaaminneVarsler({ arrangementId: a.id, tittel: a.tittel, startTidspunkt: a.start_tidspunkt, type: 'paaminne_1' })
-  for (const a of arr_3 ?? []) await sendPurringVarsler({ arrangementId: a.id, tittel: a.tittel, startTidspunkt: a.start_tidspunkt })
-
+  await kjorPaaminnelser(admin)
   return true
 }

--- a/app/(app)/innstillinger/page.tsx
+++ b/app/(app)/innstillinger/page.tsx
@@ -35,7 +35,7 @@ export default async function Innstillinger() {
       .limit(10),
     supabase
       .from('push_subscriptions')
-      .select('*', { count: 'exact', head: true }),
+      .select('id', { count: 'exact', head: true }),
     supabase
       .from('varsel_innstillinger')
       .select('noekkel, aktiv, beskrivelse')

--- a/app/api/cron/paaminne/route.ts
+++ b/app/api/cron/paaminne/route.ts
@@ -1,62 +1,24 @@
 import { createAdminClient } from '@/lib/supabase/admin'
-import { sendPaaminneVarsler, sendPurringVarsler } from '@/lib/varsler'
-import { norskDatoNaa } from '@/lib/dato'
+import { kjorPaaminnelser } from '@/lib/actions/paaminnelser'
 import { NextRequest, NextResponse } from 'next/server'
-import { addDays } from 'date-fns'
 
-async function kjorPaaminnelser(req: NextRequest) {
+async function handle(req: NextRequest) {
   const auth = req.headers.get('authorization')
   if (auth !== `Bearer ${process.env.CRON_SECRET}`) {
     return NextResponse.json({ feil: 'Uautorisert' }, { status: 401 })
   }
 
-  const supabase = createAdminClient()
-
-  // Bruk norsk dato slik at datosjekken er riktig uansett servertid
-  const idag = norskDatoNaa()
-
-  const dag7 = addDays(idag, 7).toISOString().slice(0, 10)
-  const dag1 = addDays(idag, 1).toISOString().slice(0, 10)
-  const dag3 = addDays(idag, 3).toISOString().slice(0, 10)
-
-  const [{ data: arr_7 }, { data: arr_1 }, { data: arr_3 }] = await Promise.all([
-    supabase.from('arrangementer').select('id, tittel, start_tidspunkt')
-      .gte('start_tidspunkt', `${dag7}T00:00:00`)
-      .lt('start_tidspunkt', `${dag7}T23:59:59`),
-    supabase.from('arrangementer').select('id, tittel, start_tidspunkt')
-      .gte('start_tidspunkt', `${dag1}T00:00:00`)
-      .lt('start_tidspunkt', `${dag1}T23:59:59`),
-    supabase.from('arrangementer').select('id, tittel, start_tidspunkt')
-      .gte('start_tidspunkt', `${dag3}T00:00:00`)
-      .lt('start_tidspunkt', `${dag3}T23:59:59`),
-  ])
-
-  const resultater = []
-
-  for (const a of arr_7 ?? []) {
-    await sendPaaminneVarsler({ arrangementId: a.id, tittel: a.tittel, startTidspunkt: a.start_tidspunkt, type: 'paaminne_7' })
-    resultater.push({ id: a.id, type: 'paaminne_7' })
-  }
-
-  for (const a of arr_1 ?? []) {
-    await sendPaaminneVarsler({ arrangementId: a.id, tittel: a.tittel, startTidspunkt: a.start_tidspunkt, type: 'paaminne_1' })
-    resultater.push({ id: a.id, type: 'paaminne_1' })
-  }
-
-  for (const a of arr_3 ?? []) {
-    await sendPurringVarsler({ arrangementId: a.id, tittel: a.tittel, startTidspunkt: a.start_tidspunkt })
-    resultater.push({ id: a.id, type: 'purring' })
-  }
-
-  return NextResponse.json({ ok: true, behandlet: resultater })
+  const admin = createAdminClient()
+  const { behandlet, feil } = await kjorPaaminnelser(admin)
+  return NextResponse.json({ ok: true, behandlet, feil })
 }
 
 // Vercel Cron sender GET-requests
 export async function GET(req: NextRequest) {
-  return kjorPaaminnelser(req)
+  return handle(req)
 }
 
 // Behold POST for manuell triggering
 export async function POST(req: NextRequest) {
-  return kjorPaaminnelser(req)
+  return handle(req)
 }

--- a/components/ArrangementTidslinje.tsx
+++ b/components/ArrangementTidslinje.tsx
@@ -141,6 +141,8 @@ export default function ArrangementTidslinje({
     ...ikkePlanlagt.map(p => ({ type: 'ikke-planlagt' as const, data: p })),
   ]
 
+  const iAar = formaterDato(new Date().toISOString(), 'yyyy')
+
   const tidligereItems = alleItems
     .filter(item => erItemPast(item))
     .sort((a, b) => itemDag(b).getTime() - itemDag(a).getTime())
@@ -209,7 +211,7 @@ export default function ArrangementTidslinje({
             <Badge variant="accent">{erTur ? 'Tur' : 'Møte'}</Badge>
             <span>
               {formaterDato(iso, 'd. MMM')}
-              {formaterDato(iso, 'yyyy') !== formaterDato(new Date().toISOString(), 'yyyy') && ` ${formaterDato(iso, 'yyyy')}`}
+              {formaterDato(iso, 'yyyy') !== iAar && ` ${formaterDato(iso, 'yyyy')}`}
               {' kl. '}
               {formaterDato(iso, 'HH:mm')}
             </span>
@@ -299,7 +301,7 @@ export default function ArrangementTidslinje({
           </p>
           <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
             {formaterDato(bursdag.dato, 'd. MMMM')}
-            {formaterDato(bursdag.dato, 'yyyy') !== formaterDato(new Date().toISOString(), 'yyyy') && ` ${formaterDato(bursdag.dato, 'yyyy')}`}
+            {formaterDato(bursdag.dato, 'yyyy') !== iAar && ` ${formaterDato(bursdag.dato, 'yyyy')}`}
           </p>
         </div>
       </div>

--- a/lib/actions/paaminnelser.ts
+++ b/lib/actions/paaminnelser.ts
@@ -1,0 +1,63 @@
+import { addDays } from 'date-fns'
+import { norskDatoNaa } from '@/lib/dato'
+import { sendPaaminneVarsler, sendPurringVarsler } from '@/lib/varsler'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/lib/supabase/database.types'
+
+type Admin = SupabaseClient<Database>
+type Arrangement = { id: string; tittel: string; start_tidspunkt: string }
+
+function dagStreng(dato: Date): string {
+  return dato.toISOString().slice(0, 10)
+}
+
+async function hentForDag(admin: Admin, dag: string) {
+  const { data } = await admin
+    .from('arrangementer')
+    .select('id, tittel, start_tidspunkt')
+    .gte('start_tidspunkt', `${dag}T00:00:00`)
+    .lt('start_tidspunkt', `${dag}T23:59:59`)
+  return data ?? []
+}
+
+export async function kjorPaaminnelser(admin: Admin) {
+  const idag = norskDatoNaa()
+  const dag7 = dagStreng(addDays(idag, 7))
+  const dag3 = dagStreng(addDays(idag, 3))
+  const dag1 = dagStreng(addDays(idag, 1))
+
+  const [arr_7, arr_1, arr_3] = await Promise.all([
+    hentForDag(admin, dag7),
+    hentForDag(admin, dag1),
+    hentForDag(admin, dag3),
+  ])
+
+  const oppgaver: Promise<{ id: string; type: string }>[] = []
+
+  for (const a of arr_7 as Arrangement[]) {
+    oppgaver.push(
+      sendPaaminneVarsler({ arrangementId: a.id, tittel: a.tittel, startTidspunkt: a.start_tidspunkt, type: 'paaminne_7' })
+        .then(() => ({ id: a.id, type: 'paaminne_7' }))
+    )
+  }
+  for (const a of arr_1 as Arrangement[]) {
+    oppgaver.push(
+      sendPaaminneVarsler({ arrangementId: a.id, tittel: a.tittel, startTidspunkt: a.start_tidspunkt, type: 'paaminne_1' })
+        .then(() => ({ id: a.id, type: 'paaminne_1' }))
+    )
+  }
+  for (const a of arr_3 as Arrangement[]) {
+    oppgaver.push(
+      sendPurringVarsler({ arrangementId: a.id, tittel: a.tittel, startTidspunkt: a.start_tidspunkt })
+        .then(() => ({ id: a.id, type: 'purring' }))
+    )
+  }
+
+  const utfall = await Promise.allSettled(oppgaver)
+  const behandlet = utfall
+    .filter((r): r is PromiseFulfilledResult<{ id: string; type: string }> => r.status === 'fulfilled')
+    .map(r => r.value)
+  const feil = utfall.filter(r => r.status === 'rejected').length
+
+  return { behandlet, feil }
+}

--- a/lib/dato.ts
+++ b/lib/dato.ts
@@ -3,6 +3,9 @@ import { nb } from 'date-fns/locale'
 
 export const TIDSSONE = 'Europe/Oslo'
 
+// Felles format-strenger brukt flere steder i appen.
+export const FORMAT_DATO_KLOKKE = "d. MMMM 'kl.' HH:mm"
+
 /**
  * Formater en ISO-dato i norsk tidssone (Europe/Oslo).
  * Håndterer sommer/vintertid automatisk.

--- a/lib/varsler.ts
+++ b/lib/varsler.ts
@@ -1,11 +1,9 @@
 import { createAdminClient } from '@/lib/supabase/admin'
 import { sendPush } from '@/lib/push'
 import { sendEpost, arrangementEpostHtml } from '@/lib/epost'
-import { formaterDato as fd } from '@/lib/dato'
+import { formaterDato, FORMAT_DATO_KLOKKE } from '@/lib/dato'
 
-function formaterDato(iso: string): string {
-  return fd(iso, "d. MMMM 'kl.' HH:mm")
-}
+const formaterDatoKlokke = (iso: string) => formaterDato(iso, FORMAT_DATO_KLOKKE)
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000'
 
@@ -195,7 +193,7 @@ export async function sendNyttArrangementVarsler({
   startTidspunkt: string
 }) {
   if (!(await erVarselAktiv('nytt_arrangement'))) return
-  const dato = formaterDato(startTidspunkt)
+  const dato = formaterDatoKlokke(startTidspunkt)
   await sendVarsel({
     tittel: 'Nytt arrangement',
     melding: `${tittel} — ${dato}`,
@@ -214,7 +212,7 @@ export async function sendOppdatertVarsler({
   tittel: string
   startTidspunkt: string
 }) {
-  const dato = formaterDato(startTidspunkt)
+  const dato = formaterDatoKlokke(startTidspunkt)
   await sendVarsel({
     tittel: 'Arrangement oppdatert',
     melding: `${tittel} — ${dato}`,
@@ -238,7 +236,7 @@ export async function sendPaaminneVarsler({
 }) {
   const noekkel = type === 'paaminne_7' ? 'paaminnelse_7d' : 'paaminnelse_1d'
   if (!(await erVarselAktiv(noekkel))) return
-  const dato = formaterDato(startTidspunkt)
+  const dato = formaterDatoKlokke(startTidspunkt)
   const dager = type === 'paaminne_7' ? 7 : 1
   await sendVarsel({
     tittel: `Påminnelse: ${tittel}`,
@@ -273,7 +271,7 @@ export async function sendPurringVarsler({
   const utenSvar = profiler.filter(p => !harSvart.has(p.id))
   if (utenSvar.length === 0) return
 
-  const dato = formaterDato(startTidspunkt)
+  const dato = formaterDatoKlokke(startTidspunkt)
   await sendVarsel({
     mottakere: utenSvar.map(p => p.id),
     tittel: 'Husk å svare!',


### PR DESCRIPTION
Samler duplikat påminnelse-løkken fra cron-route og innstillinger-action i ny lib/actions/paaminnelser.ts, som også parallelliserer sendinger (Promise.allSettled i stedet for sekvensielle for-await). Gir raskere admin-trigger og én kilde til sannhet.

Andre småopprydninger:
- FORMAT_DATO_KLOKKE eksportert fra lib/dato.ts, fjerner duplikat wrapper i lib/varsler.ts.
- Chat.tsx gjenbruker én createClient()-instans i stedet for tre.
- ArrangementTidslinje cacher gjeldende år utenfor render-løkka så formaterDato ikke kalles 3 ganger per kort.
- innstillinger-page og push-count query bruker .select('id') for count-head i stedet for full-row payload.
- innstillinger-actions bruker getProfil()-cache i stedet for egen auth-lookup.