### PR TITLE
Bilder: deferred upload til R2 (ingen orphans ved bytte)

### DIFF
--- a/app/(app)/arrangementer/[id]/rediger/RedigerSkjema.tsx
+++ b/app/(app)/arrangementer/[id]/rediger/RedigerSkjema.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useMemo, useState, useTransition, type CSSProperties } from 'react'
+import { useEffect, useMemo, useState, useTransition, type CSSProperties } from 'react'
 import { useRouter } from 'next/navigation'
 import Image from 'next/image'
 import { oppdaterArrangement, slettArrangement } from '@/lib/actions/arrangementer'
+import { lastOppBilde, slettBilde } from '@/lib/actions/bilde-opplasting'
 import SkjemaBar from '@/components/ui/SkjemaBar'
 import SkjemaSeksjon from '@/components/ui/SkjemaSeksjon'
 import Segment from '@/components/ui/Segment'
@@ -13,6 +14,7 @@ import Placeholder from '@/components/ui/Placeholder'
 import BildeBytterKnapp from '@/components/BildeBytterKnapp'
 import TypeVelger, { type MalValg } from '@/components/arrangement/TypeVelger'
 import { isoTilDatetimeLocal, datetimeLocalTilIso } from '@/lib/dato'
+import { genererFilnavn } from '@/lib/bilde-utils'
 
 type Arrangement = {
   id: string
@@ -97,7 +99,21 @@ export default function RedigerSkjema({
   const erTur = effektivType === 'tur'
 
   const [sensurert, setSensurert] = useState<Record<string, boolean>>(arr.sensurerte_felt ?? {})
-  const [bildeUrl, setBildeUrl] = useState<string | null>(arr.bilde_url)
+  // bildeUrl = nåværende lagrede URL i DB. bildeFil = ventende ny upload.
+  // Når bildeFil er satt, vises blob-URL. Ved submit lastes filen opp,
+  // og det gamle R2-bildet (hvis det er R2) slettes etter vellykket
+  // oppdatering.
+  const [bildeUrl] = useState<string | null>(arr.bilde_url)
+  const [bildeFil, setBildeFil] = useState<File | null>(null)
+  const previewUrl = useMemo(
+    () => (bildeFil ? URL.createObjectURL(bildeFil) : bildeUrl),
+    [bildeFil, bildeUrl],
+  )
+  useEffect(() => {
+    return () => {
+      if (previewUrl?.startsWith('blob:')) URL.revokeObjectURL(previewUrl)
+    }
+  }, [previewUrl])
   const [tittel, setTittel] = useState(arr.tittel)
   // Hvis nåværende tittel avviker fra mal-navnet, regnes den som tilpasset.
   const [tittelBerørt, setTittelBerørt] = useState(
@@ -130,6 +146,17 @@ export default function RedigerSkjema({
     setFeil('')
     startTransition(async () => {
       try {
+        // Last opp ny fil (hvis valgt) før vi rører DB-raden
+        let nyBildeUrl = bildeUrl
+        if (bildeFil) {
+          const fd = new FormData()
+          fd.append('fil', bildeFil)
+          fd.append('filnavn', genererFilnavn(bildeFil))
+          fd.append('kategori', 'arrangementer')
+          const res = await lastOppBilde(fd)
+          nyBildeUrl = res.url
+        }
+
         await oppdaterArrangement(arr.id, {
           type: effektivType,
           tittel,
@@ -141,10 +168,17 @@ export default function RedigerSkjema({
           destinasjon: erTur ? (destinasjon || null) : null,
           pris_per_person: erTur ? (pris ? parseInt(pris) : null) : null,
           sensurerte_felt: erTur ? sensurert : {},
-          bilde_url: bildeUrl,
+          bilde_url: nyBildeUrl,
           mal_navn: valgt.mal_navn,
           aar: valgt.aar,
         })
+
+        // Slett gammel R2-fil hvis vi byttet (best effort — orphan i R2 er
+        // ikke kritisk hvis det skulle feile)
+        if (bildeFil && arr.bilde_url && arr.bilde_url !== nyBildeUrl) {
+          slettBilde(arr.bilde_url).catch(() => {})
+        }
+
         router.push(`/arrangementer/${arr.id}`)
       } catch (err) {
         // Redirect/notFound fra server action skal boble videre
@@ -229,23 +263,32 @@ export default function RedigerSkjema({
           overflow: 'hidden',
         }}
       >
-        {bildeUrl ? (
+        {previewUrl ? (
           <div style={{ position: 'relative', aspectRatio: '16/9' }}>
-            <Image
-              src={bildeUrl}
-              alt=""
-              fill
-              style={{ objectFit: 'cover' }}
-              sizes="(max-width: 512px) 100vw, 512px"
-            />
+            {previewUrl.startsWith('blob:') ? (
+              // Lokal forhåndsvisning før upload
+              <img
+                src={previewUrl}
+                alt=""
+                style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+              />
+            ) : (
+              <Image
+                src={previewUrl}
+                alt=""
+                fill
+                style={{ objectFit: 'cover' }}
+                sizes="(max-width: 512px) 100vw, 512px"
+              />
+            )}
           </div>
         ) : (
           <Placeholder label="Arrangement bilde" aspectRatio="16/9" type={erTur ? 'tur' : 'møte'} />
         )}
         <div style={{ position: 'absolute', bottom: 12, right: 12 }}>
           <BildeBytterKnapp
-            onBildeUrl={setBildeUrl}
-            label={bildeUrl ? 'Bytt bilde' : 'Legg til bilde'}
+            onBildeFil={setBildeFil}
+            label={previewUrl ? 'Bytt bilde' : 'Legg til bilde'}
           />
         </div>
       </div>

--- a/app/(app)/arrangementer/ny/NyttArrangementSkjema.tsx
+++ b/app/(app)/arrangementer/ny/NyttArrangementSkjema.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { useState, useTransition, useMemo, type CSSProperties } from 'react'
+import { useEffect, useState, useTransition, useMemo, type CSSProperties } from 'react'
 import { useRouter } from 'next/navigation'
-import Image from 'next/image'
 import { opprettArrangement } from '@/lib/actions/arrangementer'
+import { lastOppBilde } from '@/lib/actions/bilde-opplasting'
 import SkjemaBar from '@/components/ui/SkjemaBar'
 import SkjemaSeksjon from '@/components/ui/SkjemaSeksjon'
 import Segment from '@/components/ui/Segment'
@@ -13,6 +13,7 @@ import Placeholder from '@/components/ui/Placeholder'
 import BildeBytterKnapp from '@/components/BildeBytterKnapp'
 import TypeVelger, { type MalValg } from '@/components/arrangement/TypeVelger'
 import { formaterDato, datetimeLocalTilIso } from '@/lib/dato'
+import { genererFilnavn } from '@/lib/bilde-utils'
 
 const monoLabel: CSSProperties = {
   fontFamily: 'var(--font-mono)',
@@ -100,7 +101,18 @@ export default function NyttArrangementSkjema({
   const [destinasjon, setDestinasjon] = useState('')
   const [pris, setPris] = useState('')
   const [sensurert, setSensurert] = useState<Record<string, boolean>>({})
-  const [bildeUrl, setBildeUrl] = useState<string | null>(null)
+  // Holder File-objektet til submit. Forhåndsvises via blob: URL — ingen
+  // R2-opplasting før brukeren faktisk lagrer.
+  const [bildeFil, setBildeFil] = useState<File | null>(null)
+  const previewUrl = useMemo(
+    () => (bildeFil ? URL.createObjectURL(bildeFil) : null),
+    [bildeFil],
+  )
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl)
+    }
+  }, [previewUrl])
   const [feil, setFeil] = useState('')
   const [isPending, startTransition] = useTransition()
   const router = useRouter()
@@ -131,6 +143,17 @@ export default function NyttArrangementSkjema({
 
     startTransition(async () => {
       try {
+        // Last opp bilde til R2 først hvis valgt — så har vi URL til DB-raden
+        let bildeUrl: string | null = null
+        if (bildeFil) {
+          const fd = new FormData()
+          fd.append('fil', bildeFil)
+          fd.append('filnavn', genererFilnavn(bildeFil))
+          fd.append('kategori', 'arrangementer')
+          const res = await lastOppBilde(fd)
+          bildeUrl = res.url
+        }
+
         await opprettArrangement({
           type: effektivType,
           tittel,
@@ -186,14 +209,14 @@ export default function NyttArrangementSkjema({
           overflow: 'hidden',
         }}
       >
-        {bildeUrl ? (
+        {previewUrl ? (
           <div style={{ position: 'relative', aspectRatio: '16/9' }}>
-            <Image
-              src={bildeUrl}
+            {/* Blob-URL for forhåndsvisning — vanlig <img> siden Next/Image
+                ikke håndterer blob-URLer */}
+            <img
+              src={previewUrl}
               alt=""
-              fill
-              style={{ objectFit: 'cover' }}
-              sizes="(max-width: 512px) 100vw, 512px"
+              style={{ width: '100%', height: '100%', objectFit: 'cover' }}
             />
           </div>
         ) : (
@@ -201,8 +224,8 @@ export default function NyttArrangementSkjema({
         )}
         <div style={{ position: 'absolute', bottom: 12, right: 12 }}>
           <BildeBytterKnapp
-            onBildeUrl={setBildeUrl}
-            label={bildeUrl ? 'Bytt bilde' : 'Legg til bilde'}
+            onBildeFil={setBildeFil}
+            label={previewUrl ? 'Bytt bilde' : 'Legg til bilde'}
           />
         </div>
       </div>

--- a/app/(app)/meldinger/ny/NyMeldingSkjema.tsx
+++ b/app/(app)/meldinger/ny/NyMeldingSkjema.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { useState, useTransition, type CSSProperties } from 'react'
+import { useEffect, useMemo, useState, useTransition, type CSSProperties } from 'react'
 import { useRouter } from 'next/navigation'
-import Image from 'next/image'
 import { opprettMelding } from '@/lib/actions/meldinger'
+import { lastOppBilde } from '@/lib/actions/bilde-opplasting'
 import SkjemaBar from '@/components/ui/SkjemaBar'
 import SkjemaSeksjon from '@/components/ui/SkjemaSeksjon'
 import BildeBytterKnapp from '@/components/BildeBytterKnapp'
+import { genererFilnavn } from '@/lib/bilde-utils'
 
 const inputStil: CSSProperties = {
   width: '100%',
@@ -26,7 +27,16 @@ const MAX_TEGN = 2000
 
 export default function NyMeldingSkjema() {
   const [innhold, setInnhold] = useState('')
-  const [bildeUrl, setBildeUrl] = useState<string | null>(null)
+  const [bildeFil, setBildeFil] = useState<File | null>(null)
+  const previewUrl = useMemo(
+    () => (bildeFil ? URL.createObjectURL(bildeFil) : null),
+    [bildeFil],
+  )
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl)
+    }
+  }, [previewUrl])
   const [feil, setFeil] = useState('')
   const [isPending, startTransition] = useTransition()
   const router = useRouter()
@@ -39,6 +49,17 @@ export default function NyMeldingSkjema() {
     }
     startTransition(async () => {
       try {
+        // Last opp bilde til R2 først hvis valgt
+        let bildeUrl: string | null = null
+        if (bildeFil) {
+          const fd = new FormData()
+          fd.append('fil', bildeFil)
+          fd.append('filnavn', genererFilnavn(bildeFil))
+          fd.append('kategori', 'meldinger')
+          const res = await lastOppBilde(fd)
+          bildeUrl = res.url
+        }
+
         await opprettMelding({ innhold, bilde_url: bildeUrl })
       } catch (err) {
         if (
@@ -94,26 +115,23 @@ export default function NyMeldingSkjema() {
 
       <SkjemaSeksjon label="Bilde (valgfritt)">
         <div style={{ padding: '10px 4px' }}>
-          {bildeUrl ? (
+          {previewUrl ? (
             <div style={{ position: 'relative' }}>
               <div style={{ position: 'relative', width: '100%', aspectRatio: '4/3', borderRadius: 'var(--radius-card)', overflow: 'hidden' }}>
-                <Image
-                  src={bildeUrl}
+                <img
+                  src={previewUrl}
                   alt="Forhåndsvisning"
-                  fill
-                  sizes="(max-width: 512px) 100vw, 512px"
-                  style={{ objectFit: 'cover' }}
+                  style={{ width: '100%', height: '100%', objectFit: 'cover' }}
                 />
               </div>
               <div style={{ display: 'flex', gap: 8, marginTop: 10 }}>
                 <BildeBytterKnapp
-                  bucket="melding-bilder"
-                  onBildeUrl={url => setBildeUrl(url)}
+                  onBildeFil={setBildeFil}
                   label="Bytt bilde"
                 />
                 <button
                   type="button"
-                  onClick={() => setBildeUrl(null)}
+                  onClick={() => setBildeFil(null)}
                   style={{
                     padding: '7px 14px',
                     background: 'transparent',
@@ -131,8 +149,7 @@ export default function NyMeldingSkjema() {
             </div>
           ) : (
             <BildeBytterKnapp
-              bucket="melding-bilder"
-              onBildeUrl={url => setBildeUrl(url)}
+              onBildeFil={setBildeFil}
               label="Legg til bilde"
             />
           )}

--- a/app/(app)/profil/rediger/RedigerProfilForm.tsx
+++ b/app/(app)/profil/rediger/RedigerProfilForm.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { useRef, useState, useTransition } from 'react'
+import { useEffect, useMemo, useRef, useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
 import { oppdaterEgenProfil } from '@/lib/actions/profil'
-import { lastOppBilde } from '@/lib/actions/bilde-opplasting'
+import { lastOppBilde, slettBilde } from '@/lib/actions/bilde-opplasting'
 import { createClient } from '@/lib/supabase/client'
 import { genererFilnavn } from '@/lib/bilde-utils'
 import SkjemaBar from '@/components/ui/SkjemaBar'
@@ -89,9 +89,24 @@ export default function RedigerProfilForm({
   const [visningsnavn, setVisningsnavn] = useState(visnInit)
   const [telefon, setTelefon] = useState(tlfInit)
   const [fodselsdato, setFodselsdato] = useState(fdInit)
-  const [bildeUrl, setBildeUrl] = useState<string | null>(bildeUrlInit)
 
-  const [bildeLaster, setBildeLaster] = useState(false)
+  // bildeUrl = lagret URL i DB. bildeFil = ventende ny upload (komprimert
+  // + cropped, ikke lastet opp ennå). bildeFjernet = brukeren har klikket
+  // "fjern". Submit avgjør hva som faktisk skjer mot R2 + DB.
+  const [bildeUrl] = useState<string | null>(bildeUrlInit)
+  const [bildeFil, setBildeFil] = useState<File | null>(null)
+  const [bildeFjernet, setBildeFjernet] = useState(false)
+  const previewUrl = useMemo(() => {
+    if (bildeFil) return URL.createObjectURL(bildeFil)
+    if (bildeFjernet) return null
+    return bildeUrl
+  }, [bildeFil, bildeFjernet, bildeUrl])
+  useEffect(() => {
+    return () => {
+      if (previewUrl?.startsWith('blob:')) URL.revokeObjectURL(previewUrl)
+    }
+  }, [previewUrl])
+
   const [bildeFeil, setBildeFeil] = useState('')
   const [cropFil, setCropFil] = useState<File | null>(null)
 
@@ -109,31 +124,17 @@ export default function RedigerProfilForm({
     if (filInputRef.current) filInputRef.current.value = ''
   }
 
-  async function handleCropFerdig(blob: Blob) {
+  function handleCropFerdig(blob: Blob) {
     setCropFil(null)
-    setBildeLaster(true)
     setBildeFeil('')
-
-    try {
-      const croppet = new File([blob], 'profil.jpg', { type: 'image/jpeg' })
-      const filnavn = genererFilnavn(croppet)
-
-      const fd = new FormData()
-      fd.append('fil', croppet)
-      fd.append('filnavn', filnavn)
-      fd.append('kategori', 'profiler')
-
-      const { url } = await lastOppBilde(fd)
-      setBildeUrl(url)
-    } catch (err) {
-      setBildeFeil(err instanceof Error ? err.message : 'Opplasting feilet')
-    } finally {
-      setBildeLaster(false)
-    }
+    const croppet = new File([blob], 'profil.jpg', { type: 'image/jpeg' })
+    setBildeFil(croppet)
+    setBildeFjernet(false)
   }
 
   function handleFjernBilde() {
-    setBildeUrl(null)
+    setBildeFil(null)
+    setBildeFjernet(true)
     setBildeFeil('')
   }
 
@@ -151,13 +152,36 @@ export default function RedigerProfilForm({
     }
 
     startTransition(async () => {
+      // Last opp ny fil først hvis valgt. bildeFjernet uten ny fil → null.
+      let nyBildeUrl: string | null = bildeUrl
+      if (bildeFil) {
+        const fd = new FormData()
+        fd.append('fil', bildeFil)
+        fd.append('filnavn', genererFilnavn(bildeFil))
+        fd.append('kategori', 'profiler')
+        try {
+          const res = await lastOppBilde(fd)
+          nyBildeUrl = res.url
+        } catch (err) {
+          setBildeFeil(err instanceof Error ? err.message : 'Opplasting feilet')
+          return
+        }
+      } else if (bildeFjernet) {
+        nyBildeUrl = null
+      }
+
       await oppdaterEgenProfil({
         navn,
         visningsnavn: visningsnavn || navn,
         telefon,
         fodselsdato: fodselsdato || undefined,
-        bilde_url: bildeUrl,
+        bilde_url: nyBildeUrl,
       })
+
+      // Slett gammelt R2-bilde hvis byttet eller fjernet (best effort)
+      if (bildeUrl && bildeUrl !== nyBildeUrl) {
+        slettBilde(bildeUrl).catch(() => {})
+      }
 
       if (visPassord && passord) {
         const supabase = createClient()
@@ -206,18 +230,18 @@ export default function RedigerProfilForm({
         <button
           type="button"
           onClick={() => filInputRef.current?.click()}
-          disabled={bildeLaster}
-          aria-label={bildeUrl ? 'Bytt profilbilde' : 'Last opp profilbilde'}
+          disabled={isPending}
+          aria-label={previewUrl ? 'Bytt profilbilde' : 'Last opp profilbilde'}
           style={{
             position: 'relative',
             flexShrink: 0,
             background: 'none',
             border: 'none',
             padding: 0,
-            cursor: bildeLaster ? 'wait' : 'pointer',
+            cursor: isPending ? 'wait' : 'pointer',
           }}
         >
-          <Avatar name={navn} size={56} src={bildeUrl} rolle={rolle} />
+          <Avatar name={navn} size={56} src={previewUrl} rolle={rolle} />
           <div
             style={{
               position: 'absolute',
@@ -254,11 +278,11 @@ export default function RedigerProfilForm({
             <button
               type="button"
               onClick={() => filInputRef.current?.click()}
-              disabled={bildeLaster}
+              disabled={isPending}
               style={{
                 background: 'none',
                 border: 'none',
-                cursor: bildeLaster ? 'wait' : 'pointer',
+                cursor: isPending ? 'wait' : 'pointer',
                 padding: 0,
                 color: 'var(--accent)',
                 fontFamily: 'var(--font-body)',
@@ -266,9 +290,9 @@ export default function RedigerProfilForm({
                 fontWeight: 500,
               }}
             >
-              {bildeLaster ? 'Laster opp…' : bildeUrl ? 'Bytt bilde' : 'Last opp bilde'}
+              {isPending ? 'Lagrer…' : previewUrl ? 'Bytt bilde' : 'Last opp bilde'}
             </button>
-            {bildeUrl && !bildeLaster && (
+            {previewUrl && !isPending && (
               <button
                 type="button"
                 onClick={handleFjernBilde}

--- a/components/BildeBytterKnapp.tsx
+++ b/components/BildeBytterKnapp.tsx
@@ -1,36 +1,28 @@
 'use client'
 
 import { useRef, useState } from 'react'
-import { komprimer, genererFilnavn, type BildeKategori } from '@/lib/bilde-utils'
-import { lastOppBilde } from '@/lib/actions/bilde-opplasting'
+import { komprimer } from '@/lib/bilde-utils'
 
-// Enkelt "Bytt bilde"-kontroll som åpner mobilens galleri direkte,
-// laster opp til R2 og kaller onBildeUrl med den nye public-URLen.
-// Viser ingen forhåndsvisning selv — forelderen viser det aktive bildet.
+// "Bytt bilde"-kontroll. Åpner mobilens galleri direkte, komprimerer i
+// nettleseren og leverer den komprimerte File-en til forelderen via
+// onBildeFil. Selve opplastingen til R2 skjer FØRST når forelderen
+// lagrer skjemaet — på den måten blir ingen bilder orphans i R2 hvis
+// brukeren angrer eller bytter bilde før save.
 //
-// Eldre `bucket`-prop er beholdt for bakoverkompatibilitet og mappes til
-// riktig R2-kategori. Nye callsites bør sende `kategori` direkte.
+// Forelderen lager preview via URL.createObjectURL(file) og lagrer File i
+// skjema-state til submit.
 export default function BildeBytterKnapp({
-  onBildeUrl,
+  onBildeFil,
   label = 'Bytt bilde',
-  bucket,
-  kategori,
   style,
 }: {
-  onBildeUrl: (url: string) => void
+  onBildeFil: (fil: File) => void
   label?: string
-  /** Eldre prop. Bruk `kategori` i nye callsites. */
-  bucket?: 'arrangement-bilder' | 'melding-bilder'
-  /** R2-kategori. Default: 'arrangementer' (eller utledet fra bucket). */
-  kategori?: BildeKategori
   style?: React.CSSProperties
 }) {
   const [laster, setLaster] = useState(false)
   const [feil, setFeil] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
-
-  const valgtKategori: BildeKategori =
-    kategori ?? (bucket === 'melding-bilder' ? 'meldinger' : 'arrangementer')
 
   async function handleFil(e: React.ChangeEvent<HTMLInputElement>) {
     const fil = e.target.files?.[0]
@@ -40,17 +32,9 @@ export default function BildeBytterKnapp({
 
     try {
       const komprimert = await komprimer(fil)
-      const filnavn = genererFilnavn(komprimert)
-
-      const fd = new FormData()
-      fd.append('fil', komprimert)
-      fd.append('filnavn', filnavn)
-      fd.append('kategori', valgtKategori)
-
-      const { url } = await lastOppBilde(fd)
-      onBildeUrl(url)
+      onBildeFil(komprimert)
     } catch (err) {
-      setFeil(err instanceof Error ? err.message : 'Opplasting feilet')
+      setFeil(err instanceof Error ? err.message : 'Kunne ikke lese bildet')
     } finally {
       setLaster(false)
       if (inputRef.current) inputRef.current.value = ''
@@ -79,7 +63,7 @@ export default function BildeBytterKnapp({
           ...style,
         }}
       >
-        {laster ? 'Laster opp…' : label}
+        {laster ? 'Klargjør…' : label}
       </button>
       <input
         ref={inputRef}

--- a/lib/actions/arrangementer.ts
+++ b/lib/actions/arrangementer.ts
@@ -7,6 +7,7 @@ import { sendNyttArrangementVarsler, sendOppdatertVarsler } from '@/lib/varsler'
 import { getProfil } from '@/lib/auth-cache'
 import { kanAdministrere } from '@/lib/roller'
 import { naa } from '@/lib/dato'
+import { r2StiFraUrl, slettR2 } from '@/lib/r2'
 
 export type ArrangementInput = {
   type: 'moete' | 'tur'
@@ -96,12 +97,27 @@ export async function opprettArrangement(data: ArrangementInput) {
 
 export async function slettArrangement(id: string) {
   const supabase = await createServerClient()
+
+  // Hent bilde_url først så vi kan rydde i R2 etter at arrangementet er
+  // slettet. Hvis dette feiler er det ikke kritisk — orphan i R2 er bedre
+  // enn at sletting feiler.
+  const { data: arr } = await supabase
+    .from('arrangementer')
+    .select('bilde_url')
+    .eq('id', id)
+    .maybeSingle()
+
   // Løsne ansvar-rader før sletting slik at typen blir tilgjengelig igjen i
   // dropdown-en (FK har on delete set null, men vi gjør det eksplisitt først
   // for klarhet).
   await losne(supabase, id)
   const { error } = await supabase.from('arrangementer').delete().eq('id', id)
   if (error) throw new Error(error.message)
+
+  // Best-effort opprydning av R2-bilde
+  const r2Sti = r2StiFraUrl(arr?.bilde_url ?? null)
+  if (r2Sti) slettR2(r2Sti).catch(() => {})
+
   revalidatePath('/')
   revalidatePath('/arrangoransvar')
   redirect('/')

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 149,
-  "versjon": "V2.149"
+  "nummer": 150,
+  "versjon": "V2.150"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.149'
+const CACHE_VERSION = 'V2.150'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Fikser orphans-problemet brukeren oppdaget: når man valgte et bilde og deretter byttet til et annet før save, endte begge i R2.

## Ny flyt

- **BildeBytterKnapp** komprimerer i nettleseren og returnerer `File` til forelderen (ingen R2-kall).
- **Forelder** viser preview via `URL.createObjectURL()` (blob URL).
- **Submit** laster filen til R2 først, deretter lagrer URL i DB. Hvis submit feiler → ingen R2-fil opprettes.
- **Edit-flyt**: gammel R2-URL slettes etter vellykket oppdatering (best-effort).
- **slettArrangement**: rydder R2-bilde også.

## Berørte filer

- `components/BildeBytterKnapp.tsx` — signatur `onBildeUrl` → `onBildeFil`
- `app/(app)/arrangementer/ny/NyttArrangementSkjema.tsx`
- `app/(app)/arrangementer/[id]/rediger/RedigerSkjema.tsx`
- `app/(app)/meldinger/ny/NyMeldingSkjema.tsx`
- `app/(app)/profil/rediger/RedigerProfilForm.tsx`
- `lib/actions/arrangementer.ts` — slettArrangement rydder R2

## Testløype på prod (etter merge)

- [ ] Lag arrangement med bilde → bilde i R2 først etter "Publiser"
- [ ] Lag arrangement, velg bilde, bytt til annet → kun ett bilde i R2 etter save
- [ ] Lag arrangement, velg bilde, avbryt → ingen R2-fil
- [ ] Rediger arrangement-bilde → gammelt slettet, nytt lagret
- [ ] Slett arrangement med bilde → R2-fila ryddet
- [ ] Bytt profilbilde → samme atferd som arrangement-bilde