### PR TITLE
Dock: fjern 120px side-bunnpadding når tastatur er oppe

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -106,6 +106,14 @@ html.tastatur-oppe main {
   padding-bottom: 0 !important;
 }
 
+/* Sider bruker inline-style `padding: 0 20px 120px` for å gi plass til
+   docken under innholdet. Når docken er skjult (tastatur oppe) blir det
+   dødt mellomrom mellom siste innhold og tastaturet. Vi nuller bunnen
+   via attribut-selektor — !important slår inline-padding-shorthand. */
+html.tastatur-oppe [style*="20px 120px"] {
+  padding-bottom: 0 !important;
+}
+
 /* Vis slett-knapp på chat-boble ved hover/fokus */
 .chat-boble:hover .chat-slett-knapp,
 .chat-boble:focus-within .chat-slett-knapp {

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 164,
-  "versjon": "V2.164"
+  "nummer": 165,
+  "versjon": "V2.165"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.164'
+const CACHE_VERSION = 'V2.165'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Følger opp #99/#104 — etter at docken nå skjules korrekt med display:none, sto inline `padding: 0 20px 120px` på sidene igjen som dødt mellomrom (~120px) mellom chat-input og tastaturet. Spesielt synlig i chat der bunnen er der man jobber.

## Diagnose

PR #105 nullet `<main>`-pb-24 (96px) når `tastatur-oppe`-klassen er på `<html>`. Men sider som `app/(app)/chat/page.tsx`, `arrangoransvar`, `innspill`, `innstillinger`, m.fl. har egen inline `padding: '0 20px 120px'` — 120px ekstra bunnpadding for å gi plass til docken.

Når docken er `display: none`, var disse 120px fortsatt der.

## Fix

Én CSS-regel i `globals.css`:
```css
html.tastatur-oppe [style*="20px 120px"] {
  padding-bottom: 0 !important;
}
```

Selektoren matcher inline `style="...20px 120px"`-pattern. `!important` slår inline shorthand-padding fordi den treffer longhand-egenskap.

## Hvorfor attribut-selektor og ikke ren refactor

Ren refactor ville flytte de ~10 inline `padding: '0 20px 120px'`-paddingene til en delt CSS-klasse. Det er flere filer å endre og mer review. Attribut-selektor er en kort, lokalisert hack som funker. Hvis pattern endrer seg må regelen oppdateres — kommentert i CSS.

## Test

- [x] Build grønn
- [x] 80 tester grønne
- [ ] iOS chat: tastatur opp → input pill ligger rett over tastatur (uten dødt mellomrom)
- [ ] iOS chat: tastatur ned → padding tilbake (dock-plass)
- [ ] iOS andre sider med 120px-padding: oppfører seg likt