### PR TITLE
Fiks docken-forsvinn etter swipe-back fra chat (#99)

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -4,6 +4,7 @@ import PageTransition from '@/components/PageTransition'
 import ServiceWorkerRegistrering from '@/components/ServiceWorkerRegistrering'
 import DraNedForOppdater from '@/components/DraNedForOppdater'
 import DeployInfo from '@/components/DeployInfo'
+import DockOpprydder from '@/components/DockOpprydder'
 import { getInnloggetBruker, getProfil } from '@/lib/auth-cache'
 import { redirect } from 'next/navigation'
 
@@ -31,6 +32,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
       }}
     >
       <ServiceWorkerRegistrering />
+      <DockOpprydder />
       <DraNedForOppdater />
       <main className="flex-1 pb-24 relative z-10">
         <div style={{ height: 'env(safe-area-inset-top)' }} aria-hidden="true" />

--- a/components/DockOpprydder.tsx
+++ b/components/DockOpprydder.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { useEffect } from 'react'
+
+// Defense-in-depth-fix for issue #99 (docken forsvinner etter swipe-back).
+// Klassen `chat-input-fokus` settes på <html> av Chat.tsx når tastaturet er
+// oppe i en chat-input. Hvis brukeren swiper tilbake mens klassen står på,
+// kan timing-edge-cases gjøre at Chat-komponentens cleanup ikke rekker å
+// rydde — og klassen forblir, noe som skjuler bottom-nav på neste side.
+//
+// Denne komponenten lytter på pathname og rydder klassen på hver
+// navigasjon. Catch-all uavhengig av Chat-komponent-livssyklus.
+export default function DockOpprydder() {
+  const pathname = usePathname()
+  useEffect(() => {
+    document.documentElement.classList.remove('chat-input-fokus')
+  }, [pathname])
+  return null
+}

--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -385,10 +385,19 @@ export default function Chat({
       }
     }
 
+    // pagehide fyrer når siden faktisk skjules (også ved iOS swipe-back),
+    // mens unmount-cleanup kan bli forsinket av animasjonen. Defense-in-
+    // depth for issue #99 — sammen med DockOpprydder i app/(app)/layout.tsx.
+    function ryddVedSkjult() {
+      settKlasse(false)
+    }
+    window.addEventListener('pagehide', ryddVedSkjult)
+
     return () => {
       vv?.removeEventListener('resize', vurder)
       document.removeEventListener('focusin', vurder)
       document.removeEventListener('focusout', vurder)
+      window.removeEventListener('pagehide', ryddVedSkjult)
       settKlasse(false)
     }
   }, [])

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 155,
-  "versjon": "V2.155"
+  "nummer": 156,
+  "versjon": "V2.156"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.155'
+const CACHE_VERSION = 'V2.156'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Copilots PR #101 ble merget som en tom 'Initial plan'-commit — selve fiksen ble aldri implementert. Lukker #99 ordentlig nå.

## Endringer

- **`components/DockOpprydder.tsx`** — liten klient-komponent som lytter på `usePathname()` og fjerner `chat-input-fokus`-klassen ved hver navigasjon. Catch-all uavhengig av Chat-komponentens livssyklus.
- **`app/(app)/layout.tsx`** — DockOpprydder mountet ved siden av ServiceWorkerRegistrering så den dekker hele app-treet.
- **`components/chat/Chat.tsx`** — `pagehide`-listener som defense-in-depth: når siden faktisk skjules (også under iOS swipe-back-animasjon), fjernes klassen umiddelbart.

## Test
- [ ] Mobil: åpne chat, fokuser input (tastatur opp), sveip tilbake → docken er synlig på forrige side
- [ ] Build + alle 80 tester grønne