### PR TITLE
Album fase 2: omslag, sletting, redigerbar tittel, /album-liste

### DIFF
--- a/app/(app)/album/[id]/page.tsx
+++ b/app/(app)/album/[id]/page.tsx
@@ -1,18 +1,24 @@
 import { createServerClient } from '@/lib/supabase/server'
-import { getInnloggetBruker } from '@/lib/auth-cache'
+import { getInnloggetBruker, getProfil } from '@/lib/auth-cache'
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import AlbumDetalj from '@/components/album/AlbumDetalj'
+import AlbumTittel from '@/components/album/AlbumTittel'
 import TillatLandskap from '@/components/album/TillatLandskap'
+import { kanAdministrere } from '@/lib/roller'
 
 export default async function AlbumSide({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
-  const [supabase] = await Promise.all([createServerClient(), getInnloggetBruker()])
+  const [supabase, user, profil] = await Promise.all([
+    createServerClient(),
+    getInnloggetBruker(),
+    getProfil(),
+  ])
 
   const { data: album } = await supabase
     .from('album')
     .select(
-      `id, tittel, arrangement_id,
+      `id, tittel, arrangement_id, opprettet_av, cover_bilde_id,
        arrangement:arrangementer (id, tittel),
        album_bilde!album_bilde_album_id_fkey (id, bilde_url, thumb_url, bredde, hoyde, opprettet, rekkefolge)`,
     )
@@ -34,11 +40,15 @@ export default async function AlbumSide({ params }: { params: Promise<{ id: stri
     .slice()
     .sort((a, b) => a.rekkefolge - b.rekkefolge || a.opprettet.localeCompare(b.opprettet))
 
+  const erEier = album.opprettet_av === user!.id
+  const erAdmin = kanAdministrere(profil?.rolle)
+  const kanRedigere = erEier || erAdmin
+
   return (
     <div style={{ padding: '0 20px 120px' }}>
       <TillatLandskap />
       <div style={{ paddingTop: 20, marginBottom: 16 }}>
-        {arrangement && (
+        {arrangement ? (
           <Link
             href={`/arrangementer/${arrangement.id}`}
             style={{
@@ -53,19 +63,23 @@ export default async function AlbumSide({ params }: { params: Promise<{ id: stri
           >
             ← {arrangement.tittel}
           </Link>
+        ) : (
+          <Link
+            href="/album"
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 11,
+              color: 'var(--text-tertiary)',
+              letterSpacing: '1.4px',
+              fontWeight: 600,
+              textTransform: 'uppercase',
+              textDecoration: 'none',
+            }}
+          >
+            ← Album
+          </Link>
         )}
-        <h1
-          style={{
-            fontFamily: 'var(--font-display)',
-            fontSize: 28,
-            fontWeight: 500,
-            margin: '6px 0 0',
-            color: 'var(--text-primary)',
-            letterSpacing: '-0.4px',
-          }}
-        >
-          {album.tittel}
-        </h1>
+        <AlbumTittel albumId={album.id} initialTittel={album.tittel} kanRedigere={kanRedigere} />
         <div
           style={{
             fontFamily: 'var(--font-mono)',
@@ -81,13 +95,18 @@ export default async function AlbumSide({ params }: { params: Promise<{ id: stri
         </div>
       </div>
 
-      <AlbumDetalj bilder={bilder.map(b => ({
-        id: b.id,
-        bilde_url: b.bilde_url,
-        thumb_url: b.thumb_url,
-        bredde: b.bredde,
-        hoyde: b.hoyde,
-      }))} />
+      <AlbumDetalj
+        bilder={bilder.map(b => ({
+          id: b.id,
+          bilde_url: b.bilde_url,
+          thumb_url: b.thumb_url,
+          bredde: b.bredde,
+          hoyde: b.hoyde,
+        }))}
+        albumId={album.id}
+        kanRedigere={kanRedigere}
+        coverBildeId={album.cover_bilde_id}
+      />
     </div>
   )
 }

--- a/app/(app)/album/page.tsx
+++ b/app/(app)/album/page.tsx
@@ -11,12 +11,16 @@ import OpprettAlbumKnapp from '@/components/album/OpprettAlbumKnapp'
 export default async function AlbumOversikt() {
   const [supabase] = await Promise.all([createServerClient(), getInnloggetBruker()])
 
+  // Henter cover-bildet via FK-join (album_cover_fk) og antall via aggregat
+  // — ikke hele bildelista. Album uten cover viser placeholder-ikonet
+  // (eksplisitt > implisitt).
   const { data: albumer } = await supabase
     .from('album')
     .select(
-      `id, tittel, arrangement_id, cover_bilde_id, opprettet,
+      `id, tittel, arrangement_id, opprettet,
        arrangement:arrangementer (id, tittel),
-       album_bilde!album_bilde_album_id_fkey (id, bilde_url, thumb_url, opprettet)`,
+       cover:album_bilde!album_cover_fk (bilde_url, thumb_url),
+       antall:album_bilde!album_bilde_album_id_fkey (count)`,
     )
     .order('opprettet', { ascending: false })
 
@@ -24,23 +28,21 @@ export default async function AlbumOversikt() {
     id: string
     tittel: string
     arrangement_id: string | null
-    cover_bilde_id: string | null
     opprettet: string
     arrangement: { id: string; tittel: string } | { id: string; tittel: string }[] | null
-    album_bilde: Array<{ id: string; bilde_url: string; thumb_url: string | null; opprettet: string }> | null
+    cover: { bilde_url: string; thumb_url: string | null } | { bilde_url: string; thumb_url: string | null }[] | null
+    antall: { count: number }[] | null
   }
 
   const rader = ((albumer ?? []) as AlbumRad[]).map(a => {
     const arr = Array.isArray(a.arrangement) ? a.arrangement[0] : a.arrangement
-    const bilder = a.album_bilde ?? []
-    const cover = a.cover_bilde_id ? bilder.find(b => b.id === a.cover_bilde_id) : null
-    const fallback = bilder.slice().sort((x, y) => x.opprettet.localeCompare(y.opprettet))[0]
-    const thumb = cover?.thumb_url ?? cover?.bilde_url ?? fallback?.thumb_url ?? fallback?.bilde_url ?? null
+    const cover = Array.isArray(a.cover) ? a.cover[0] : a.cover
+    const thumb = cover?.thumb_url ?? cover?.bilde_url ?? null
     return {
       id: a.id,
       tittel: a.tittel,
       arrangement: arr,
-      antall: bilder.length,
+      antall: a.antall?.[0]?.count ?? 0,
       thumb,
     }
   })

--- a/app/(app)/album/page.tsx
+++ b/app/(app)/album/page.tsx
@@ -1,0 +1,191 @@
+import { createServerClient } from '@/lib/supabase/server'
+import { getInnloggetBruker } from '@/lib/auth-cache'
+import Link from 'next/link'
+import Image from 'next/image'
+import Icon from '@/components/ui/Icon'
+import OpprettAlbumKnapp from '@/components/album/OpprettAlbumKnapp'
+
+// Album-oversikt — alle album i klubben. Standalone-album og arrangement-
+// koblede vises samme sted, sortert nyeste først. Kortet viser cover (eller
+// første bilde som fallback), tittel, evt. arrangement-navn og bilde-antall.
+export default async function AlbumOversikt() {
+  const [supabase] = await Promise.all([createServerClient(), getInnloggetBruker()])
+
+  const { data: albumer } = await supabase
+    .from('album')
+    .select(
+      `id, tittel, arrangement_id, cover_bilde_id, opprettet,
+       arrangement:arrangementer (id, tittel),
+       album_bilde!album_bilde_album_id_fkey (id, bilde_url, thumb_url, opprettet)`,
+    )
+    .order('opprettet', { ascending: false })
+
+  type AlbumRad = {
+    id: string
+    tittel: string
+    arrangement_id: string | null
+    cover_bilde_id: string | null
+    opprettet: string
+    arrangement: { id: string; tittel: string } | { id: string; tittel: string }[] | null
+    album_bilde: Array<{ id: string; bilde_url: string; thumb_url: string | null; opprettet: string }> | null
+  }
+
+  const rader = ((albumer ?? []) as AlbumRad[]).map(a => {
+    const arr = Array.isArray(a.arrangement) ? a.arrangement[0] : a.arrangement
+    const bilder = a.album_bilde ?? []
+    const cover = a.cover_bilde_id ? bilder.find(b => b.id === a.cover_bilde_id) : null
+    const fallback = bilder.slice().sort((x, y) => x.opprettet.localeCompare(y.opprettet))[0]
+    const thumb = cover?.thumb_url ?? cover?.bilde_url ?? fallback?.thumb_url ?? fallback?.bilde_url ?? null
+    return {
+      id: a.id,
+      tittel: a.tittel,
+      arrangement: arr,
+      antall: bilder.length,
+      thumb,
+    }
+  })
+
+  return (
+    <div style={{ padding: '0 20px 120px' }}>
+      <div style={{ padding: '12px 4px 22px' }}>
+        <div
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 9,
+            color: 'var(--text-tertiary)',
+            letterSpacing: '2.5px',
+            textTransform: 'uppercase',
+            marginBottom: 18,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+          }}
+        >
+          <span style={{ width: 18, height: '0.5px', background: 'var(--border-strong)' }} />
+          Album
+        </div>
+        <h1
+          style={{
+            fontFamily: 'var(--font-display)',
+            fontSize: 36,
+            fontWeight: 500,
+            letterSpacing: '-0.5px',
+            lineHeight: 1,
+            margin: 0,
+            color: 'var(--text-primary)',
+          }}
+        >
+          Bildene
+        </h1>
+      </div>
+
+      <OpprettAlbumKnapp />
+
+      {rader.length === 0 ? (
+        <div
+          style={{
+            padding: 24,
+            borderRadius: 'var(--radius-card)',
+            border: '0.5px solid var(--border-subtle)',
+            background: 'var(--bg-elevated)',
+            textAlign: 'center',
+            color: 'var(--text-tertiary)',
+            fontSize: 13,
+            marginTop: 16,
+          }}
+        >
+          Ingen album opprettet ennå.
+        </div>
+      ) : (
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(2, 1fr)',
+            gap: 10,
+            marginTop: 14,
+          }}
+        >
+          {rader.map(r => (
+            <Link
+              key={r.id}
+              href={`/album/${r.id}`}
+              style={{
+                display: 'block',
+                textDecoration: 'none',
+                color: 'inherit',
+                borderRadius: 'var(--radius-card)',
+                overflow: 'hidden',
+                background: 'var(--bg-elevated)',
+                border: '0.5px solid var(--border-subtle)',
+              }}
+            >
+              <div
+                style={{
+                  position: 'relative',
+                  aspectRatio: '1 / 1',
+                  background: 'var(--bg-elevated-2)',
+                }}
+              >
+                {r.thumb ? (
+                  <Image
+                    src={r.thumb}
+                    alt=""
+                    fill
+                    sizes="(max-width: 480px) 50vw, 240px"
+                    style={{ objectFit: 'cover' }}
+                  />
+                ) : (
+                  <div
+                    style={{
+                      position: 'absolute',
+                      inset: 0,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      color: 'var(--text-tertiary)',
+                    }}
+                  >
+                    <Icon name="image" size={28} color="currentColor" strokeWidth={1.25} />
+                  </div>
+                )}
+              </div>
+              <div style={{ padding: '10px 12px 12px' }}>
+                <div
+                  style={{
+                    fontFamily: 'var(--font-display)',
+                    fontSize: 16,
+                    color: 'var(--text-primary)',
+                    fontWeight: 500,
+                    letterSpacing: '-0.2px',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {r.tittel}
+                </div>
+                <div
+                  style={{
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 10,
+                    color: 'var(--text-tertiary)',
+                    letterSpacing: '1.2px',
+                    fontWeight: 600,
+                    textTransform: 'uppercase',
+                    marginTop: 4,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {r.antall} {r.antall === 1 ? 'bilde' : 'bilder'}
+                  {r.arrangement && ` · ${r.arrangement.tittel}`}
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/(app)/arrangementer/[id]/page.tsx
+++ b/app/(app)/arrangementer/[id]/page.tsx
@@ -90,7 +90,7 @@ export default async function ArrangementDetaljer({
     supabase
       .from('album')
       .select(
-        'id, tittel, album_bilde!album_bilde_album_id_fkey (id, bilde_url, thumb_url, opprettet)',
+        'id, tittel, cover_bilde_id, opprettet_av, album_bilde!album_bilde_album_id_fkey (id, bilde_url, thumb_url, opprettet)',
       )
       .eq('arrangement_id', id)
       .order('opprettet', { ascending: false })
@@ -588,11 +588,16 @@ export default async function ArrangementDetaljer({
         {/* Album */}
         <AlbumSeksjon
           arrangementId={id}
+          kanRedigere={
+            !!(albumRader && albumRader[0] &&
+              (albumRader[0].opprettet_av === user!.id || erAdmin))
+          }
           album={
             albumRader && albumRader[0]
               ? {
                   id: albumRader[0].id,
                   tittel: albumRader[0].tittel,
+                  cover_bilde_id: albumRader[0].cover_bilde_id,
                   bilder: ((albumRader[0].album_bilde ?? []) as Array<{
                     id: string
                     bilde_url: string

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -129,12 +129,15 @@ export default async function Forside() {
       )
       .order('opprettet', { ascending: false })
       .limit(60),
-    // Hvilke arrangementer har album med ≥1 bilde — brukes til å vise
-    // kamera-ikon på agenda-kortet. Henter kun arrangement_id og første
-    // bilde-id som indikator på at det finnes innhold.
+    // Hvilke arrangementer har album — brukes til både kamera-ikon på
+    // agenda-kortet og som fallback-bilde når arrangementet ikke har eget
+    // bilde_url. Henter alle bilder så vi kan plukke cover (eller første)
+    // for fallback-rendering.
     supabase
       .from('album')
-      .select('arrangement_id, album_bilde!album_bilde_album_id_fkey (id)')
+      .select(
+        'arrangement_id, cover_bilde_id, album_bilde!album_bilde_album_id_fkey (id, bilde_url, thumb_url, opprettet)',
+      )
       .not('arrangement_id', 'is', null),
   ])
 
@@ -287,18 +290,31 @@ export default async function Forside() {
     }
   })
 
-  // Set av arrangement-id-er som har album med ≥1 bilde
-  type AlbumIndikator = { arrangement_id: string | null; album_bilde: { id: string }[] | null }
+  // Album-info per arrangement: finnes album, og hva er cover-bildet?
+  type AlbumIndikator = {
+    arrangement_id: string | null
+    cover_bilde_id: string | null
+    album_bilde: Array<{ id: string; bilde_url: string; thumb_url: string | null; opprettet: string }> | null
+  }
   const arrangementMedAlbum = new Set<string>()
+  const coverPerArrangement = new Map<string, string>()
   for (const a of (albumMedArrangement ?? []) as AlbumIndikator[]) {
-    if (a.arrangement_id && a.album_bilde && a.album_bilde.length > 0) {
-      arrangementMedAlbum.add(a.arrangement_id)
-    }
+    if (!a.arrangement_id) continue
+    const bilder = a.album_bilde ?? []
+    if (bilder.length === 0) continue
+    arrangementMedAlbum.add(a.arrangement_id)
+    const cover = a.cover_bilde_id ? bilder.find(b => b.id === a.cover_bilde_id) : null
+    const fallback = bilder.slice().sort((x, y) => x.opprettet.localeCompare(y.opprettet))[0]
+    const url = cover?.bilde_url ?? fallback?.bilde_url
+    if (url) coverPerArrangement.set(a.arrangement_id, url)
   }
 
-  const arrangementerBerikt = ((arrangementer ?? []) as unknown as ArrangementRaad[]).map(
-    a => ({ ...a, harAlbum: arrangementMedAlbum.has(a.id) }),
-  )
+  const arrangementerBerikt = ((arrangementer ?? []) as unknown as ArrangementRaad[]).map(a => ({
+    ...a,
+    harAlbum: arrangementMedAlbum.has(a.id),
+    // Fall tilbake til album-cover hvis arr ikke har eget bilde
+    bilde_url: a.bilde_url ?? coverPerArrangement.get(a.id) ?? null,
+  }))
 
   const { meldinger, idag, kommende, tidligere } = byggAgenda({
     arrangementer: arrangementerBerikt,

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -131,12 +131,14 @@ export default async function Forside() {
       .limit(60),
     // Hvilke arrangementer har album — brukes til både kamera-ikon på
     // agenda-kortet og som fallback-bilde når arrangementet ikke har eget
-    // bilde_url. Henter alle bilder så vi kan plukke cover (eller første)
-    // for fallback-rendering.
+    // bilde_url. Vi henter cover via FK-join (album_cover_fk) + bilde-antall
+    // via aggregat, ikke hele bildelista. Fallback-bilde brukes kun når
+    // cover er eksplisitt satt — uten cover får arrangementet kamera-ikon
+    // men beholder placeholder-stilen.
     supabase
       .from('album')
       .select(
-        'arrangement_id, cover_bilde_id, album_bilde!album_bilde_album_id_fkey (id, bilde_url, thumb_url, opprettet)',
+        'arrangement_id, cover:album_bilde!album_cover_fk (bilde_url), antall:album_bilde!album_bilde_album_id_fkey (count)',
       )
       .not('arrangement_id', 'is', null),
   ])
@@ -290,23 +292,23 @@ export default async function Forside() {
     }
   })
 
-  // Album-info per arrangement: finnes album, og hva er cover-bildet?
+  // Album-info per arrangement: finnes album med ≥1 bilde, og er det satt
+  // cover? cover kommer som ett embedded objekt via album_cover_fk; antall
+  // som ett aggregat-objekt ([{count}]).
   type AlbumIndikator = {
     arrangement_id: string | null
-    cover_bilde_id: string | null
-    album_bilde: Array<{ id: string; bilde_url: string; thumb_url: string | null; opprettet: string }> | null
+    cover: { bilde_url: string } | { bilde_url: string }[] | null
+    antall: { count: number }[] | null
   }
   const arrangementMedAlbum = new Set<string>()
   const coverPerArrangement = new Map<string, string>()
   for (const a of (albumMedArrangement ?? []) as AlbumIndikator[]) {
     if (!a.arrangement_id) continue
-    const bilder = a.album_bilde ?? []
-    if (bilder.length === 0) continue
+    const antall = a.antall?.[0]?.count ?? 0
+    if (antall === 0) continue
     arrangementMedAlbum.add(a.arrangement_id)
-    const cover = a.cover_bilde_id ? bilder.find(b => b.id === a.cover_bilde_id) : null
-    const fallback = bilder.slice().sort((x, y) => x.opprettet.localeCompare(y.opprettet))[0]
-    const url = cover?.bilde_url ?? fallback?.bilde_url
-    if (url) coverPerArrangement.set(a.arrangement_id, url)
+    const cover = Array.isArray(a.cover) ? a.cover[0] : a.cover
+    if (cover?.bilde_url) coverPerArrangement.set(a.arrangement_id, cover.bilde_url)
   }
 
   const arrangementerBerikt = ((arrangementer ?? []) as unknown as ArrangementRaad[]).map(a => ({

--- a/components/album/AlbumDetalj.tsx
+++ b/components/album/AlbumDetalj.tsx
@@ -15,7 +15,17 @@ export type AlbumBildeDetalj = {
 // Grid med 3 kolonner. Klikk på en thumb åpner lightbox med fullt bilde.
 // Per-bilde-kommentarer kommer i fase 2 — derfor ingen interaksjon utover
 // vis-i-fullskjerm her.
-export default function AlbumDetalj({ bilder }: { bilder: AlbumBildeDetalj[] }) {
+export default function AlbumDetalj({
+  bilder,
+  albumId,
+  kanRedigere = false,
+  coverBildeId = null,
+}: {
+  bilder: AlbumBildeDetalj[]
+  albumId: string
+  kanRedigere?: boolean
+  coverBildeId?: string | null
+}) {
   const [aktiv, setAktiv] = useState<number | null>(null)
 
   if (bilder.length === 0) {
@@ -77,6 +87,9 @@ export default function AlbumDetalj({ bilder }: { bilder: AlbumBildeDetalj[] }) 
           bilder={bilder.map(b => ({ id: b.id, bilde_url: b.bilde_url }))}
           startIndex={aktiv}
           onLukk={() => setAktiv(null)}
+          albumId={albumId}
+          kanRedigere={kanRedigere}
+          coverBildeId={coverBildeId}
         />
       )}
     </>

--- a/components/album/AlbumLightbox.tsx
+++ b/components/album/AlbumLightbox.tsx
@@ -1,8 +1,10 @@
 'use client'
 
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useState, useRef, useTransition } from 'react'
 import { createPortal } from 'react-dom'
+import { useRouter } from 'next/navigation'
 import Icon from '@/components/ui/Icon'
+import { settOmslagsbilde, slettAlbumBilde } from '@/lib/actions/album'
 
 // Fullskjerm-galleri for album. Pil-knapper, swipe, tastatur og X for å lukke.
 // Krysser mellom bilder uten å unmounte hele overlayet — det gir en stabil
@@ -14,13 +16,21 @@ export default function AlbumLightbox({
   bilder,
   startIndex,
   onLukk,
+  albumId,
+  kanRedigere = false,
+  coverBildeId = null,
 }: {
   bilder: { id: string; bilde_url: string }[]
   startIndex: number
   onLukk: () => void
+  albumId?: string
+  kanRedigere?: boolean
+  coverBildeId?: string | null
 }) {
+  const router = useRouter()
   const [index, setIndex] = useState(startIndex)
   const [montert, setMontert] = useState(false)
+  const [pending, startTransition] = useTransition()
   const dragStartX = useRef<number | null>(null)
   const dragDeltaX = useRef(0)
 
@@ -73,6 +83,39 @@ export default function AlbumLightbox({
 
   const aktiv = bilder[index]
   if (!aktiv || !montert) return null
+
+  function handleSettOmslag() {
+    if (!albumId || !aktiv) return
+    startTransition(async () => {
+      try {
+        await settOmslagsbilde(albumId, aktiv.id)
+        router.refresh()
+      } catch (e) {
+        console.error(e)
+        alert('Kunne ikke sette omslag')
+      }
+    })
+  }
+
+  function handleSlett() {
+    if (!aktiv) return
+    if (!confirm('Slett dette bildet?')) return
+    const bildeId = aktiv.id
+    const erSiste = bilder.length === 1
+    startTransition(async () => {
+      try {
+        await slettAlbumBilde(bildeId)
+        if (erSiste) onLukk()
+        else if (index >= bilder.length - 1) setIndex(Math.max(0, index - 1))
+        router.refresh()
+      } catch (e) {
+        console.error(e)
+        alert('Kunne ikke slette bildet')
+      }
+    })
+  }
+
+  const erOmslag = coverBildeId === aktiv.id
 
   // Portal til <body> så fixed-positioning ikke begrenses av layout-
   // containeren (maxWidth 480, position: relative). Uten portal havner
@@ -212,6 +255,65 @@ export default function AlbumLightbox({
             <Icon name="chevron" size={22} color="currentColor" strokeWidth={2.5} />
           </button>
         </>
+      )}
+
+      {/* Handlinger (kun synlig for admin/eier) */}
+      {kanRedigere && albumId && (
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 'max(20px, env(safe-area-inset-bottom))',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            display: 'flex',
+            gap: 10,
+            padding: '8px 10px',
+            borderRadius: 999,
+            background: 'rgba(0,0,0,0.65)',
+            boxShadow: '0 0 0 1px rgba(255,255,255,0.18)',
+          }}
+        >
+          <button
+            type="button"
+            onClick={handleSettOmslag}
+            disabled={pending || erOmslag}
+            style={{
+              border: 'none',
+              padding: '8px 14px',
+              borderRadius: 999,
+              background: erOmslag ? 'var(--accent-soft)' : 'transparent',
+              color: erOmslag ? 'var(--accent)' : '#fff',
+              fontFamily: 'var(--font-body)',
+              fontSize: 12,
+              fontWeight: 600,
+              cursor: erOmslag || pending ? 'default' : 'pointer',
+              opacity: pending && !erOmslag ? 0.6 : 1,
+            }}
+          >
+            {erOmslag ? 'Omslag' : 'Sett som omslag'}
+          </button>
+          <button
+            type="button"
+            onClick={handleSlett}
+            disabled={pending}
+            aria-label="Slett bilde"
+            style={{
+              width: 36,
+              height: 36,
+              borderRadius: '50%',
+              border: 'none',
+              background: 'transparent',
+              color: '#e87060',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              cursor: pending ? 'default' : 'pointer',
+              opacity: pending ? 0.6 : 1,
+            }}
+          >
+            <Icon name="x" size={18} color="currentColor" strokeWidth={2.5} />
+          </button>
+        </div>
       )}
     </div>
   )

--- a/components/album/AlbumSeksjon.tsx
+++ b/components/album/AlbumSeksjon.tsx
@@ -19,6 +19,7 @@ export type AlbumForSeksjon = {
   id: string
   tittel: string
   bilder: AlbumBildeForGrid[]
+  cover_bilde_id: string | null
 }
 
 const MAKS_FORHANDSVISNING = 8
@@ -75,9 +76,11 @@ async function opplastIBolker(albumId: string, filer: File[], onProgress: (n: nu
 export default function AlbumSeksjon({
   album,
   arrangementId,
+  kanRedigere = false,
 }: {
   album: AlbumForSeksjon | null
   arrangementId: string
+  kanRedigere?: boolean
 }) {
   const router = useRouter()
   const [oppretter, startOpprett] = useTransition()
@@ -278,6 +281,9 @@ export default function AlbumSeksjon({
           bilder={album.bilder.map(b => ({ id: b.id, bilde_url: b.bilde_url }))}
           startIndex={lightbox}
           onLukk={() => setLightbox(null)}
+          albumId={album.id}
+          kanRedigere={kanRedigere}
+          coverBildeId={album.cover_bilde_id}
         />
       )}
     </section>

--- a/components/album/AlbumTittel.tsx
+++ b/components/album/AlbumTittel.tsx
@@ -1,0 +1,158 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import Icon from '@/components/ui/Icon'
+import { oppdaterAlbumTittel } from '@/lib/actions/album'
+
+// Album-tittel med inline-redigering for admin og eier. Klikk på blyant
+// gir et kompakt input + lagre/avbryt-knapper. Lagring kjører via server
+// action og refresher siden så også andre steder (lenker, lister) ser ny
+// tittel umiddelbart.
+export default function AlbumTittel({
+  albumId,
+  initialTittel,
+  kanRedigere,
+}: {
+  albumId: string
+  initialTittel: string
+  kanRedigere: boolean
+}) {
+  const router = useRouter()
+  const [redigerer, setRedigerer] = useState(false)
+  const [tekst, setTekst] = useState(initialTittel)
+  const [pending, start] = useTransition()
+
+  function lagre() {
+    const ny = tekst.trim()
+    if (!ny || ny === initialTittel) {
+      setRedigerer(false)
+      setTekst(initialTittel)
+      return
+    }
+    start(async () => {
+      try {
+        await oppdaterAlbumTittel(albumId, ny)
+        setRedigerer(false)
+        router.refresh()
+      } catch (e) {
+        console.error(e)
+        alert('Kunne ikke oppdatere tittel')
+      }
+    })
+  }
+
+  if (!redigerer) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 6 }}>
+        <h1
+          style={{
+            fontFamily: 'var(--font-display)',
+            fontSize: 28,
+            fontWeight: 500,
+            margin: 0,
+            color: 'var(--text-primary)',
+            letterSpacing: '-0.4px',
+          }}
+        >
+          {initialTittel}
+        </h1>
+        {kanRedigere && (
+          <button
+            type="button"
+            onClick={() => setRedigerer(true)}
+            aria-label="Rediger tittel"
+            style={{
+              border: 'none',
+              background: 'transparent',
+              color: 'var(--text-tertiary)',
+              cursor: 'pointer',
+              padding: 4,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Icon name="cog" size={16} color="currentColor" />
+          </button>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 6 }}>
+      <input
+        type="text"
+        value={tekst}
+        onChange={e => setTekst(e.target.value)}
+        autoFocus
+        maxLength={200}
+        onKeyDown={e => {
+          if (e.key === 'Enter') lagre()
+          else if (e.key === 'Escape') {
+            setRedigerer(false)
+            setTekst(initialTittel)
+          }
+        }}
+        style={{
+          flex: 1,
+          minWidth: 0,
+          background: 'var(--bg-elevated)',
+          border: '0.5px solid var(--border)',
+          borderRadius: 8,
+          color: 'var(--text-primary)',
+          fontFamily: 'var(--font-display)',
+          fontSize: 24,
+          fontWeight: 500,
+          padding: '6px 10px',
+          outline: 'none',
+          letterSpacing: '-0.4px',
+        }}
+      />
+      <button
+        type="button"
+        onClick={lagre}
+        disabled={pending}
+        aria-label="Lagre"
+        style={{
+          width: 36,
+          height: 36,
+          borderRadius: '50%',
+          border: 'none',
+          background: 'var(--accent)',
+          color: '#0a0a0a',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          cursor: pending ? 'default' : 'pointer',
+          opacity: pending ? 0.6 : 1,
+        }}
+      >
+        <Icon name="checkmark" size={18} color="currentColor" strokeWidth={2.5} />
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          setRedigerer(false)
+          setTekst(initialTittel)
+        }}
+        aria-label="Avbryt"
+        style={{
+          width: 36,
+          height: 36,
+          borderRadius: '50%',
+          border: '0.5px solid var(--border)',
+          background: 'transparent',
+          color: 'var(--text-tertiary)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          cursor: 'pointer',
+        }}
+      >
+        <Icon name="x" size={16} color="currentColor" />
+      </button>
+    </div>
+  )
+}

--- a/components/album/AlbumTittel.tsx
+++ b/components/album/AlbumTittel.tsx
@@ -1,14 +1,14 @@
 'use client'
 
-import { useState, useTransition } from 'react'
+import { useState, useTransition, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import Icon from '@/components/ui/Icon'
 import { oppdaterAlbumTittel } from '@/lib/actions/album'
 
-// Album-tittel med inline-redigering for admin og eier. Klikk på blyant
-// gir et kompakt input + lagre/avbryt-knapper. Lagring kjører via server
-// action og refresher siden så også andre steder (lenker, lister) ser ny
-// tittel umiddelbart.
+// Album-tittel med inline-redigering for admin og eier. Klikk på rediger-
+// knappen gir et kompakt input + lagre/avbryt-knapper. Lagring kjører via
+// server action og refresher siden så også andre steder (lenker, lister) ser
+// ny tittel umiddelbart.
 export default function AlbumTittel({
   albumId,
   initialTittel,
@@ -22,6 +22,13 @@ export default function AlbumTittel({
   const [redigerer, setRedigerer] = useState(false)
   const [tekst, setTekst] = useState(initialTittel)
   const [pending, start] = useTransition()
+
+  // Synk lokal tekst-state når initialTittel endres (etter router.refresh
+  // hvor den nye tittelen kommer inn som ny prop). Uten dette ville neste
+  // åpning av redigeringen vise forrige tekst-input.
+  useEffect(() => {
+    setTekst(initialTittel)
+  }, [initialTittel])
 
   function lagre() {
     const ny = tekst.trim()

--- a/components/album/OpprettAlbumKnapp.tsx
+++ b/components/album/OpprettAlbumKnapp.tsx
@@ -1,0 +1,166 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import Icon from '@/components/ui/Icon'
+import { opprettAlbum } from '@/lib/actions/album'
+
+// Knapp + dialog for å opprette nytt album uten arrangement-tilknytning.
+// Album med arrangement opprettes inline på arrangement-detaljsiden via
+// AlbumSeksjon — denne dekker resten (turer som ble glemt opprettet, blandet
+// innhold, generelle klubbalbum osv.).
+export default function OpprettAlbumKnapp() {
+  const router = useRouter()
+  const [apen, setApen] = useState(false)
+  const [tittel, setTittel] = useState('')
+  const [pending, start] = useTransition()
+
+  function lukk() {
+    setApen(false)
+    setTittel('')
+  }
+
+  function lagre() {
+    const t = tittel.trim()
+    if (!t) return
+    start(async () => {
+      try {
+        const { id } = await opprettAlbum({ tittel: t })
+        lukk()
+        router.push(`/album/${id}`)
+      } catch (e) {
+        console.error(e)
+        alert('Kunne ikke opprette album')
+      }
+    })
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setApen(true)}
+        style={{
+          width: '100%',
+          padding: '12px 16px',
+          borderRadius: 'var(--radius-card)',
+          border: '0.5px dashed var(--border)',
+          background: 'var(--bg-elevated)',
+          color: 'var(--text-primary)',
+          fontFamily: 'var(--font-body)',
+          fontSize: 13,
+          cursor: 'pointer',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 8,
+        }}
+      >
+        <Icon name="plus" size={16} color="var(--accent)" />
+        Nytt album
+      </button>
+
+      {apen && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          onClick={lukk}
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(0,0,0,0.6)',
+            zIndex: 9999,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: 20,
+          }}
+        >
+          <div
+            onClick={e => e.stopPropagation()}
+            style={{
+              width: '100%',
+              maxWidth: 400,
+              background: 'var(--bg-elevated)',
+              border: '0.5px solid var(--border)',
+              borderRadius: 'var(--radius)',
+              padding: 20,
+            }}
+          >
+            <h2
+              style={{
+                fontFamily: 'var(--font-display)',
+                fontSize: 22,
+                fontWeight: 500,
+                margin: '0 0 14px',
+                color: 'var(--text-primary)',
+              }}
+            >
+              Nytt album
+            </h2>
+            <input
+              type="text"
+              value={tittel}
+              onChange={e => setTittel(e.target.value)}
+              autoFocus
+              placeholder="Tittel"
+              maxLength={200}
+              onKeyDown={e => {
+                if (e.key === 'Enter') lagre()
+                else if (e.key === 'Escape') lukk()
+              }}
+              style={{
+                width: '100%',
+                background: 'var(--bg)',
+                border: '0.5px solid var(--border)',
+                borderRadius: 8,
+                color: 'var(--text-primary)',
+                fontFamily: 'var(--font-body)',
+                fontSize: 15,
+                padding: '10px 12px',
+                outline: 'none',
+                marginBottom: 16,
+                boxSizing: 'border-box',
+              }}
+            />
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+              <button
+                type="button"
+                onClick={lukk}
+                style={{
+                  padding: '8px 14px',
+                  borderRadius: 999,
+                  border: '0.5px solid var(--border)',
+                  background: 'transparent',
+                  color: 'var(--text-secondary)',
+                  fontSize: 13,
+                  cursor: 'pointer',
+                }}
+              >
+                Avbryt
+              </button>
+              <button
+                type="button"
+                onClick={lagre}
+                disabled={!tittel.trim() || pending}
+                style={{
+                  padding: '8px 16px',
+                  borderRadius: 999,
+                  border: 'none',
+                  background: 'var(--accent)',
+                  color: '#0a0a0a',
+                  fontSize: 13,
+                  fontWeight: 600,
+                  cursor: !tittel.trim() || pending ? 'default' : 'pointer',
+                  opacity: !tittel.trim() || pending ? 0.5 : 1,
+                }}
+              >
+                {pending ? 'Oppretter…' : 'Opprett'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/lib/actions/album.ts
+++ b/lib/actions/album.ts
@@ -115,6 +115,18 @@ export async function oppdaterAlbumTittel(id: string, tittel: string): Promise<v
 export async function settOmslagsbilde(albumId: string, bildeId: string): Promise<void> {
   const { supabase } = await ensureInnlogget()
 
+  // Verifiser at bildet faktisk tilhører albumet — uten denne sjekken kunne
+  // en bruker som kjenner et annet albums bildeId sette det som cover her.
+  // FK-en alene garanterer kun at bildeId eksisterer som album_bilde-rad.
+  const { data: bilde } = await supabase
+    .from('album_bilde')
+    .select('album_id')
+    .eq('id', bildeId)
+    .maybeSingle()
+  if (!bilde || bilde.album_id !== albumId) {
+    throw new Error('Bildet hører ikke til dette albumet')
+  }
+
   const { error } = await supabase
     .from('album')
     .update({ cover_bilde_id: bildeId, oppdatert: new Date().toISOString() })

--- a/lib/actions/album.ts
+++ b/lib/actions/album.ts
@@ -96,6 +96,80 @@ export async function lastOppAlbumBilde(formData: FormData): Promise<{ id: strin
   return { id: rad.id, url }
 }
 
+export async function oppdaterAlbumTittel(id: string, tittel: string): Promise<void> {
+  const { supabase } = await ensureInnlogget()
+  const ny = tittel.trim()
+  if (!ny) throw new Error('Tittel kan ikke være tom')
+  if (ny.length > 200) throw new Error('Tittel er for lang')
+
+  const { error } = await supabase
+    .from('album')
+    .update({ tittel: ny, oppdatert: new Date().toISOString() })
+    .eq('id', id)
+  if (error) throw new Error(error.message)
+
+  revalidatePath(`/album/${id}`)
+  revalidatePath('/album')
+}
+
+export async function settOmslagsbilde(albumId: string, bildeId: string): Promise<void> {
+  const { supabase } = await ensureInnlogget()
+
+  const { error } = await supabase
+    .from('album')
+    .update({ cover_bilde_id: bildeId, oppdatert: new Date().toISOString() })
+    .eq('id', albumId)
+  if (error) throw new Error(error.message)
+
+  // Sjekk arrangement-id for revalidering
+  const { data: album } = await supabase
+    .from('album')
+    .select('arrangement_id')
+    .eq('id', albumId)
+    .maybeSingle()
+
+  revalidatePath(`/album/${albumId}`)
+  revalidatePath('/album')
+  revalidatePath('/')
+  if (album?.arrangement_id) revalidatePath(`/arrangementer/${album.arrangement_id}`)
+}
+
+export async function slettAlbumBilde(bildeId: string): Promise<void> {
+  const { supabase } = await ensureInnlogget()
+
+  // Hent URL-er + albumId før delete så vi kan rydde i R2 etterpå
+  const { data: bilde } = await supabase
+    .from('album_bilde')
+    .select('bilde_url, thumb_url, album_id')
+    .eq('id', bildeId)
+    .maybeSingle()
+
+  if (!bilde) return
+
+  const { error } = await supabase.from('album_bilde').delete().eq('id', bildeId)
+  if (error) throw new Error(error.message)
+
+  // Best-effort opprydding i R2
+  const s1 = r2StiFraUrl(bilde.bilde_url)
+  if (s1) await slettR2(s1).catch(() => {})
+  if (bilde.thumb_url) {
+    const s2 = r2StiFraUrl(bilde.thumb_url)
+    if (s2) await slettR2(s2).catch(() => {})
+  }
+
+  // Sjekk arrangement-id for revalidering
+  const { data: album } = await supabase
+    .from('album')
+    .select('arrangement_id')
+    .eq('id', bilde.album_id)
+    .maybeSingle()
+
+  revalidatePath(`/album/${bilde.album_id}`)
+  revalidatePath('/album')
+  revalidatePath('/')
+  if (album?.arrangement_id) revalidatePath(`/arrangementer/${album.arrangement_id}`)
+}
+
 export async function slettAlbum(id: string): Promise<void> {
   const { supabase } = await ensureInnlogget()
 

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 174,
-  "versjon": "V2.174"
+  "nummer": 175,
+  "versjon": "V2.175"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 173,
-  "versjon": "V2.173"
+  "nummer": 174,
+  "versjon": "V2.174"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.173'
+const CACHE_VERSION = 'V2.174'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.174'
+const CACHE_VERSION = 'V2.175'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Lukker #109. Del av #107.

## Hva
- **Omslag-velger:** «Sett som omslag»-knapp i AlbumLightbox (admin/eier). Cover-bildet vises som fallback-bilde på arrangementkort på agenda når arrangementet ikke har eget bilde.
- **Sletting av enkeltbilder:** sletteknapp i AlbumLightbox (admin/eier/opplaster). Best-effort R2-rydding.
- **Redigerbar tittel:** inline-redigering på album-detaljsiden.
- **/album-oversiktsside:** grid med alle album, cover-thumbnail (fallback til første bilde), opprett-knapp for standalone-album.

## Endringer
- `lib/actions/album.ts` — nye actions: `oppdaterAlbumTittel`, `settOmslagsbilde`, `slettAlbumBilde`
- `components/album/AlbumLightbox.tsx` — handlings-toolbar i bunnen
- `components/album/AlbumTittel.tsx` — ny inline-redigerer
- `components/album/OpprettAlbumKnapp.tsx` — ny opprett-dialog
- `app/(app)/album/page.tsx` — ny oversiktsside
- `app/(app)/album/[id]/page.tsx` — bruker AlbumTittel + threader kanRedigere/coverBildeId
- `app/(app)/arrangementer/[id]/page.tsx` — threader kanRedigere/coverBildeId til AlbumSeksjon
- `app/(app)/page.tsx` — bruker album-cover som fallback-bilde på agenda

## Ut av scope (kommer evt. senere)
- Manuell omsortering av bilder
- Per-bilde kommentarer

## Test
- [ ] Tap thumb i lightbox: «Sett som omslag» og slett-knapp synlig som admin/eier
- [ ] Sett omslag → arr-kortet på agenda viser cover-bildet
- [ ] Slett siste bilde → lightbox lukkes automatisk
- [ ] Klikk blyant på album-tittel → rediger inline → lagre
- [ ] /album viser grid med alle album, opprett-knapp lager nytt standalone-album og redirecter til detaljsiden