### PR TITLE
Chat-arkitektur: CHAT_KONFIG + unifiserte server actions

### DIFF
--- a/components/agenda/KommentarerPaaKort.tsx
+++ b/components/agenda/KommentarerPaaKort.tsx
@@ -4,7 +4,8 @@ import { useState, useTransition, type MouseEvent, type KeyboardEvent } from 're
 import { useRouter } from 'next/navigation'
 import Avatar from '@/components/ui/Avatar'
 import Icon from '@/components/ui/Icon'
-import { sendMelding, sendPollMelding, sendMeldingKommentar } from '@/lib/actions/chat'
+import { sendChatMelding } from '@/lib/actions/chat'
+import type { ChatScope } from '@/lib/chat-konfig'
 import { formatDistanceToNowStrict } from 'date-fns'
 import { nb } from 'date-fns/locale'
 
@@ -74,15 +75,17 @@ export default function KommentarerPaaKort({
     if (!melding || sender) return
     setTekst('')
 
+    // Map fra det lokale KommentarScope til CHAT_KONFIG-scopet.
+    const chatScope: ChatScope =
+      scope.type === 'arrangement'
+        ? { type: 'arrangement', arrangementId: scope.id }
+        : scope.type === 'poll'
+          ? { type: 'poll', pollId: scope.id }
+          : { type: 'melding', meldingId: scope.id }
+
     startTransition(async () => {
       try {
-        if (scope.type === 'arrangement') {
-          await sendMelding(scope.id, melding)
-        } else if (scope.type === 'poll') {
-          await sendPollMelding(scope.id, melding)
-        } else {
-          await sendMeldingKommentar(scope.id, melding)
-        }
+        await sendChatMelding(chatScope, melding, null)
         router.refresh()
       } catch {
         // Gjenopprett tekst ved feil så brukeren ikke mister det de skrev

--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -3,26 +3,13 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { createClient } from '@/lib/supabase/client'
 import {
-  sendMelding,
-  slettMelding,
-  oppdaterMelding,
-  sendKlubbMelding,
-  slettKlubbMelding,
-  oppdaterKlubbMelding,
-  sendPollMelding,
-  slettPollMelding,
-  oppdaterPollMelding,
-  sendMeldingKommentar,
-  slettMeldingKommentar,
-  oppdaterMeldingKommentar,
+  sendChatMelding,
+  oppdaterChatMelding,
+  slettChatMelding,
   leggTilReaksjon,
   fjernReaksjon,
 } from '@/lib/actions/chat'
-import {
-  sendPrivatMelding,
-  slettPrivatMelding,
-  oppdaterPrivatMelding,
-} from '@/lib/actions/samtaler'
+import { konfigFor, type ChatScope as ChatScopeKonfig } from '@/lib/chat-konfig'
 import { formaterDato } from '@/lib/dato'
 import Avatar from '@/components/ui/Avatar'
 import Icon from '@/components/ui/Icon'
@@ -30,15 +17,10 @@ import SectionLabel from '@/components/ui/SectionLabel'
 import BildeLightbox from '@/components/ui/BildeLightbox'
 import { komprimer, genererFilnavn } from '@/lib/bilde-utils'
 import { lastOppBilde, slettBilde } from '@/lib/actions/bilde-opplasting'
-import { CHAT_MAKS_LENGDE } from '@/lib/konstanter'
-import { INNLEGG_MAKS_LENGDE } from '@/lib/konstanter'
 
-export type ChatScope =
-  | { type: 'arrangement'; arrangementId: string }
-  | { type: 'klubb' }
-  | { type: 'poll'; pollId: string }
-  | { type: 'melding'; meldingId: string }
-  | { type: 'privat'; samtaleId: string }
+// ChatScope er sentralt definert i lib/chat-konfig.ts og re-eksportert her
+// for kall-ergonomi (eksisterende callsites importerer fra Chat.tsx).
+export type ChatScope = ChatScopeKonfig
 
 export type ChatMelding = {
   id: string
@@ -143,80 +125,28 @@ export default function Chat({
   ).current
   const supabase = useRef(createClient()).current
 
-  const tabell =
-    scope.type === 'klubb'
-      ? 'klubb_chat'
-      : scope.type === 'poll'
-        ? 'poll_chat'
-        : scope.type === 'melding'
-          ? 'melding_chat'
-          : scope.type === 'privat'
-            ? 'samtale_chat'
-            : 'arrangement_chat'
-  const kanalNavn =
-    scope.type === 'klubb'
-      ? 'chat-klubb'
-      : scope.type === 'poll'
-        ? `chat-poll-${scope.pollId}`
-        : scope.type === 'melding'
-          ? `chat-melding-${scope.meldingId}`
-          : scope.type === 'privat'
-            ? `chat-privat-${scope.samtaleId}`
-            : `chat-arr-${scope.arrangementId}`
+  // CHAT_KONFIG-lookup samler tabell/kanal/charLimit per scope. Erstatter
+  // 5 paralle switch-kjeder som tidligere måtte holdes synk her, i hentMeldinger,
+  // i realtime-oppsett og i input-validering.
+  const konfig = konfigFor(scope)
+  const tabell = konfig.tabell
+  const kanalNavn = konfig.kanalNavn(scope)
 
   // Helper — henter meldinger med riktig scope-filter. Returnerer i
   // *stigende* rekkefølge (eldste først) siden det er det UI-et ønsker.
+  // Bruker CHAT_KONFIG til å slå opp tabell + FK-filter — ingen scope-
+  // spesifikke grener her.
   const hentMeldinger = useCallback(
     async (forTidspunkt?: string): Promise<ChatMelding[]> => {
-      if (scope.type === 'klubb') {
-        let q = supabase
-          .from('klubb_chat')
-          .select('id, profil_id, innhold, bilde_url, opprettet')
-          .order('opprettet', { ascending: false })
-          .limit(SIDE_STORRELSE)
-        if (forTidspunkt) q = q.lt('opprettet', forTidspunkt)
-        const { data } = await q
-        return data ? [...data].reverse() : []
-      }
-      if (scope.type === 'poll') {
-        let q = supabase
-          .from('poll_chat')
-          .select('id, profil_id, innhold, bilde_url, opprettet')
-          .eq('poll_id', scope.pollId)
-          .order('opprettet', { ascending: false })
-          .limit(SIDE_STORRELSE)
-        if (forTidspunkt) q = q.lt('opprettet', forTidspunkt)
-        const { data } = await q
-        return data ? [...data].reverse() : []
-      }
-      if (scope.type === 'melding') {
-        let q = supabase
-          .from('melding_chat')
-          .select('id, profil_id, innhold, bilde_url, opprettet')
-          .eq('melding_id', scope.meldingId)
-          .order('opprettet', { ascending: false })
-          .limit(SIDE_STORRELSE)
-        if (forTidspunkt) q = q.lt('opprettet', forTidspunkt)
-        const { data } = await q
-        return data ? [...data].reverse() : []
-      }
-      if (scope.type === 'privat') {
-        let q = supabase
-          .from('samtale_chat')
-          .select('id, profil_id, innhold, bilde_url, opprettet')
-          .eq('samtale_id', scope.samtaleId)
-          .order('opprettet', { ascending: false })
-          .limit(SIDE_STORRELSE)
-        if (forTidspunkt) q = q.lt('opprettet', forTidspunkt)
-        const { data } = await q
-        return data ? [...data].reverse() : []
-      }
       let q = supabase
-        .from('arrangement_chat')
+        .from(konfig.tabell)
         .select('id, profil_id, innhold, bilde_url, opprettet')
-        .eq('arrangement_id', scope.arrangementId)
         .order('opprettet', { ascending: false })
         .limit(SIDE_STORRELSE)
+      const fkVerdi = konfig.scopeId(scope)
+      if (konfig.fkFelt && fkVerdi) {
+        q = q.eq(konfig.fkFelt, fkVerdi)
+      }
       if (forTidspunkt) q = q.lt('opprettet', forTidspunkt)
       const { data } = await q
       return data ? [...data].reverse() : []
@@ -354,38 +284,17 @@ export default function Chat({
 
       const channel = supabase.channel(kanalNavn)
 
-      // Filter: for arrangement/poll, filtrer på respektive id. For klubb,
-      // ingen filter siden tabellen kun inneholder klubb-meldinger.
+      // Filter på FK-kolonnen hvis scope har en (alle utenom klubb).
+      const fkVerdi = konfig.scopeId(scope)
       const insertConfig =
-        scope.type === 'arrangement'
+        konfig.fkFelt && fkVerdi
           ? {
               event: 'INSERT' as const,
               schema: 'public',
               table: tabell,
-              filter: `arrangement_id=eq.${scope.arrangementId}`,
+              filter: `${konfig.fkFelt}=eq.${fkVerdi}`,
             }
-          : scope.type === 'poll'
-            ? {
-                event: 'INSERT' as const,
-                schema: 'public',
-                table: tabell,
-                filter: `poll_id=eq.${scope.pollId}`,
-              }
-            : scope.type === 'melding'
-              ? {
-                  event: 'INSERT' as const,
-                  schema: 'public',
-                  table: tabell,
-                  filter: `melding_id=eq.${scope.meldingId}`,
-                }
-              : scope.type === 'privat'
-                ? {
-                    event: 'INSERT' as const,
-                    schema: 'public',
-                    table: tabell,
-                    filter: `samtale_id=eq.${scope.samtaleId}`,
-                  }
-                : { event: 'INSERT' as const, schema: 'public', table: tabell }
+          : { event: 'INSERT' as const, schema: 'public', table: tabell }
 
       const deleteConfig = { event: 'DELETE' as const, schema: 'public', table: tabell }
       const updateConfig = { event: 'UPDATE' as const, schema: 'public', table: tabell }
@@ -631,17 +540,7 @@ export default function Chat({
         bildeUrl = res.url
       }
 
-      if (scope.type === 'arrangement') {
-        await sendMelding(scope.arrangementId, melding, bildeUrl)
-      } else if (scope.type === 'poll') {
-        await sendPollMelding(scope.pollId, melding, bildeUrl)
-      } else if (scope.type === 'melding') {
-        await sendMeldingKommentar(scope.meldingId, melding, bildeUrl)
-      } else if (scope.type === 'privat') {
-        await sendPrivatMelding(scope.samtaleId, melding, bildeUrl)
-      } else {
-        await sendKlubbMelding(melding, bildeUrl)
-      }
+      await sendChatMelding(scope, melding, bildeUrl)
     } catch (err) {
       console.error('Send feilet:', err)
       setMeldinger(prev => prev.filter(m => m.id !== tempId))
@@ -744,17 +643,7 @@ export default function Chat({
     // Optimistisk oppdatering
     setMeldinger(prev => prev.map(m => (m.id === id ? { ...m, innhold: ny } : m)))
     try {
-      if (scope.type === 'arrangement') {
-        await oppdaterMelding(id, ny)
-      } else if (scope.type === 'poll') {
-        await oppdaterPollMelding(id, ny)
-      } else if (scope.type === 'melding') {
-        await oppdaterMeldingKommentar(id, ny)
-      } else if (scope.type === 'privat') {
-        await oppdaterPrivatMelding(id, ny)
-      } else {
-        await oppdaterKlubbMelding(id, ny)
-      }
+      await oppdaterChatMelding(scope, id, ny)
       avbrytEdit()
     } catch {
       // Rull tilbake ved feil
@@ -772,17 +661,7 @@ export default function Chat({
     if (!confirm('Slette denne meldingen?')) return
     setMeldinger(prev => prev.filter(m => m.id !== id))
     try {
-      if (scope.type === 'arrangement') {
-        await slettMelding(id)
-      } else if (scope.type === 'poll') {
-        await slettPollMelding(id)
-      } else if (scope.type === 'melding') {
-        await slettMeldingKommentar(id)
-      } else if (scope.type === 'privat') {
-        await slettPrivatMelding(id)
-      } else {
-        await slettKlubbMelding(id)
-      }
+      await slettChatMelding(scope, id)
     } catch {
       // Ved feil: last inn de siste N på nytt
       const nyeste = await hentMeldinger()
@@ -941,7 +820,7 @@ export default function Chat({
                             avbrytEdit()
                           }
                         }}
-                        maxLength={500}
+                        maxLength={konfig.charLimit}
                         rows={2}
                         style={{
                           width: '100%',
@@ -1430,7 +1309,7 @@ export default function Chat({
             }
           }}
           placeholder={bildePreview ? 'Legg til tekst (valgfritt)…' : 'Skriv en melding…'}
-          maxLength={scope.type === 'privat' ? INNLEGG_MAKS_LENGDE : CHAT_MAKS_LENGDE}
+          maxLength={konfig.charLimit}
           enterKeyHint="send"
           autoComplete="off"
           style={{

--- a/lib/actions/chat.ts
+++ b/lib/actions/chat.ts
@@ -134,7 +134,14 @@ export async function oppdaterChatMelding(
   const k = konfigFor(scope)
   // Ved redigering kreves alltid tekst — dummy bildeUrl for å passere bilde-
   // fallbacken i validerInnhold. Bilde kan ikke endres via redigering.
+  // Eksplisitt sjekk for tom/whitespace etter trim siden validerInnhold med
+  // bildeUrl='placeholder' ellers ville la null-tekst slippe gjennom og
+  // nulle ut innhold-kolonnen i DB.
   const { tekst } = validerInnhold(innhold, 'placeholder', k.charLimit)
+  if (!tekst) {
+    const minLengde = k.charLimit > 500 ? INNLEGG_MIN_LENGDE : CHAT_MIN_LENGDE
+    throw new Error(`Meldingen må være ${minLengde}–${k.charLimit} tegn`)
+  }
 
   const supabase = await createServerClient()
   const { error } = await supabase

--- a/lib/actions/chat.ts
+++ b/lib/actions/chat.ts
@@ -1,234 +1,167 @@
 'use server'
 
 import { createServerClient } from '@/lib/supabase/server'
-import { sendChatMentionVarsler } from '@/lib/varsler'
-import { CHAT_MAKS_LENGDE, CHAT_MIN_LENGDE } from '@/lib/konstanter'
+import { sendChatMentionVarsler, sendVarsel } from '@/lib/varsler'
+import { BASE_URL } from '@/lib/config'
+import { CHAT_MIN_LENGDE, INNLEGG_MIN_LENGDE } from '@/lib/konstanter'
+import { konfigFor, type ChatScope } from '@/lib/chat-konfig'
 
-// Trimmer og validerer chat-innhold.
-// Tekst kan være tom hvis bilde_url er satt — meldingen kan være ren bilde.
-// Returnerer trimmed tekst (eller null hvis tom).
+// Trimmer og validerer chat-innhold for et gitt scope. Bruker scope-spesifikk
+// charLimit (privat = INNLEGG_MAKS_LENGDE = 2000, øvrige = CHAT_MAKS_LENGDE
+// = 500). Tekst kan være tom hvis bilde_url er satt — meldingen kan være
+// ren bilde. Returnerer trimmed tekst (eller null hvis tom).
 function validerInnhold(
   innhold: string | null,
   bildeUrl: string | null,
+  charLimit: number,
 ): { tekst: string | null } {
   const tekst = innhold?.trim() || null
   if (!tekst && !bildeUrl) {
     throw new Error('Meldingen må ha tekst eller bilde')
   }
-  if (tekst && (tekst.length < CHAT_MIN_LENGDE || tekst.length > CHAT_MAKS_LENGDE)) {
-    throw new Error(`Meldingen må være ${CHAT_MIN_LENGDE}–${CHAT_MAKS_LENGDE} tegn`)
+  // Privat har egen min via INNLEGG_MIN_LENGDE; for chat er CHAT_MIN_LENGDE
+  // det riktige. Begge er 1, så vi velger basert på charLimit-størrelsen.
+  const minLengde = charLimit > 500 ? INNLEGG_MIN_LENGDE : CHAT_MIN_LENGDE
+  if (tekst && (tekst.length < minLengde || tekst.length > charLimit)) {
+    throw new Error(`Meldingen må være ${minLengde}–${charLimit} tegn`)
   }
   return { tekst }
 }
 
-export async function sendMelding(
-  arrangementId: string,
-  innhold: string | null,
-  bildeUrl: string | null = null,
-) {
-  const { tekst } = validerInnhold(innhold, bildeUrl)
-
-  const supabase = await createServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error('Ikke innlogget')
-
-  const { error } = await supabase
-    .from('arrangement_chat')
-    .insert({ arrangement_id: arrangementId, profil_id: user.id, innhold: tekst, bilde_url: bildeUrl })
-
-  if (error) throw new Error(error.message)
-
+// Etter vellykket insert: send mention- eller privat-melding-varsel.
+// For arrangement/klubb/poll/melding: skanner teksten etter @-mentions og
+// varsler bare de mottakerne. For privat: én varsel til motparten.
+async function sendVarslerEtterPost(
+  scope: ChatScope,
+  tekst: string | null,
+  avsenderId: string,
+): Promise<void> {
+  if (scope.type === 'privat') {
+    const varselTekst = tekst ?? '📷 Sendte deg et bilde'
+    await sendPrivatMeldingVarsel(scope.samtaleId, varselTekst, avsenderId)
+    return
+  }
+  if (!tekst) return
   // @-mention-varsler MÅ awaites — fire-and-forget kuttes av Vercel
   // når server action returnerer (CLAUDE.md: «Bruk aldri after()…
   // Bruk await direkte»). Promise.all internt gjør utsendingen
   // parallell, så latency er kort selv med mange mottakere.
-  if (tekst) {
-    try {
-      await sendChatMentionVarsler(
-        { type: 'arrangement', id: arrangementId },
-        tekst,
-        user.id,
-      )
-    } catch (err) {
-      console.error('mention-varsler feilet:', err)
-    }
+  if (scope.type === 'arrangement') {
+    await sendChatMentionVarsler({ type: 'arrangement', id: scope.arrangementId }, tekst, avsenderId)
+  } else if (scope.type === 'klubb') {
+    await sendChatMentionVarsler({ type: 'klubb' }, tekst, avsenderId)
+  } else if (scope.type === 'poll') {
+    await sendChatMentionVarsler({ type: 'poll', id: scope.pollId }, tekst, avsenderId)
+  } else if (scope.type === 'melding') {
+    await sendChatMentionVarsler({ type: 'melding', id: scope.meldingId }, tekst, avsenderId)
   }
 }
 
-export async function oppdaterMelding(meldingId: string, innhold: string) {
-  const { tekst } = validerInnhold(innhold, 'placeholder') // tekst er påkrevd ved redigering
-
+async function sendPrivatMeldingVarsel(
+  samtaleId: string,
+  tekst: string,
+  avsenderId: string,
+): Promise<void> {
   const supabase = await createServerClient()
-  const { error } = await supabase
-    .from('arrangement_chat')
-    .update({ innhold: tekst })
-    .eq('id', meldingId)
 
-  if (error) throw new Error(error.message)
+  const { data: samtale } = await supabase
+    .from('samtale')
+    .select('profil_a, profil_b')
+    .eq('id', samtaleId)
+    .single()
+
+  if (!samtale) return
+
+  const motpartId = samtale.profil_a === avsenderId ? samtale.profil_b : samtale.profil_a
+
+  const { data: avsender } = await supabase
+    .from('profiles')
+    .select('navn, visningsnavn')
+    .eq('id', avsenderId)
+    .single()
+
+  const avsenderNavn = avsender?.visningsnavn ?? avsender?.navn ?? 'Noen'
+  const utdrag = tekst.length > 80 ? tekst.slice(0, 77) + '...' : tekst
+
+  // Hver privatmelding er sin egen — tillatDuplikat: true så samme avsender
+  // kan sende flere meldinger uten at de filtreres bort i dedup-laget.
+  await sendVarsel({
+    mottakere: [motpartId],
+    tittel: `${avsenderNavn} skrev`,
+    melding: utdrag,
+    url: `${BASE_URL}/samtaler/${samtaleId}`,
+    knappTekst: 'Åpne samtalen',
+    type: 'privat-melding',
+    tillatDuplikat: true,
+  })
 }
 
-export async function slettMelding(meldingId: string) {
-  const supabase = await createServerClient()
-  const { error } = await supabase
-    .from('arrangement_chat')
-    .delete()
-    .eq('id', meldingId)
-
-  if (error) throw new Error(error.message)
-}
-
-// ---------- Klubb-chat ----------
-
-export async function sendKlubbMelding(
+// Generisk send for alle chat-scopes. Tabell, FK-felt og charLimit slås opp
+// i CHAT_KONFIG. RLS i Postgres er fortsatt det som faktisk håndhever
+// tilgang per scope; her gjør vi bare ergonomisk innsetting.
+export async function sendChatMelding(
+  scope: ChatScope,
   innhold: string | null,
   bildeUrl: string | null = null,
-) {
-  const { tekst } = validerInnhold(innhold, bildeUrl)
+): Promise<void> {
+  const k = konfigFor(scope)
+  const { tekst } = validerInnhold(innhold, bildeUrl, k.charLimit)
 
   const supabase = await createServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) throw new Error('Ikke innlogget')
 
+  const fkData = k.fkFelt ? { [k.fkFelt]: k.scopeId(scope) } : {}
   const { error } = await supabase
-    .from('klubb_chat')
-    .insert({ profil_id: user.id, innhold: tekst, bilde_url: bildeUrl })
-
+    .from(k.tabell)
+    .insert({ ...fkData, profil_id: user.id, innhold: tekst, bilde_url: bildeUrl })
   if (error) throw new Error(error.message)
 
-  if (tekst) {
-    try {
-      await sendChatMentionVarsler({ type: 'klubb' }, tekst, user.id)
-    } catch (err) {
-      console.error('mention-varsler feilet:', err)
-    }
+  try {
+    await sendVarslerEtterPost(scope, tekst, user.id)
+  } catch (err) {
+    // Varsel-svikt skal ikke feile selve meldingen — den er allerede skrevet
+    // til DB. Logg og gå videre.
+    console.error('post-send-varsler feilet:', err)
   }
 }
 
-export async function oppdaterKlubbMelding(meldingId: string, innhold: string) {
-  const { tekst } = validerInnhold(innhold, 'placeholder')
-
-  const supabase = await createServerClient()
-  const { error } = await supabase
-    .from('klubb_chat')
-    .update({ innhold: tekst })
-    .eq('id', meldingId)
-
-  if (error) throw new Error(error.message)
-}
-
-export async function slettKlubbMelding(meldingId: string) {
-  const supabase = await createServerClient()
-  const { error } = await supabase
-    .from('klubb_chat')
-    .delete()
-    .eq('id', meldingId)
-
-  if (error) throw new Error(error.message)
-}
-
-// ---------- Poll-chat ----------
-
-export async function sendPollMelding(
-  pollId: string,
-  innhold: string | null,
-  bildeUrl: string | null = null,
-) {
-  const { tekst } = validerInnhold(innhold, bildeUrl)
-
-  const supabase = await createServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error('Ikke innlogget')
-
-  const { error } = await supabase
-    .from('poll_chat')
-    .insert({ poll_id: pollId, profil_id: user.id, innhold: tekst, bilde_url: bildeUrl })
-
-  if (error) throw new Error(error.message)
-
-  if (tekst) {
-    try {
-      await sendChatMentionVarsler({ type: 'poll', id: pollId }, tekst, user.id)
-    } catch (err) {
-      console.error('mention-varsler feilet:', err)
-    }
-  }
-}
-
-export async function oppdaterPollMelding(meldingId: string, innhold: string) {
-  const { tekst } = validerInnhold(innhold, 'placeholder')
-
-  const supabase = await createServerClient()
-  const { error } = await supabase
-    .from('poll_chat')
-    .update({ innhold: tekst })
-    .eq('id', meldingId)
-
-  if (error) throw new Error(error.message)
-}
-
-export async function slettPollMelding(meldingId: string) {
-  const supabase = await createServerClient()
-  const { error } = await supabase
-    .from('poll_chat')
-    .delete()
-    .eq('id', meldingId)
-
-  if (error) throw new Error(error.message)
-}
-
-// === Kommentarer på meldinger (#90) =================================
-
-export async function sendMeldingKommentar(
+export async function oppdaterChatMelding(
+  scope: ChatScope,
   meldingId: string,
-  innhold: string | null,
-  bildeUrl: string | null = null,
-) {
-  const { tekst } = validerInnhold(innhold, bildeUrl)
-
-  const supabase = await createServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error('Ikke innlogget')
-
-  const { error } = await supabase
-    .from('melding_chat')
-    .insert({ melding_id: meldingId, profil_id: user.id, innhold: tekst, bilde_url: bildeUrl })
-
-  if (error) throw new Error(error.message)
-
-  if (tekst) {
-    try {
-      await sendChatMentionVarsler({ type: 'melding', id: meldingId }, tekst, user.id)
-    } catch (err) {
-      console.error('mention-varsler feilet:', err)
-    }
-  }
-}
-
-export async function oppdaterMeldingKommentar(kommentarId: string, innhold: string) {
-  const { tekst } = validerInnhold(innhold, 'placeholder')
+  innhold: string,
+): Promise<void> {
+  const k = konfigFor(scope)
+  // Ved redigering kreves alltid tekst — dummy bildeUrl for å passere bilde-
+  // fallbacken i validerInnhold. Bilde kan ikke endres via redigering.
+  const { tekst } = validerInnhold(innhold, 'placeholder', k.charLimit)
 
   const supabase = await createServerClient()
   const { error } = await supabase
-    .from('melding_chat')
+    .from(k.tabell)
     .update({ innhold: tekst })
-    .eq('id', kommentarId)
+    .eq('id', meldingId)
 
   if (error) throw new Error(error.message)
 }
 
-export async function slettMeldingKommentar(kommentarId: string) {
+export async function slettChatMelding(
+  scope: ChatScope,
+  meldingId: string,
+): Promise<void> {
+  const k = konfigFor(scope)
   const supabase = await createServerClient()
   const { error } = await supabase
-    .from('melding_chat')
+    .from(k.tabell)
     .delete()
-    .eq('id', kommentarId)
+    .eq('id', meldingId)
 
   if (error) throw new Error(error.message)
 }
 
-// Reaksjoner — samme flyt for arrangement-chat og klubb-chat. melding_id
-// peker til id i enten arrangement_chat eller klubb_chat. RLS håndhever at
-// brukeren kun kan legge til/fjerne egne reaksjoner.
+// Reaksjoner — felles for alle scopes via chat_reaksjoner-tabellen.
+// melding_id peker til id-en i den underliggende chat-tabellen (RLS
+// håndhever at brukeren kun kan legge til/fjerne egne reaksjoner).
 export async function leggTilReaksjon(meldingId: string, emoji: string) {
   const supabase = await createServerClient()
   const { data: { user } } = await supabase.auth.getUser()

--- a/lib/actions/samtaler.ts
+++ b/lib/actions/samtaler.ts
@@ -1,10 +1,7 @@
 'use server'
 
 import { createServerClient } from '@/lib/supabase/server'
-import { sendVarsel } from '@/lib/varsler'
 import { redirect } from 'next/navigation'
-import { BASE_URL } from '@/lib/config'
-import { INNLEGG_MAKS_LENGDE, INNLEGG_MIN_LENGDE } from '@/lib/konstanter'
 
 /**
  * Finn eller opprett samtalen mellom innlogget bruker og motpart.
@@ -47,71 +44,6 @@ export async function aapneSamtale(motpartId: string) {
   redirect(`/samtaler/${ny.id}`)
 }
 
-export async function sendPrivatMelding(
-  samtaleId: string,
-  innhold: string | null,
-  bildeUrl: string | null = null,
-) {
-  const tekst = innhold?.trim() || null
-  if (!tekst && !bildeUrl) {
-    throw new Error('Meldingen må ha tekst eller bilde')
-  }
-  if (tekst && (tekst.length < INNLEGG_MIN_LENGDE || tekst.length > INNLEGG_MAKS_LENGDE)) {
-    throw new Error(`Meldingen må være ${INNLEGG_MIN_LENGDE}–${INNLEGG_MAKS_LENGDE} tegn`)
-  }
-
-  const supabase = await createServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error('Ikke innlogget')
-
-  // RLS sørger for at vi kun kan poste i samtaler vi deltar i
-  const { error } = await supabase
-    .from('samtale_chat')
-    .insert({ samtale_id: samtaleId, profil_id: user.id, innhold: tekst, bilde_url: bildeUrl })
-
-  if (error) throw new Error(error.message)
-
-  // Varsle motparten i bakgrunnen — sentral sendVarsel håndterer
-  // brukerpreferanser, dedup-policy og logging.
-  const varselTekst = tekst ?? '📷 Sendte deg et bilde'
-  sendPrivatMeldingVarsel(samtaleId, varselTekst, user.id).catch(console.error)
-}
-
-async function sendPrivatMeldingVarsel(samtaleId: string, tekst: string, avsenderId: string) {
-  const supabase = await createServerClient()
-
-  const { data: samtale } = await supabase
-    .from('samtale')
-    .select('profil_a, profil_b')
-    .eq('id', samtaleId)
-    .single()
-
-  if (!samtale) return
-
-  const motpartId = samtale.profil_a === avsenderId ? samtale.profil_b : samtale.profil_a
-
-  const { data: avsender } = await supabase
-    .from('profiles')
-    .select('navn, visningsnavn')
-    .eq('id', avsenderId)
-    .single()
-
-  const avsenderNavn = avsender?.visningsnavn ?? avsender?.navn ?? 'Noen'
-  const utdrag = tekst.length > 80 ? tekst.slice(0, 77) + '...' : tekst
-
-  // Hver privatmelding er sin egen — tillatDuplikat: true så samme avsender
-  // kan sende flere meldinger uten at de filtreres bort i dedup-laget.
-  await sendVarsel({
-    mottakere: [motpartId],
-    tittel: `${avsenderNavn} skrev`,
-    melding: utdrag,
-    url: `${BASE_URL}/samtaler/${samtaleId}`,
-    knappTekst: 'Åpne samtalen',
-    type: 'privat-melding',
-    tillatDuplikat: true,
-  })
-}
-
 /**
  * Marker alle innkomne meldinger i samtalen som lest. Kalles fra
  * samtalesiden ved load. RLS sørger for at man kun kan oppdatere
@@ -130,27 +62,6 @@ export async function markerSamtaleLest(samtaleId: string) {
     .eq('lest', false)
 }
 
-export async function oppdaterPrivatMelding(meldingId: string, innhold: string) {
-  const tekst = innhold.trim()
-  if (tekst.length < INNLEGG_MIN_LENGDE || tekst.length > INNLEGG_MAKS_LENGDE) {
-    throw new Error(`Meldingen må være ${INNLEGG_MIN_LENGDE}–${INNLEGG_MAKS_LENGDE} tegn`)
-  }
-
-  const supabase = await createServerClient()
-  const { error } = await supabase
-    .from('samtale_chat')
-    .update({ innhold: tekst })
-    .eq('id', meldingId)
-
-  if (error) throw new Error(error.message)
-}
-
-export async function slettPrivatMelding(meldingId: string) {
-  const supabase = await createServerClient()
-  const { error } = await supabase
-    .from('samtale_chat')
-    .delete()
-    .eq('id', meldingId)
-
-  if (error) throw new Error(error.message)
-}
+// Send/oppdater/slett private meldinger går via sendChatMelding /
+// oppdaterChatMelding / slettChatMelding i lib/actions/chat.ts (scope
+// 'privat'). Privat-melding-varselet håndteres i samme generiske flyt.

--- a/lib/chat-konfig.ts
+++ b/lib/chat-konfig.ts
@@ -1,0 +1,108 @@
+// Sentral konfigurasjon for de fem chat-scopene. Erstatter spredte switch-
+// statements i Chat.tsx og 4× kopipasta i lib/actions/chat.ts. Hver scope
+// har sin egen tabell, valgfri FK-kolonne, kanal-navn og charLimit. Mention-
+// varsler / privat-melding-varsler kobles inn via `postSend`-callbacken slik
+// at sendChatMelding kan være helt scope-agnostisk.
+//
+// Endringer her speiles av RLS-policies i Postgres — RLS er fortsatt
+// sannheten. Denne filen er en TS-side bekvemmelighet for kall-ergonomi.
+
+import { CHAT_MAKS_LENGDE, INNLEGG_MAKS_LENGDE } from '@/lib/konstanter'
+
+export type ChatScope =
+  | { type: 'arrangement'; arrangementId: string }
+  | { type: 'klubb' }
+  | { type: 'poll'; pollId: string }
+  | { type: 'melding'; meldingId: string }
+  | { type: 'privat'; samtaleId: string }
+
+export type ChatScopeType = ChatScope['type']
+
+export type ChatTabell =
+  | 'arrangement_chat'
+  | 'klubb_chat'
+  | 'poll_chat'
+  | 'melding_chat'
+  | 'samtale_chat'
+
+export type ChatKonfig = {
+  tabell: ChatTabell
+  /** Navn på FK-kolonnen i chat-tabellen (eller null for klubb-chat). */
+  fkFelt: string | null
+  /** Henter ut FK-verdien fra et scope. */
+  scopeId: (s: ChatScope) => string | null
+  /** Stabilt kanalnavn for supabase-realtime per scope-instans. */
+  kanalNavn: (s: ChatScope) => string
+  /** Maksimalt antall tegn i en melding. Privat = 2000, andre = 500. */
+  charLimit: number
+}
+
+function antarType<T extends ChatScopeType>(s: ChatScope, t: T): asserts s is Extract<ChatScope, { type: T }> {
+  if (s.type !== t) throw new Error(`Forventet scope-type ${t}, fikk ${s.type}`)
+}
+
+export const CHAT_KONFIG: Record<ChatScopeType, ChatKonfig> = {
+  arrangement: {
+    tabell: 'arrangement_chat',
+    fkFelt: 'arrangement_id',
+    scopeId: s => {
+      antarType(s, 'arrangement')
+      return s.arrangementId
+    },
+    kanalNavn: s => {
+      antarType(s, 'arrangement')
+      return `chat-arr-${s.arrangementId}`
+    },
+    charLimit: CHAT_MAKS_LENGDE,
+  },
+  klubb: {
+    tabell: 'klubb_chat',
+    fkFelt: null,
+    scopeId: () => null,
+    kanalNavn: () => 'chat-klubb',
+    charLimit: CHAT_MAKS_LENGDE,
+  },
+  poll: {
+    tabell: 'poll_chat',
+    fkFelt: 'poll_id',
+    scopeId: s => {
+      antarType(s, 'poll')
+      return s.pollId
+    },
+    kanalNavn: s => {
+      antarType(s, 'poll')
+      return `chat-poll-${s.pollId}`
+    },
+    charLimit: CHAT_MAKS_LENGDE,
+  },
+  melding: {
+    tabell: 'melding_chat',
+    fkFelt: 'melding_id',
+    scopeId: s => {
+      antarType(s, 'melding')
+      return s.meldingId
+    },
+    kanalNavn: s => {
+      antarType(s, 'melding')
+      return `chat-melding-${s.meldingId}`
+    },
+    charLimit: CHAT_MAKS_LENGDE,
+  },
+  privat: {
+    tabell: 'samtale_chat',
+    fkFelt: 'samtale_id',
+    scopeId: s => {
+      antarType(s, 'privat')
+      return s.samtaleId
+    },
+    kanalNavn: s => {
+      antarType(s, 'privat')
+      return `chat-privat-${s.samtaleId}`
+    },
+    charLimit: INNLEGG_MAKS_LENGDE,
+  },
+}
+
+export function konfigFor(scope: ChatScope): ChatKonfig {
+  return CHAT_KONFIG[scope.type]
+}

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 175,
-  "versjon": "V2.175"
+  "nummer": 176,
+  "versjon": "V2.176"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 176,
-  "versjon": "V2.176"
+  "nummer": 177,
+  "versjon": "V2.177"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.176'
+const CACHE_VERSION = 'V2.177'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.175'
+const CACHE_VERSION = 'V2.176'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Lukker #100.

## Hva
Refactor av chat-arkitekturen fra «5 scopes med kopipasta» til konfig-drevet design:

- **Ny `lib/chat-konfig.ts`** — sentral CHAT_KONFIG som mapper hver scope (arrangement, klubb, poll, melding, privat) til tabell, FK-felt, kanalnavn, scope-id-extractor og charLimit. Slutt på spredte switch-statements.

- **Tre generiske server actions** i stedet for 15:
  - `sendChatMelding(scope, innhold, bilde_url)`
  - `oppdaterChatMelding(scope, id, innhold)`
  - `slettChatMelding(scope, id)`
  
  Alle slår opp tabell + FK i CHAT_KONFIG. Privat-melding-varsel og @-mention-varsler dispatches via `sendVarslerEtterPost`-helperen.

- **Chat.tsx forenklet:** fem switch-kjeder erstattet med ett `konfig` oppslag. \`hentMeldinger\`, realtime \`insertConfig\`, send/edit/delete-dispatch og \`maxLength\` bruker alle samme objekt.

- **KommentarerPaaKort.tsx** mapper sitt lokale KommentarScope til ChatScope og kaller \`sendChatMelding\` direkte.

- **samtaler.ts** beholder kun \`aapneSamtale\` + \`markerSamtaleLest\` — alt chat-relatert er flyttet inn i den unifiserte flyten.

## Tall
- 7 filer endret
- −429 linjer / +263 linjer (netto −166)
- 15 server actions → 3
- 5 switch-kjeder i Chat.tsx → 1 konfig-lookup

## Sikkerhet
RLS i Postgres er fortsatt det som faktisk håndhever tilgang per tabell/scope. Den generiske \`sendChatMelding\` legger til riktig FK-felt i insert-payloaden basert på scope-typen, og RLS validerer at brukeren har lov til å skrive til den tabellen for den scope-id-en (samme som før).

## Test
- [ ] Send i klubbchat (/chat)
- [ ] Send + slett + rediger i arrangement-chat
- [ ] Send + slett + rediger i poll-chat
- [ ] Send + slett + rediger i meldings-kommentarer
- [ ] Send + slett + rediger i privat-samtale (sjekk at varsel sendes til motpart)
- [ ] @-mention i klubbchat → varsel går
- [ ] Bilde i alle scopes
- [ ] Inline-kommentar fra agenda (KommentarerPaaKort)

## Hva som ikke er gjort (fra issue #100, "10/10"-listen)
- A. Splitt Chat.tsx i sub-komponenter
- B. Custom hooks (useChatRealtime, useChatPaginering, useDeferredBildeUpload)
- C. Tester
- D. Discriminated union strammere typing på CHAT_KONFIG
- E. Slå sammen 5 chat-tabeller til én polymorf

Disse er bevisst utelatt — for 17-mannsklubb er 9/10 sannsynligvis høyt nok. Tas opp igjen ved behov.