### PR TITLE
Album fase 1: album på arrangement med opplasting og visning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ Thumbs.db
 /scripts/fb-reimport.mjs
 /scripts/fb-kjor.mjs
 /scripts/kjor-migrasjon.mjs
+.vercel
+.env*.local

--- a/app/(app)/album/[id]/page.tsx
+++ b/app/(app)/album/[id]/page.tsx
@@ -1,0 +1,91 @@
+import { createServerClient } from '@/lib/supabase/server'
+import { getInnloggetBruker } from '@/lib/auth-cache'
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import AlbumDetalj from '@/components/album/AlbumDetalj'
+
+export default async function AlbumSide({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const [supabase] = await Promise.all([createServerClient(), getInnloggetBruker()])
+
+  const { data: album } = await supabase
+    .from('album')
+    .select(
+      `id, tittel, arrangement_id,
+       arrangement:arrangementer (id, tittel),
+       album_bilde (id, bilde_url, thumb_url, bredde, hoyde, opprettet, rekkefolge)`,
+    )
+    .eq('id', id)
+    .single()
+
+  if (!album) notFound()
+
+  const arrangement = Array.isArray(album.arrangement) ? album.arrangement[0] : album.arrangement
+  const bilder = ((album.album_bilde ?? []) as Array<{
+    id: string
+    bilde_url: string
+    thumb_url: string | null
+    bredde: number | null
+    hoyde: number | null
+    opprettet: string
+    rekkefolge: number
+  }>)
+    .slice()
+    .sort((a, b) => a.rekkefolge - b.rekkefolge || a.opprettet.localeCompare(b.opprettet))
+
+  return (
+    <div style={{ padding: '0 20px 120px' }}>
+      <div style={{ paddingTop: 20, marginBottom: 16 }}>
+        {arrangement && (
+          <Link
+            href={`/arrangementer/${arrangement.id}`}
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 11,
+              color: 'var(--text-tertiary)',
+              letterSpacing: '1.4px',
+              fontWeight: 600,
+              textTransform: 'uppercase',
+              textDecoration: 'none',
+            }}
+          >
+            ← {arrangement.tittel}
+          </Link>
+        )}
+        <h1
+          style={{
+            fontFamily: 'var(--font-display)',
+            fontSize: 28,
+            fontWeight: 500,
+            margin: '6px 0 0',
+            color: 'var(--text-primary)',
+            letterSpacing: '-0.4px',
+          }}
+        >
+          {album.tittel}
+        </h1>
+        <div
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 11,
+            color: 'var(--text-tertiary)',
+            letterSpacing: '1.4px',
+            fontWeight: 600,
+            textTransform: 'uppercase',
+            marginTop: 4,
+          }}
+        >
+          {bilder.length} {bilder.length === 1 ? 'bilde' : 'bilder'}
+        </div>
+      </div>
+
+      <AlbumDetalj bilder={bilder.map(b => ({
+        id: b.id,
+        bilde_url: b.bilde_url,
+        thumb_url: b.thumb_url,
+        bredde: b.bredde,
+        hoyde: b.hoyde,
+      }))} />
+    </div>
+  )
+}

--- a/app/(app)/arrangementer/[id]/page.tsx
+++ b/app/(app)/arrangementer/[id]/page.tsx
@@ -11,6 +11,7 @@ import RsvpBlokk from '@/components/arrangement/RsvpBlokk'
 import VarsleNuKnapp from './VarsleNuKnapp'
 import Chat from '@/components/chat/Chat'
 import PassListe, { type PassListeDeltaker } from '@/components/arrangement/PassListe'
+import AlbumSeksjon from '@/components/album/AlbumSeksjon'
 import { formaterDato } from '@/lib/dato'
 import { kanAdministrere } from '@/lib/roller'
 
@@ -50,6 +51,7 @@ export default async function ArrangementDetaljer({
     { data: chatProfiler },
     { data: passInfoRader },
     { data: passForespørsler },
+    { data: albumRader },
   ] = await Promise.all([
     supabase
       .from('arrangementer')
@@ -82,6 +84,15 @@ export default async function ArrangementDetaljer({
       .eq('arrangement_id', id)
       .eq('soker_id', user!.id)
       .order('opprettet', { ascending: false }),
+    // Album for arrangementet (fase 1: forventer 0 eller 1 — vi tar nyeste).
+    // Hentes med tilhørende bilder slik at AlbumSeksjon kan rendre grid uten
+    // ytterligere round trip.
+    supabase
+      .from('album')
+      .select('id, tittel, album_bilde (id, bilde_url, thumb_url, opprettet)')
+      .eq('arrangement_id', id)
+      .order('opprettet', { ascending: false })
+      .limit(1),
   ])
 
   if (!arr) notFound()
@@ -571,6 +582,28 @@ export default async function ArrangementDetaljer({
             <PassListe arrangementId={id} deltakere={passDeltakere} />
           </section>
         )}
+
+        {/* Album */}
+        <AlbumSeksjon
+          arrangementId={id}
+          album={
+            albumRader && albumRader[0]
+              ? {
+                  id: albumRader[0].id,
+                  tittel: albumRader[0].tittel,
+                  bilder: ((albumRader[0].album_bilde ?? []) as Array<{
+                    id: string
+                    bilde_url: string
+                    thumb_url: string | null
+                    opprettet: string
+                  }>)
+                    .slice()
+                    .sort((a, b) => a.opprettet.localeCompare(b.opprettet))
+                    .map(b => ({ id: b.id, bilde_url: b.bilde_url, thumb_url: b.thumb_url })),
+                }
+              : null
+          }
+        />
 
         {/* Kommentarer */}
         <div id="kommentarer">

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -53,6 +53,7 @@ export default async function Forside() {
     { data: meldingerRaad },
     { data: meldingReaksjoner },
     { data: meldingKommentarer },
+    { data: albumMedArrangement },
   ] = await Promise.all([
     supabase
       .from('arrangementer')
@@ -128,6 +129,13 @@ export default async function Forside() {
       )
       .order('opprettet', { ascending: false })
       .limit(60),
+    // Hvilke arrangementer har album med ≥1 bilde — brukes til å vise
+    // kamera-ikon på agenda-kortet. Henter kun arrangement_id og første
+    // bilde-id som indikator på at det finnes innhold.
+    supabase
+      .from('album')
+      .select('arrangement_id, album_bilde (id)')
+      .not('arrangement_id', 'is', null),
   ])
 
   // Aggreger poll-stemmer: antall unike profiler + om innlogget bruker er
@@ -279,8 +287,21 @@ export default async function Forside() {
     }
   })
 
+  // Set av arrangement-id-er som har album med ≥1 bilde
+  type AlbumIndikator = { arrangement_id: string | null; album_bilde: { id: string }[] | null }
+  const arrangementMedAlbum = new Set<string>()
+  for (const a of (albumMedArrangement ?? []) as AlbumIndikator[]) {
+    if (a.arrangement_id && a.album_bilde && a.album_bilde.length > 0) {
+      arrangementMedAlbum.add(a.arrangement_id)
+    }
+  }
+
+  const arrangementerBerikt = ((arrangementer ?? []) as unknown as ArrangementRaad[]).map(
+    a => ({ ...a, harAlbum: arrangementMedAlbum.has(a.id) }),
+  )
+
   const { meldinger, idag, kommende, tidligere } = byggAgenda({
-    arrangementer: (arrangementer ?? []) as unknown as ArrangementRaad[],
+    arrangementer: arrangementerBerikt,
     ansvar: (ansvar ?? []) as unknown as UtkastRaad[],
     profilerMedBursdag: (profilerMedBursdag ?? []) as ProfilMedBursdag[],
     poller,

--- a/components/agenda/ArrangementKort.tsx
+++ b/components/agenda/ArrangementKort.tsx
@@ -14,6 +14,7 @@ export type ArrangementKortData = {
   bilde_url?: string | null
   antallJa: number
   minStatus: 'ja' | 'kanskje' | 'nei' | null
+  harAlbum?: boolean
 }
 
 function sceneFor(type: string): 'tur' | 'møte' | 'event' {
@@ -113,6 +114,20 @@ export default function ArrangementKort({ arr, tidligere = false, kommentarer = 
               {dag}. {mnd}{aar && ` ${aar}`}
             </span>
             <span style={{ color: 'var(--text-tertiary)', letterSpacing: '1.2px' }}>· {tid}</span>
+            {arr.harAlbum && (
+              <span
+                aria-label="Har album"
+                title="Har album"
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  marginLeft: 'auto',
+                  color: 'var(--text-tertiary)',
+                }}
+              >
+                <Icon name="image" size={12} color="currentColor" />
+              </span>
+            )}
           </div>
 
           {/* Tittel */}

--- a/components/album/AlbumDetalj.tsx
+++ b/components/album/AlbumDetalj.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { useState } from 'react'
+import Image from 'next/image'
+import BildeLightbox from '@/components/ui/BildeLightbox'
+
+export type AlbumBildeDetalj = {
+  id: string
+  bilde_url: string
+  thumb_url: string | null
+  bredde: number | null
+  hoyde: number | null
+}
+
+// Grid med 3 kolonner. Klikk på en thumb åpner lightbox med fullt bilde.
+// Per-bilde-kommentarer kommer i fase 2 — derfor ingen interaksjon utover
+// vis-i-fullskjerm her.
+export default function AlbumDetalj({ bilder }: { bilder: AlbumBildeDetalj[] }) {
+  const [aktiv, setAktiv] = useState<string | null>(null)
+
+  if (bilder.length === 0) {
+    return (
+      <div
+        style={{
+          padding: 24,
+          borderRadius: 'var(--radius-card)',
+          border: '0.5px solid var(--border-subtle)',
+          background: 'var(--bg-elevated)',
+          textAlign: 'center',
+          color: 'var(--text-tertiary)',
+          fontSize: 13,
+        }}
+      >
+        Ingen bilder i albumet ennå.
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(3, 1fr)',
+          gap: 4,
+        }}
+      >
+        {bilder.map(b => (
+          <button
+            key={b.id}
+            type="button"
+            onClick={() => setAktiv(b.bilde_url)}
+            style={{
+              position: 'relative',
+              aspectRatio: '1 / 1',
+              border: 'none',
+              padding: 0,
+              overflow: 'hidden',
+              borderRadius: 6,
+              cursor: 'zoom-in',
+              background: 'var(--bg-elevated)',
+            }}
+          >
+            <Image
+              src={b.thumb_url ?? b.bilde_url}
+              alt=""
+              fill
+              sizes="(max-width: 480px) 33vw, 160px"
+              style={{ objectFit: 'cover' }}
+            />
+          </button>
+        ))}
+      </div>
+
+      {aktiv && <BildeLightbox src={aktiv} onLukk={() => setAktiv(null)} />}
+    </>
+  )
+}

--- a/components/album/AlbumSeksjon.tsx
+++ b/components/album/AlbumSeksjon.tsx
@@ -1,0 +1,279 @@
+'use client'
+
+import { useState, useTransition, useRef } from 'react'
+import Link from 'next/link'
+import Image from 'next/image'
+import { useRouter } from 'next/navigation'
+import Icon from '@/components/ui/Icon'
+import BildeLightbox from '@/components/ui/BildeLightbox'
+import { komprimer, lagThumbnail, genererFilnavn } from '@/lib/bilde-utils'
+import { opprettAlbum, lastOppAlbumBilde } from '@/lib/actions/album'
+
+export type AlbumBildeForGrid = {
+  id: string
+  bilde_url: string
+  thumb_url: string | null
+}
+
+export type AlbumForSeksjon = {
+  id: string
+  tittel: string
+  bilder: AlbumBildeForGrid[]
+}
+
+const MAKS_FORHANDSVISNING = 8
+// Antall opplastinger som kjører parallelt. 3 er ok kompromiss for mobildata
+// — tre samtidige R2-puts metter ikke serverløsningen og holder UI responsiv.
+const PARALLELL_OPPLAST = 3
+
+async function opplastEn(albumId: string, fil: File): Promise<void> {
+  const komp = await komprimer(fil)
+  const thumb = await lagThumbnail(fil)
+  const filnavn = genererFilnavn(komp)
+
+  // Hent dimensjoner fra det komprimerte bildet for layout uten skift
+  const dims = await new Promise<{ bredde: number; hoyde: number }>(resolve => {
+    const img = new window.Image()
+    const url = URL.createObjectURL(komp)
+    img.onload = () => {
+      URL.revokeObjectURL(url)
+      resolve({ bredde: img.naturalWidth, hoyde: img.naturalHeight })
+    }
+    img.onerror = () => resolve({ bredde: 0, hoyde: 0 })
+    img.src = url
+  })
+
+  const fd = new FormData()
+  fd.set('albumId', albumId)
+  fd.set('fil', komp)
+  fd.set('thumb', thumb)
+  fd.set('filnavn', filnavn)
+  fd.set('bredde', String(dims.bredde))
+  fd.set('hoyde', String(dims.hoyde))
+  await lastOppAlbumBilde(fd)
+}
+
+async function opplastIBolker(albumId: string, filer: File[], onProgress: (n: number) => void) {
+  let i = 0
+  let ferdig = 0
+  async function neste(): Promise<void> {
+    while (i < filer.length) {
+      const idx = i++
+      try {
+        await opplastEn(albumId, filer[idx])
+      } catch (e) {
+        console.error('Opplasting feilet for', filer[idx].name, e)
+      }
+      ferdig++
+      onProgress(ferdig)
+    }
+  }
+  const arbeidere = Array.from({ length: Math.min(PARALLELL_OPPLAST, filer.length) }, () => neste())
+  await Promise.all(arbeidere)
+}
+
+export default function AlbumSeksjon({
+  album,
+  arrangementId,
+}: {
+  album: AlbumForSeksjon | null
+  arrangementId: string
+}) {
+  const router = useRouter()
+  const [oppretter, startOpprett] = useTransition()
+  const [pending, setPending] = useState<{ totalt: number; ferdig: number } | null>(null)
+  const [lightbox, setLightbox] = useState<string | null>(null)
+  const filInput = useRef<HTMLInputElement>(null)
+
+  function handleLagAlbum() {
+    startOpprett(async () => {
+      try {
+        await opprettAlbum({
+          tittel: 'Album',
+          arrangementId,
+        })
+        router.refresh()
+      } catch (e) {
+        console.error(e)
+        alert('Kunne ikke opprette album')
+      }
+    })
+  }
+
+  async function handleFiler(e: React.ChangeEvent<HTMLInputElement>) {
+    if (!album) return
+    const filer = Array.from(e.target.files ?? [])
+    if (!filer.length) return
+    e.target.value = ''
+    setPending({ totalt: filer.length, ferdig: 0 })
+    try {
+      await opplastIBolker(album.id, filer, n => setPending({ totalt: filer.length, ferdig: n }))
+      router.refresh()
+    } finally {
+      setPending(null)
+    }
+  }
+
+  return (
+    <section style={{ margin: '24px 20px 0' }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          marginBottom: 12,
+        }}
+      >
+        <h3
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 11,
+            color: 'var(--text-tertiary)',
+            letterSpacing: '1.6px',
+            fontWeight: 600,
+            textTransform: 'uppercase',
+            margin: 0,
+          }}
+        >
+          Album
+        </h3>
+        {album && (
+          <Link
+            href={`/album/${album.id}`}
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 11,
+              color: 'var(--accent)',
+              letterSpacing: '1.4px',
+              fontWeight: 600,
+              textTransform: 'uppercase',
+              textDecoration: 'none',
+            }}
+          >
+            Se alle ({album.bilder.length})
+          </Link>
+        )}
+      </div>
+
+      {!album && (
+        <button
+          type="button"
+          onClick={handleLagAlbum}
+          disabled={oppretter}
+          style={{
+            width: '100%',
+            padding: '14px 16px',
+            borderRadius: 'var(--radius-card)',
+            border: '0.5px dashed var(--border)',
+            background: 'var(--bg-elevated)',
+            color: 'var(--text-secondary)',
+            fontFamily: 'var(--font-body)',
+            fontSize: 13,
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 8,
+          }}
+        >
+          <Icon name="image" size={16} color="var(--accent)" />
+          {oppretter ? 'Lager…' : 'Lag album'}
+        </button>
+      )}
+
+      {album && (
+        <>
+          {album.bilder.length === 0 && (
+            <div
+              style={{
+                padding: '20px 14px',
+                borderRadius: 'var(--radius-card)',
+                border: '0.5px solid var(--border-subtle)',
+                background: 'var(--bg-elevated)',
+                fontSize: 13,
+                color: 'var(--text-tertiary)',
+                textAlign: 'center',
+                marginBottom: 10,
+              }}
+            >
+              Ingen bilder ennå. Last opp første bilde under.
+            </div>
+          )}
+
+          {album.bilder.length > 0 && (
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(4, 1fr)',
+                gap: 4,
+                marginBottom: 10,
+              }}
+            >
+              {album.bilder.slice(0, MAKS_FORHANDSVISNING).map(b => (
+                <button
+                  key={b.id}
+                  type="button"
+                  onClick={() => setLightbox(b.bilde_url)}
+                  style={{
+                    position: 'relative',
+                    aspectRatio: '1 / 1',
+                    border: 'none',
+                    padding: 0,
+                    overflow: 'hidden',
+                    borderRadius: 6,
+                    cursor: 'zoom-in',
+                    background: 'var(--bg-elevated)',
+                  }}
+                >
+                  <Image
+                    src={b.thumb_url ?? b.bilde_url}
+                    alt=""
+                    fill
+                    sizes="120px"
+                    style={{ objectFit: 'cover' }}
+                  />
+                </button>
+              ))}
+            </div>
+          )}
+
+          <input
+            ref={filInput}
+            type="file"
+            accept="image/*"
+            multiple
+            style={{ display: 'none' }}
+            onChange={handleFiler}
+          />
+          <button
+            type="button"
+            onClick={() => filInput.current?.click()}
+            disabled={!!pending}
+            style={{
+              width: '100%',
+              padding: '12px 16px',
+              borderRadius: 'var(--radius-card)',
+              border: '0.5px solid var(--border)',
+              background: 'var(--bg-elevated)',
+              color: 'var(--text-primary)',
+              fontFamily: 'var(--font-body)',
+              fontSize: 13,
+              cursor: pending ? 'default' : 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 8,
+            }}
+          >
+            <Icon name="image" size={14} color="var(--accent)" />
+            {pending
+              ? `Laster opp ${pending.ferdig}/${pending.totalt}…`
+              : 'Last opp bilder'}
+          </button>
+        </>
+      )}
+
+      {lightbox && <BildeLightbox src={lightbox} onLukk={() => setLightbox(null)} />}
+    </section>
+  )
+}

--- a/lib/actions/album.ts
+++ b/lib/actions/album.ts
@@ -1,0 +1,129 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { ensureInnlogget } from '@/lib/auth'
+import { lastOppR2, slettR2, r2StiFraUrl } from '@/lib/r2'
+
+// Album-server actions. Bilder lastes opp via egen flyt: klient genererer
+// både hovedbilde og thumbnail, server tar imot begge i samme call og lagrer
+// dem under `album/{album_id}/...` i R2 + en rad i album_bilde.
+
+const MAKS_BYTES = 5 * 1024 * 1024
+const TILLATTE_TYPER = ['image/jpeg', 'image/png', 'image/webp']
+
+export async function opprettAlbum(input: {
+  tittel: string
+  arrangementId?: string | null
+}): Promise<{ id: string }> {
+  const { supabase, user } = await ensureInnlogget()
+  const tittel = input.tittel.trim()
+  if (!tittel) throw new Error('Tittel kan ikke være tom')
+
+  const { data, error } = await supabase
+    .from('album')
+    .insert({
+      tittel,
+      arrangement_id: input.arrangementId ?? null,
+      opprettet_av: user.id,
+    })
+    .select('id')
+    .single()
+
+  if (error || !data) throw new Error(error?.message ?? 'Kunne ikke opprette album')
+
+  if (input.arrangementId) revalidatePath(`/arrangementer/${input.arrangementId}`)
+  revalidatePath('/')
+  return { id: data.id }
+}
+
+export async function lastOppAlbumBilde(formData: FormData): Promise<{ id: string; url: string }> {
+  const { supabase, user } = await ensureInnlogget()
+
+  const albumId = formData.get('albumId')
+  const fil = formData.get('fil')
+  const thumb = formData.get('thumb')
+  const filnavn = formData.get('filnavn')
+  const breddeRaw = formData.get('bredde')
+  const hoydeRaw = formData.get('hoyde')
+
+  if (typeof albumId !== 'string' || !albumId) throw new Error('Mangler albumId')
+  if (!(fil instanceof File)) throw new Error('Mangler fil')
+  if (typeof filnavn !== 'string' || !filnavn.trim()) throw new Error('Mangler filnavn')
+  if (fil.size > MAKS_BYTES) throw new Error(`Filen er for stor (maks ${MAKS_BYTES / 1024 / 1024} MB)`)
+  if (!TILLATTE_TYPER.includes(fil.type)) throw new Error('Ugyldig filtype')
+
+  const bredde = breddeRaw ? parseInt(String(breddeRaw)) : null
+  const hoyde = hoydeRaw ? parseInt(String(hoydeRaw)) : null
+
+  const data = new Uint8Array(await fil.arrayBuffer())
+  const sti = `album/${albumId}/${filnavn}`
+  const url = await lastOppR2(sti, data, fil.type)
+
+  let thumbUrl: string | null = null
+  if (thumb instanceof File && thumb.size > 0) {
+    const thumbData = new Uint8Array(await thumb.arrayBuffer())
+    const thumbSti = `album/${albumId}/thumb_${filnavn}`
+    thumbUrl = await lastOppR2(thumbSti, thumbData, thumb.type)
+  }
+
+  const { data: rad, error } = await supabase
+    .from('album_bilde')
+    .insert({
+      album_id: albumId,
+      bilde_url: url,
+      thumb_url: thumbUrl,
+      bredde,
+      hoyde,
+      lastet_opp_av: user.id,
+    })
+    .select('id')
+    .single()
+
+  if (error || !rad) {
+    // Rydd opp R2-objekter hvis DB-insert feilet
+    await slettR2(sti).catch(() => {})
+    if (thumbUrl) {
+      const thumbSti = r2StiFraUrl(thumbUrl)
+      if (thumbSti) await slettR2(thumbSti).catch(() => {})
+    }
+    throw new Error(error?.message ?? 'Kunne ikke registrere bildet')
+  }
+
+  // Bumper oppdatert på album så agendakort kan reflektere endring
+  await supabase.from('album').update({ oppdatert: new Date().toISOString() }).eq('id', albumId)
+
+  revalidatePath(`/album/${albumId}`)
+  return { id: rad.id, url }
+}
+
+export async function slettAlbum(id: string): Promise<void> {
+  const { supabase } = await ensureInnlogget()
+
+  // Hent alle bilder for å rydde R2 før vi sletter raden (cascade tar DB).
+  const { data: bilder } = await supabase
+    .from('album_bilde')
+    .select('bilde_url, thumb_url')
+    .eq('album_id', id)
+
+  const { data: album } = await supabase
+    .from('album')
+    .select('arrangement_id')
+    .eq('id', id)
+    .maybeSingle()
+
+  const { error } = await supabase.from('album').delete().eq('id', id)
+  if (error) throw new Error(error.message)
+
+  // Best-effort opprydding i R2
+  for (const b of bilder ?? []) {
+    const s1 = r2StiFraUrl(b.bilde_url)
+    if (s1) await slettR2(s1).catch(() => {})
+    if (b.thumb_url) {
+      const s2 = r2StiFraUrl(b.thumb_url)
+      if (s2) await slettR2(s2).catch(() => {})
+    }
+  }
+
+  if (album?.arrangement_id) revalidatePath(`/arrangementer/${album.arrangement_id}`)
+  revalidatePath('/')
+}

--- a/lib/agenda-sortering.ts
+++ b/lib/agenda-sortering.ts
@@ -76,6 +76,7 @@ export type ArrangementRaad = {
   oppmoetested: string | null
   bilde_url: string | null
   paameldinger: PaameldingRaad[]
+  harAlbum?: boolean
 }
 
 export type UtkastRaad = {
@@ -272,6 +273,7 @@ export function tilKort(arr: ArrangementRaad, meg: string): ArrangementKortData 
     bilde_url: arr.bilde_url,
     antallJa: jaListe.length,
     minStatus: (min?.status as 'ja' | 'kanskje' | 'nei' | undefined) ?? null,
+    harAlbum: arr.harAlbum ?? false,
   }
 }
 

--- a/lib/bilde-utils.ts
+++ b/lib/bilde-utils.ts
@@ -22,7 +22,7 @@ export function genererFilnavn(fil: File): string {
 // Bildekategorier i R2 — én topp-mappe per type. Holder bucket-en organisert
 // og gjør det enkelt å se hva en fil hører til. Legg til ny kategori her
 // når en ny upload-sti tas i bruk.
-export const BILDE_KATEGORIER = ['arrangementer', 'profiler', 'meldinger', 'chat'] as const
+export const BILDE_KATEGORIER = ['arrangementer', 'profiler', 'meldinger', 'chat', 'album'] as const
 export type BildeKategori = (typeof BILDE_KATEGORIER)[number]
 
 // Lag en unik path innen kategorien.

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -14,6 +14,109 @@ export type Database = {
   }
   public: {
     Tables: {
+      album: {
+        Row: {
+          arrangement_id: string | null
+          cover_bilde_id: string | null
+          id: string
+          oppdatert: string
+          opprettet: string
+          opprettet_av: string
+          tittel: string
+        }
+        Insert: {
+          arrangement_id?: string | null
+          cover_bilde_id?: string | null
+          id?: string
+          oppdatert?: string
+          opprettet?: string
+          opprettet_av: string
+          tittel: string
+        }
+        Update: {
+          arrangement_id?: string | null
+          cover_bilde_id?: string | null
+          id?: string
+          oppdatert?: string
+          opprettet?: string
+          opprettet_av?: string
+          tittel?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "album_arrangement_id_fkey"
+            columns: ["arrangement_id"]
+            isOneToOne: false
+            referencedRelation: "arrangementer"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "album_cover_fk"
+            columns: ["cover_bilde_id"]
+            isOneToOne: false
+            referencedRelation: "album_bilde"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "album_opprettet_av_fkey"
+            columns: ["opprettet_av"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      album_bilde: {
+        Row: {
+          album_id: string
+          bilde_url: string
+          bredde: number | null
+          hoyde: number | null
+          id: string
+          lastet_opp_av: string
+          opprettet: string
+          rekkefolge: number
+          thumb_url: string | null
+        }
+        Insert: {
+          album_id: string
+          bilde_url: string
+          bredde?: number | null
+          hoyde?: number | null
+          id?: string
+          lastet_opp_av: string
+          opprettet?: string
+          rekkefolge?: number
+          thumb_url?: string | null
+        }
+        Update: {
+          album_id?: string
+          bilde_url?: string
+          bredde?: number | null
+          hoyde?: number | null
+          id?: string
+          lastet_opp_av?: string
+          opprettet?: string
+          rekkefolge?: number
+          thumb_url?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "album_bilde_album_id_fkey"
+            columns: ["album_id"]
+            isOneToOne: false
+            referencedRelation: "album"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "album_bilde_lastet_opp_av_fkey"
+            columns: ["lastet_opp_av"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       arrangement_chat: {
         Row: {
           arrangement_id: string

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 167,
-  "versjon": "V2.167"
+  "nummer": 168,
+  "versjon": "V2.168"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.167'
+const CACHE_VERSION = 'V2.168'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/scripts/import-album.mjs
+++ b/scripts/import-album.mjs
@@ -3,25 +3,18 @@
 //
 // Forberedelse:
 //   1. Pakk ut zip-filen så bilder ligger som JPG-filer i én mappe
-//   2. Sett R2-secrets i .env.local (f.eks. via `vercel env pull`)
+//   2. Sett R2-secrets i .env.local (verdier hentes manuelt fra Vercel-
+//      dashbord siden de er markert som Sensitive og ikke kan pull-es)
 //
-// Bruk:
-//   node scripts/import-album.mjs <bilder-mappe> <arrangement-id> "<album-tittel>"
-//
-// Eksempel:
-//   node scripts/import-album.mjs \
-//     "C:/temp/tysk-aften-2018" \
-//     "abc123-..." \
-//     "Tysk aften 2018"
+// Bruk (Node 20.6+ med native --env-file):
+//   node --env-file=.env.local scripts/import-album.mjs \
+//     <bilder-mappe> <arrangement-id> "<album-tittel>"
 
 import { readdir, readFile } from 'node:fs/promises'
 import { join, basename, extname } from 'node:path'
-import { config } from 'dotenv'
 import sharp from 'sharp'
 import pg from 'pg'
 import { AwsClient } from 'aws4fetch'
-
-config({ path: '.env.local' })
 
 const [, , bilderMappe, arrangementId, albumTittel] = process.argv
 if (!bilderMappe || !arrangementId || !albumTittel) {

--- a/scripts/import-album.mjs
+++ b/scripts/import-album.mjs
@@ -1,0 +1,164 @@
+// Importer en mappe med bilder som et album i DB + R2.
+// Brukes f.eks. til å importere Facebook-album fra nedlastet eksport.
+//
+// Forberedelse:
+//   1. Pakk ut zip-filen så bilder ligger som JPG-filer i én mappe
+//   2. Sett R2-secrets i .env.local (f.eks. via `vercel env pull`)
+//
+// Bruk:
+//   node scripts/import-album.mjs <bilder-mappe> <arrangement-id> "<album-tittel>"
+//
+// Eksempel:
+//   node scripts/import-album.mjs \
+//     "C:/temp/tysk-aften-2018" \
+//     "abc123-..." \
+//     "Tysk aften 2018"
+
+import { readdir, readFile } from 'node:fs/promises'
+import { join, basename, extname } from 'node:path'
+import { config } from 'dotenv'
+import sharp from 'sharp'
+import pg from 'pg'
+import { AwsClient } from 'aws4fetch'
+
+config({ path: '.env.local' })
+
+const [, , bilderMappe, arrangementId, albumTittel] = process.argv
+if (!bilderMappe || !arrangementId || !albumTittel) {
+  console.error('Bruk: node scripts/import-album.mjs <mappe> <arrangement-id> "<tittel>"')
+  process.exit(1)
+}
+
+const PROJECT_REF = 'tdlfswmxezjdnxcbbiwn'
+const DB_PASSWORD = 'd2F3j$G!-@j!i94'
+
+const R2_ACCOUNT_ID = process.env.R2_ACCOUNT_ID
+const R2_ACCESS_KEY_ID = process.env.R2_ACCESS_KEY_ID
+const R2_SECRET_ACCESS_KEY = process.env.R2_SECRET_ACCESS_KEY
+const R2_BUCKET = process.env.R2_BUCKET ?? 'herreklubben-bilder'
+const R2_PUBLIC_URL = (process.env.R2_PUBLIC_URL ?? '').replace(/\/$/, '')
+const R2_JURISDICTION = (process.env.R2_JURISDICTION ?? 'default').toLowerCase()
+
+if (!R2_ACCOUNT_ID || !R2_ACCESS_KEY_ID || !R2_SECRET_ACCESS_KEY || !R2_PUBLIC_URL) {
+  console.error('Mangler R2-env. Kjør `vercel env pull .env.local` først.')
+  process.exit(1)
+}
+
+const r2Segment = R2_JURISDICTION === 'default' ? '' : `.${R2_JURISDICTION}`
+const aws = new AwsClient({
+  accessKeyId: R2_ACCESS_KEY_ID,
+  secretAccessKey: R2_SECRET_ACCESS_KEY,
+  region: 'auto',
+  service: 's3',
+})
+
+async function lastOppR2(sti, data, contentType) {
+  const url = `https://${R2_ACCOUNT_ID}${r2Segment}.r2.cloudflarestorage.com/${R2_BUCKET}/${sti}`
+  const res = await aws.fetch(url, {
+    method: 'PUT',
+    body: data,
+    headers: {
+      'Content-Type': contentType,
+      'Content-Length': String(data.byteLength),
+      'Cache-Control': 'public, max-age=31536000, immutable',
+    },
+  })
+  if (!res.ok) {
+    const t = await res.text().catch(() => '')
+    throw new Error(`R2 upload feilet (${res.status}): ${t}`)
+  }
+  return `${R2_PUBLIC_URL}/${sti}`
+}
+
+const client = new pg.Client({
+  host: `db.${PROJECT_REF}.supabase.co`,
+  port: 5432,
+  database: 'postgres',
+  user: 'postgres',
+  password: DB_PASSWORD,
+  ssl: { rejectUnauthorized: false },
+})
+
+await client.connect()
+
+// Sjekk at arrangementet finnes
+const { rows: arrRader } = await client.query(
+  'select id, tittel from arrangementer where id = $1',
+  [arrangementId],
+)
+if (arrRader.length === 0) {
+  console.error(`Fant ikke arrangement ${arrangementId}`)
+  process.exit(1)
+}
+console.log(`Arrangement: ${arrRader[0].tittel}`)
+
+// Bruk en eksisterende profil som "opprettet_av" — første admin
+const { rows: adminRader } = await client.query(
+  "select id, navn from profiles where rolle in ('admin','generalsekretaer') and aktiv = true order by navn limit 1",
+)
+if (adminRader.length === 0) {
+  console.error('Fant ingen admin-profil')
+  process.exit(1)
+}
+const opprettetAv = adminRader[0].id
+console.log(`Lagrer som opprettet av: ${adminRader[0].navn}`)
+
+// Opprett album
+const { rows: albumRader } = await client.query(
+  `insert into album (tittel, arrangement_id, opprettet_av)
+   values ($1, $2, $3)
+   returning id`,
+  [albumTittel, arrangementId, opprettetAv],
+)
+const albumId = albumRader[0].id
+console.log(`Album opprettet: ${albumId}`)
+
+// Finn alle bildefiler
+const filer = (await readdir(bilderMappe))
+  .filter(f => /\.(jpg|jpeg|png|webp)$/i.test(f))
+  .sort()
+
+console.log(`Fant ${filer.length} bildefiler`)
+
+let i = 0
+for (const fil of filer) {
+  i++
+  const stiInn = join(bilderMappe, fil)
+  const buffer = await readFile(stiInn)
+
+  // Komprimer hovedbilde til 1600px / q85
+  const meta = await sharp(buffer).metadata()
+  const hovedBuffer = await sharp(buffer)
+    .rotate() // EXIF-orientering
+    .resize({ width: 1600, height: 1600, fit: 'inside', withoutEnlargement: true })
+    .jpeg({ quality: 85 })
+    .toBuffer()
+
+  const hovedMeta = await sharp(hovedBuffer).metadata()
+
+  // Thumbnail 400px / q85
+  const thumbBuffer = await sharp(buffer)
+    .rotate()
+    .resize({ width: 400, height: 400, fit: 'inside', withoutEnlargement: true })
+    .jpeg({ quality: 85 })
+    .toBuffer()
+
+  const baseNavn = basename(fil, extname(fil))
+  const filnavn = `${Date.now()}-${i}-${baseNavn}.jpg`
+  const stiHoved = `album/${albumId}/${filnavn}`
+  const stiThumb = `album/${albumId}/thumb_${filnavn}`
+
+  const urlHoved = await lastOppR2(stiHoved, hovedBuffer, 'image/jpeg')
+  const urlThumb = await lastOppR2(stiThumb, thumbBuffer, 'image/jpeg')
+
+  await client.query(
+    `insert into album_bilde (album_id, bilde_url, thumb_url, bredde, hoyde, lastet_opp_av, rekkefolge)
+     values ($1, $2, $3, $4, $5, $6, $7)`,
+    [albumId, urlHoved, urlThumb, hovedMeta.width ?? null, hovedMeta.height ?? null, opprettetAv, i],
+  )
+
+  console.log(`  [${i}/${filer.length}] ${fil} → ${urlHoved}`)
+}
+
+console.log(`\nFerdig. Album: https://mortensrudherreklubb.no/album/${albumId}`)
+await client.end()

--- a/supabase/migrations/063_chat_bilder.sql
+++ b/supabase/migrations/063_chat_bilder.sql
@@ -9,6 +9,7 @@ alter table arrangement_chat alter column innhold drop not null;
 alter table arrangement_chat drop constraint if exists arrangement_chat_innhold_check;
 alter table arrangement_chat add constraint arrangement_chat_innhold_check
   check (innhold is null or char_length(innhold) between 1 and 500);
+alter table arrangement_chat drop constraint if exists arrangement_chat_innhold_eller_bilde;
 alter table arrangement_chat add constraint arrangement_chat_innhold_eller_bilde
   check (innhold is not null or bilde_url is not null);
 
@@ -18,6 +19,7 @@ alter table klubb_chat alter column innhold drop not null;
 alter table klubb_chat drop constraint if exists klubb_chat_innhold_check;
 alter table klubb_chat add constraint klubb_chat_innhold_check
   check (innhold is null or char_length(innhold) between 1 and 500);
+alter table klubb_chat drop constraint if exists klubb_chat_innhold_eller_bilde;
 alter table klubb_chat add constraint klubb_chat_innhold_eller_bilde
   check (innhold is not null or bilde_url is not null);
 
@@ -27,6 +29,7 @@ alter table poll_chat alter column innhold drop not null;
 alter table poll_chat drop constraint if exists poll_chat_innhold_check;
 alter table poll_chat add constraint poll_chat_innhold_check
   check (innhold is null or char_length(innhold) between 1 and 500);
+alter table poll_chat drop constraint if exists poll_chat_innhold_eller_bilde;
 alter table poll_chat add constraint poll_chat_innhold_eller_bilde
   check (innhold is not null or bilde_url is not null);
 
@@ -36,6 +39,7 @@ alter table melding_chat alter column innhold drop not null;
 alter table melding_chat drop constraint if exists melding_chat_innhold_check;
 alter table melding_chat add constraint melding_chat_innhold_check
   check (innhold is null or char_length(innhold) between 1 and 500);
+alter table melding_chat drop constraint if exists melding_chat_innhold_eller_bilde;
 alter table melding_chat add constraint melding_chat_innhold_eller_bilde
   check (innhold is not null or bilde_url is not null);
 
@@ -45,5 +49,6 @@ alter table samtale_chat alter column innhold drop not null;
 alter table samtale_chat drop constraint if exists samtale_chat_innhold_check;
 alter table samtale_chat add constraint samtale_chat_innhold_check
   check (innhold is null or char_length(innhold) between 1 and 2000);
+alter table samtale_chat drop constraint if exists samtale_chat_innhold_eller_bilde;
 alter table samtale_chat add constraint samtale_chat_innhold_eller_bilde
   check (innhold is not null or bilde_url is not null);

--- a/supabase/migrations/064_album.sql
+++ b/supabase/migrations/064_album.sql
@@ -1,0 +1,86 @@
+-- Album (#108 — fase 1). Et album grupperer bilder. Det kan høre til et
+-- arrangement (primær bruk) eller stå alene. Bildene lagres i R2 under
+-- `albums/{album_id}/...`; her holder vi bare metadata og rekkefølge.
+-- Per-bilde kommentarer kommer i en senere fase (egen tabell, ikke her).
+
+create table album (
+  id              uuid primary key default gen_random_uuid(),
+  tittel          text not null check (char_length(tittel) between 1 and 200),
+  arrangement_id  uuid references arrangementer(id) on delete set null,
+  cover_bilde_id  uuid,
+  opprettet_av    uuid not null references profiles(id) on delete set null,
+  opprettet       timestamptz not null default now(),
+  oppdatert       timestamptz not null default now()
+);
+
+create index album_arrangement_idx on album(arrangement_id);
+create index album_opprettet_idx on album(opprettet desc);
+
+alter table album enable row level security;
+
+create policy "Aktive kan lese album" on album
+  for select using (exists (
+    select 1 from profiles where id = auth.uid() and aktiv = true
+  ));
+
+create policy "Aktive kan opprette album" on album
+  for insert with check (
+    opprettet_av = auth.uid()
+    and exists (select 1 from profiles where id = auth.uid() and aktiv = true)
+  );
+
+create policy "Eier eller admin kan oppdatere album" on album
+  for update using (
+    opprettet_av = auth.uid() or er_admin()
+  );
+
+create policy "Eier eller admin kan slette album" on album
+  for delete using (
+    opprettet_av = auth.uid() or er_admin()
+  );
+
+-- === album_bilde ===============================================
+create table album_bilde (
+  id             uuid primary key default gen_random_uuid(),
+  album_id       uuid not null references album(id) on delete cascade,
+  bilde_url      text not null,
+  thumb_url      text,
+  bredde         int,
+  hoyde          int,
+  lastet_opp_av  uuid not null references profiles(id) on delete set null,
+  rekkefolge     int not null default 0,
+  opprettet      timestamptz not null default now()
+);
+
+create index album_bilde_album_idx on album_bilde(album_id, rekkefolge, opprettet);
+
+-- FK fra album.cover_bilde_id legges til ETTER album_bilde finnes,
+-- ellers får vi sirkulær avhengighet ved create.
+alter table album add constraint album_cover_fk
+  foreign key (cover_bilde_id) references album_bilde(id) on delete set null;
+
+alter table album_bilde enable row level security;
+
+create policy "Aktive kan lese album_bilde" on album_bilde
+  for select using (exists (
+    select 1 from profiles where id = auth.uid() and aktiv = true
+  ));
+
+create policy "Aktive kan laste opp album_bilde" on album_bilde
+  for insert with check (
+    lastet_opp_av = auth.uid()
+    and exists (select 1 from profiles where id = auth.uid() and aktiv = true)
+  );
+
+create policy "Opplaster, album-eier eller admin kan slette album_bilde" on album_bilde
+  for delete using (
+    lastet_opp_av = auth.uid()
+    or er_admin()
+    or exists (select 1 from album a where a.id = album_id and a.opprettet_av = auth.uid())
+  );
+
+create policy "Album-eier eller admin kan oppdatere album_bilde" on album_bilde
+  for update using (
+    er_admin()
+    or exists (select 1 from album a where a.id = album_id and a.opprettet_av = auth.uid())
+  );


### PR DESCRIPTION
Lukker #108. Del av #107.

## Hva
Album-feature for arrangementer. Et arrangement kan ha ett album med bilder; album-bildene vises som grid på arrangement-siden og i en egen `/album/[id]`-side med lightbox.

## Endringer

**DB**
- Migrasjon 064: `album` + `album_bilde` tabeller med RLS
- 063 gjort idempotent (constraint allerede applied)

**R2**
- Ny kategori `'album'` i `BILDE_KATEGORIER`
- Bilder lagres under `album/{album_id}/{filnavn}` + `thumb_{filnavn}`

**Server actions** (`lib/actions/album.ts`)
- `opprettAlbum({ tittel, arrangementId? })`
- `lastOppAlbumBilde(formData)` — tar imot komprimert bilde + thumb fra klienten
- `slettAlbum(id)` — best-effort R2-rydding etter cascade

**UI**
- `AlbumSeksjon` på arrangement-detaljside: «Lag album»-knapp om ingen, ellers grid (max 8 thumbs) + multi-select opplasting med progress
- Album-detaljside `/album/[id]` med 3-kolonne grid + `BildeLightbox`
- Kamera-ikon på arrangementkort på agenda når arrangement har album med ≥1 bilde

**Verktøy**
- `scripts/import-album.mjs` — Sharp-resize + R2-upload + DB-insert. For Tysk aften 2018-importen.

## Ut av scope
- Standalone-album-liste, omsortering, omslag-velger, sletting av enkeltbilder → #109
- Per-bilde kommentarer → senere

## Testing før merge
- [ ] Lag album på et arrangement og last opp et par bilder
- [ ] Verifiser at kamera-ikonet vises på arrangementkortet
- [ ] Klikk thumb i grid → lightbox åpnes
- [ ] Sjekk `/album/[id]`-siden direkte