### PR TITLE
DB-migrasjoner: video i chat + kilde-felt på klubb_chat (#114)

### DIFF
--- a/supabase/migrations/065_chat_video.sql
+++ b/supabase/migrations/065_chat_video.sql
@@ -1,0 +1,33 @@
+-- Video i chat: legger til video_url som tredje media-type på alle fem chat-tabellene.
+-- Samme prinsipp som bilder (063): minst én av (innhold, bilde_url, video_url) må være
+-- satt — så meldinger kan være ren-tekst, ren-bilde, ren-video eller media med caption.
+
+-- arrangement_chat
+alter table arrangement_chat add column if not exists video_url text;
+alter table arrangement_chat drop constraint if exists arrangement_chat_innhold_eller_bilde;
+alter table arrangement_chat add constraint arrangement_chat_innhold_eller_media
+  check (innhold is not null or bilde_url is not null or video_url is not null);
+
+-- klubb_chat
+alter table klubb_chat add column if not exists video_url text;
+alter table klubb_chat drop constraint if exists klubb_chat_innhold_eller_bilde;
+alter table klubb_chat add constraint klubb_chat_innhold_eller_media
+  check (innhold is not null or bilde_url is not null or video_url is not null);
+
+-- poll_chat
+alter table poll_chat add column if not exists video_url text;
+alter table poll_chat drop constraint if exists poll_chat_innhold_eller_bilde;
+alter table poll_chat add constraint poll_chat_innhold_eller_media
+  check (innhold is not null or bilde_url is not null or video_url is not null);
+
+-- melding_chat (kommentarer på meldinger/innlegg)
+alter table melding_chat add column if not exists video_url text;
+alter table melding_chat drop constraint if exists melding_chat_innhold_eller_bilde;
+alter table melding_chat add constraint melding_chat_innhold_eller_media
+  check (innhold is not null or bilde_url is not null or video_url is not null);
+
+-- samtale_chat (private meldinger)
+alter table samtale_chat add column if not exists video_url text;
+alter table samtale_chat drop constraint if exists samtale_chat_innhold_eller_bilde;
+alter table samtale_chat add constraint samtale_chat_innhold_eller_media
+  check (innhold is not null or bilde_url is not null or video_url is not null);

--- a/supabase/migrations/066_klubb_chat_kilde.sql
+++ b/supabase/migrations/066_klubb_chat_kilde.sql
@@ -2,6 +2,8 @@
 -- Brukes til å skille importerte historiske meldinger fra ekte meldinger i appen
 -- (UI-en kan vise dem litt annerledes — f.eks. med en "fra Messenger"-merkelapp).
 --
+-- Speiler 062 for arrangementer-tabellen — samme idempotens-strategi for re-import.
+--
 -- kilde_ekstern_id har format `messenger:{timestamp_ms}:{idx}` og brukes for
 -- idempotent re-import: unik-indeksen sørger for at samme melding ikke kan
 -- importeres to ganger selv om import-skriptet kjøres på nytt.

--- a/supabase/migrations/066_klubb_chat_kilde.sql
+++ b/supabase/migrations/066_klubb_chat_kilde.sql
@@ -1,0 +1,22 @@
+-- Flagg for klubb_chat-meldinger importert fra Facebook/Messenger-historikk.
+-- Brukes til å skille importerte historiske meldinger fra ekte meldinger i appen
+-- (UI-en kan vise dem litt annerledes — f.eks. med en "fra Messenger"-merkelapp).
+--
+-- kilde_ekstern_id har format `messenger:{timestamp_ms}:{idx}` og brukes for
+-- idempotent re-import: unik-indeksen sørger for at samme melding ikke kan
+-- importeres to ganger selv om import-skriptet kjøres på nytt.
+alter table klubb_chat
+  add column if not exists fra_facebook boolean not null default false;
+
+alter table klubb_chat
+  add column if not exists kilde_ekstern_id text;
+
+-- Unik-indeks for idempotent re-import (kun for rader som faktisk har en ekstern id)
+create unique index if not exists klubb_chat_kilde_ekstern_id_unique
+  on klubb_chat(kilde_ekstern_id)
+  where kilde_ekstern_id is not null;
+
+-- Indeks for å filtrere/skjule FB-historikk i lister effektivt
+create index if not exists klubb_chat_fra_facebook_idx
+  on klubb_chat(fra_facebook)
+  where fra_facebook = true;

--- a/supabase/migrations/066_klubb_chat_kilde.sql
+++ b/supabase/migrations/066_klubb_chat_kilde.sql
@@ -2,11 +2,15 @@
 -- Brukes til å skille importerte historiske meldinger fra ekte meldinger i appen
 -- (UI-en kan vise dem litt annerledes — f.eks. med en "fra Messenger"-merkelapp).
 --
--- Speiler 062 for arrangementer-tabellen — samme idempotens-strategi for re-import.
+-- Speiler 062 (arrangementer-tabellen) på `fra_facebook`-flagget og partial
+-- indeksen for å filtrere FB-historikk effektivt.
 --
--- kilde_ekstern_id har format `messenger:{timestamp_ms}:{idx}` og brukes for
--- idempotent re-import: unik-indeksen sørger for at samme melding ikke kan
--- importeres to ganger selv om import-skriptet kjøres på nytt.
+-- I tillegg introduseres her `kilde_ekstern_id` + partial unique index — en
+-- idempotens-mekanisme som 062 ikke har. Klubb-chat-import kan generere
+-- mange tusen rader, og uten unik ekstern id ville re-kjøring av
+-- import-skriptet gitt duplikater. Format: `messenger:{timestamp_ms}:{idx}`.
+-- Unik-indeksen er partial (kun rader med ikke-null id), så manuelt
+-- opprettede meldinger uten ekstern id ikke berøres.
 alter table klubb_chat
   add column if not exists fra_facebook boolean not null default false;
 


### PR DESCRIPTION
## Summary
- Ny migrasjon `065_chat_video.sql` legger `video_url` på alle fem chat-tabeller og bytter `_innhold_eller_bilde`-constraint til `_innhold_eller_media` (innhold OR bilde_url OR video_url).
- Ny migrasjon `066_klubb_chat_kilde.sql` legger `fra_facebook` + `kilde_ekstern_id` på `klubb_chat` med partial unique-index for idempotent Messenger-import. Speiler 062-mønsteret.
- Ingen TS/JS endret. Type-regen + `db push` må kjøres manuelt etter merge.

Refs #114 (part of #113).

## Test plan
- [x] `npm run build` grønt (37/37 sider)
- [ ] `npx supabase db push` etter merge
- [ ] `npx supabase gen types typescript --project-id tdlfswmxezjdnxcbbiwn > lib/supabase/database.types.ts`
- [ ] Verifiser i Supabase: `\d klubb_chat` viser nye kolonner; insert med kun `video_url` godtas

🤖 Generated with [Claude Code](https://claude.com/claude-code)