### PR TITLE
Server actions for video-opplasting til R2 (#116)

### DIFF
--- a/lib/actions/video-opplasting.ts
+++ b/lib/actions/video-opplasting.ts
@@ -4,19 +4,18 @@ import { ensureInnlogget } from '@/lib/auth'
 import { lastOppR2, slettR2, r2StiFraUrl } from '@/lib/r2'
 import { videoSti, VIDEO_KATEGORIER, type VideoKategori } from '@/lib/bilde-utils'
 
-// Maksstørrelse for video. 50 MB rommer noen sekunder med høy bitrate eller
-// et halvt minutt typisk mobilopptak. Vi avviser større filer eksplisitt
-// for å unngå at urimelig store råfiler slipper gjennom.
+// Maksstørrelse for video. 50 MB er en pragmatisk grense som rommer korte
+// mobilopptak; vi avviser større filer eksplisitt for å unngå at urimelig
+// store råfiler slipper gjennom.
 const MAKS_BYTES = 50 * 1024 * 1024
 
-// Tillatte MIME-typer. mp4 er standard, quicktime (.mov) er det iPhones
-// produserer som standard. Andre formater (webm, avi, mkv) avvises.
-const TILLATTE_TYPER = ['video/mp4', 'video/quicktime']
-
-// Beltesele mot MIME-spoofing — sjekker også filendelsen i tillegg til
-// Content-Type. Klienter kan lyge om MIME, men endelsen kommer fra
-// faktisk filnavn vi selv har generert/akseptert.
-const TILLATTE_EKSTENSJONER = ['mp4', 'mov']
+// Tillatte (MIME, ekstensjon)-par. Vi krysssjekker for å hindre at en
+// klient sender f.eks. .mov-ekstensjon med video/mp4-MIME (eller motsatt).
+// mp4 er standard; quicktime (.mov) er det iPhones produserer som default.
+const TILLATTE_PAR: ReadonlyArray<{ mime: string; ext: string }> = [
+  { mime: 'video/mp4', ext: 'mp4' },
+  { mime: 'video/quicktime', ext: 'mov' },
+]
 
 function erKategori(v: unknown): v is VideoKategori {
   return typeof v === 'string' && (VIDEO_KATEGORIER as readonly string[]).includes(v)
@@ -42,9 +41,11 @@ export async function lastOppVideo(formData: FormData): Promise<{ url: string }>
     if (!(fil instanceof File)) throw new Error('Mangler fil')
     if (typeof filnavn !== 'string' || !filnavn.trim()) throw new Error('Mangler filnavn')
     if (!erKategori(kategori)) throw new Error('Ugyldig kategori')
-    if (fil.size > MAKS_BYTES) throw new Error('Filen er for stor (maks 50 MB)')
-    if (!TILLATTE_TYPER.includes(fil.type)) throw new Error('Ugyldig filtype')
-    if (!TILLATTE_EKSTENSJONER.includes(ekstensjon(filnavn))) throw new Error('Ugyldig filendelse')
+    if (fil.size > MAKS_BYTES) throw new Error(`Filen er for stor (maks ${MAKS_BYTES / 1024 / 1024} MB)`)
+    const ext = ekstensjon(filnavn)
+    if (!TILLATTE_PAR.some((p) => p.mime === fil.type && p.ext === ext)) {
+      throw new Error('Ugyldig filtype eller filendelse')
+    }
 
     const data = new Uint8Array(await fil.arrayBuffer())
     const sti = videoSti(kategori, filnavn)

--- a/lib/actions/video-opplasting.ts
+++ b/lib/actions/video-opplasting.ts
@@ -1,0 +1,70 @@
+'use server'
+
+import { ensureInnlogget } from '@/lib/auth'
+import { lastOppR2, slettR2, r2StiFraUrl } from '@/lib/r2'
+import { videoSti, VIDEO_KATEGORIER, type VideoKategori } from '@/lib/bilde-utils'
+
+// Maksstørrelse for video. 50 MB rommer noen sekunder med høy bitrate eller
+// et halvt minutt typisk mobilopptak. Vi avviser større filer eksplisitt
+// for å unngå at urimelig store råfiler slipper gjennom.
+const MAKS_BYTES = 50 * 1024 * 1024
+
+// Tillatte MIME-typer. mp4 er standard, quicktime (.mov) er det iPhones
+// produserer som standard. Andre formater (webm, avi, mkv) avvises.
+const TILLATTE_TYPER = ['video/mp4', 'video/quicktime']
+
+// Beltesele mot MIME-spoofing — sjekker også filendelsen i tillegg til
+// Content-Type. Klienter kan lyge om MIME, men endelsen kommer fra
+// faktisk filnavn vi selv har generert/akseptert.
+const TILLATTE_EKSTENSJONER = ['mp4', 'mov']
+
+function erKategori(v: unknown): v is VideoKategori {
+  return typeof v === 'string' && (VIDEO_KATEGORIER as readonly string[]).includes(v)
+}
+
+function ekstensjon(filnavn: string): string {
+  const idx = filnavn.lastIndexOf('.')
+  if (idx < 0) return ''
+  return filnavn.slice(idx + 1).toLowerCase()
+}
+
+// Last opp en video til R2 i gitt kategori. Returnerer public URL.
+// FormData skal inneholde `fil`, `filnavn` og `kategori`. Filnavn genereres
+// på klienten — server validerer kun at det finnes og har lovlig endelse.
+export async function lastOppVideo(formData: FormData): Promise<{ url: string }> {
+  try {
+    await ensureInnlogget()
+
+    const fil = formData.get('fil')
+    const filnavn = formData.get('filnavn')
+    const kategori = formData.get('kategori')
+
+    if (!(fil instanceof File)) throw new Error('Mangler fil')
+    if (typeof filnavn !== 'string' || !filnavn.trim()) throw new Error('Mangler filnavn')
+    if (!erKategori(kategori)) throw new Error('Ugyldig kategori')
+    if (fil.size > MAKS_BYTES) throw new Error('Filen er for stor (maks 50 MB)')
+    if (!TILLATTE_TYPER.includes(fil.type)) throw new Error('Ugyldig filtype')
+    if (!TILLATTE_EKSTENSJONER.includes(ekstensjon(filnavn))) throw new Error('Ugyldig filendelse')
+
+    const data = new Uint8Array(await fil.arrayBuffer())
+    const sti = videoSti(kategori, filnavn)
+    const url = await lastOppR2(sti, data, fil.type)
+
+    return { url }
+  } catch (err) {
+    console.error('[video-opplasting] feil:', err)
+    const melding = err instanceof Error ? err.message : 'Ukjent feil ved opplasting'
+    throw new Error(`Opplasting feilet: ${melding}`)
+  }
+}
+
+// Slett en R2-video basert på public URL.
+// Idempotent — feiler ikke hvis URL-en ikke peker til vår R2 eller filen
+// allerede er borte. Eldre Supabase-URL-er passerer uberørt.
+export async function slettVideo(url: string | null): Promise<void> {
+  if (!url) return
+  await ensureInnlogget()
+  const sti = r2StiFraUrl(url)
+  if (!sti) return // ikke en R2-URL, hopp over
+  await slettR2(sti)
+}

--- a/lib/actions/video-opplasting.ts
+++ b/lib/actions/video-opplasting.ts
@@ -47,9 +47,10 @@ export async function lastOppVideo(formData: FormData): Promise<{ url: string }>
       throw new Error('Ugyldig filtype eller filendelse')
     }
 
-    const data = new Uint8Array(await fil.arrayBuffer())
+    // Send Blob direkte til R2 — sparer en ekstra kopi i minnet (50 MB ×).
+    // lastOppR2 leser size fra Blob og setter Content-Length korrekt.
     const sti = videoSti(kategori, filnavn)
-    const url = await lastOppR2(sti, data, fil.type)
+    const url = await lastOppR2(sti, fil, fil.type)
 
     return { url }
   } catch (err) {

--- a/lib/bilde-utils.ts
+++ b/lib/bilde-utils.ts
@@ -30,6 +30,16 @@ export function bildeSti(kategori: BildeKategori, filnavn: string): string {
   return `${kategori}/${filnavn}`
 }
 
+// Videokategorier i R2 — egen topp-mappe `video/` slik at video og bilder
+// holdes adskilt i bucket-en. Foreløpig kun chat og album; legg til ny
+// kategori her når en ny upload-sti tas i bruk.
+export const VIDEO_KATEGORIER = ['chat', 'album'] as const
+export type VideoKategori = (typeof VIDEO_KATEGORIER)[number]
+
+export function videoSti(kategori: VideoKategori, filnavn: string): string {
+  return `video/${kategori}/${filnavn}`
+}
+
 // Felles helper: skalerer et bilde til maks `maks` på lang side, returnerer
 // JPEG-Blob med gitt kvalitet. Bruk i komprimer() og lagThumbnail().
 function skalerOgEksporter(

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 184,
-  "versjon": "V2.184"
+  "nummer": 185,
+  "versjon": "V2.185"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 185,
-  "versjon": "V2.185"
+  "nummer": 186,
+  "versjon": "V2.186"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 186,
-  "versjon": "V2.186"
+  "nummer": 187,
+  "versjon": "V2.187"
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -19,6 +19,8 @@ const nextConfig: NextConfig = {
   // Server actions sin default body-grense på 1 MB er for liten for
   // video-opplasting. Vi gir 52 MB — litt slack over MAKS_BYTES (50 MB)
   // i video-opplasting.ts slik at multipart-overhead ikke spiser av grensa.
+  // NB: I Next 15.5.x ligger `serverActions` fortsatt under `experimental`
+  // i config-schemaet. Top-level-plassering gir warning «Unrecognized key».
   experimental: {
     serverActions: {
       bodySizeLimit: '52mb',

--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,14 @@ const nextConfig: NextConfig = {
     BUILD_TIMESTAMP: new Date().toLocaleString('nb-NO', { timeZone: 'Europe/Oslo', day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' }),
     APP_VERSION: appVersjon(),
   },
+  // Server actions sin default body-grense på 1 MB er for liten for
+  // video-opplasting. Vi gir 52 MB — litt slack over MAKS_BYTES (50 MB)
+  // i video-opplasting.ts slik at multipart-overhead ikke spiser av grensa.
+  experimental: {
+    serverActions: {
+      bodySizeLimit: '52mb',
+    },
+  },
   images: {
     remotePatterns: [
       {

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.184'
+const CACHE_VERSION = 'V2.185'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.185'
+const CACHE_VERSION = 'V2.187'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
## Summary
- `lib/actions/video-opplasting.ts` (ny) — `lastOppVideo` og `slettVideo` som speiler `bilde-opplasting.ts`. Cap 50 MB, MIME `video/mp4` + `video/quicktime`, ekstensjon `.mp4`/`.mov`.
- **MIME↔ekstensjon krysssjekkes** som par — hindrer at `.mov` med `video/mp4`-MIME passerer.
- `lib/bilde-utils.ts` utvidet med `VIDEO_KATEGORIER = ['chat', 'album']` og `videoSti()` som lager `video/{kategori}/{filnavn}` (eget rot-prefiks i bucket).
- `next.config.ts` — `experimental.serverActions.bodySizeLimit: '52mb'` (med kommentar som dokumenterer hvorfor under `experimental` for Next 15.5).

Refs #116 (part of #113). Brukes av appens UI fremover; selve Messenger-importen (#118) går utenom og laster direkte til R2 server-side.

## Beslutninger underveis
**Intern review fanget (rettet):**
- MIME og ekstensjon ble validert uavhengig — angriper kunne sende `.mov` med `video/mp4`-MIME. Endret til paret krysssjekk.
- `(maks 50 MB)` var hardkodet i feilmelding — endret til dynamisk `${MAKS_BYTES / 1024 / 1024}` for konsistens med bilde-actionen.

**Intern review foreslo, vi forsvarte:**
- `serverActions` flyttet til top-level i Next 15: bekreftet feil for vår 15.5-versjon — schema-en har det fortsatt under `experimental`. Build-warning bekrefter at konfigen blir lest.
- `VIDEO_KATEGORIER` overlapper med `BILDE_KATEGORIER`-navn: path-prefiks `video/` skiller dem i bucket; ingen reell kollisjon.
- Filnavn `bilde-utils.ts` matcher ikke fullt innhold lenger: gyldig observasjon, men utenfor scope. Vurder rename til `medie-utils.ts` hvis flere video-helpere kommer.

**Copilot fanget (rettet i runde 2):**
- Versjonsstamp ut av sync mellom `lib/versjon.json` og `public/sw.js` — bumpet til V2.187 i begge.
- Unødvendig minne-kopi: `arrayBuffer()` → `Uint8Array` byttet til å sende `Blob` direkte til `lastOppR2`. Sparer 50 MB ekstra i RAM per opplasting.

## Test plan
- [x] `npm run build` grønt (warning kun den forventede `serverActions experimental`-notisen)
- [ ] Manuell verifisering kommer i #117 når UI-koden faktisk kaller actionen

🤖 Generated with [Claude Code](https://claude.com/claude-code)