### PR TITLE
Chat: video-rendering + Messenger-badge (#117)

### DIFF
--- a/app/(app)/arrangementer/[id]/page.tsx
+++ b/app/(app)/arrangementer/[id]/page.tsx
@@ -66,7 +66,7 @@ export default async function ArrangementDetaljer({
       .single(),
     supabase
       .from('arrangement_chat')
-      .select('id, profil_id, innhold, bilde_url, opprettet')
+      .select('id, profil_id, innhold, bilde_url, video_url, opprettet')
       .eq('arrangement_id', id)
       .order('opprettet', { ascending: false })
       .limit(30),

--- a/app/(app)/chat/page.tsx
+++ b/app/(app)/chat/page.tsx
@@ -18,7 +18,7 @@ export default async function KlubbChatSide() {
   const [{ data: siste }, { data: profiler }, { count: ulestPrivat }] = await Promise.all([
     supabase
       .from('klubb_chat')
-      .select('id, profil_id, innhold, bilde_url, opprettet')
+      .select('id, profil_id, innhold, bilde_url, video_url, opprettet, fra_facebook')
       .order('opprettet', { ascending: false })
       .limit(30),
     supabase.from('profiles').select('id, navn, bilde_url, rolle').eq('aktiv', true),

--- a/app/(app)/meldinger/[id]/page.tsx
+++ b/app/(app)/meldinger/[id]/page.tsx
@@ -59,7 +59,7 @@ export default async function MeldingDetalj({
       .eq('melding_id', id),
     supabase
       .from('melding_chat')
-      .select('id, profil_id, innhold, bilde_url, opprettet')
+      .select('id, profil_id, innhold, bilde_url, video_url, opprettet')
       .eq('melding_id', id)
       .order('opprettet', { ascending: false })
       .limit(30),

--- a/app/(app)/poll/[id]/page.tsx
+++ b/app/(app)/poll/[id]/page.tsx
@@ -45,7 +45,7 @@ export default async function PollDetalj({
       .single<PollRad>(),
     supabase
       .from('poll_chat')
-      .select('id, profil_id, innhold, bilde_url, opprettet')
+      .select('id, profil_id, innhold, bilde_url, video_url, opprettet')
       .eq('poll_id', id)
       .order('opprettet', { ascending: false })
       .limit(30),

--- a/app/(app)/samtaler/[id]/page.tsx
+++ b/app/(app)/samtaler/[id]/page.tsx
@@ -46,7 +46,7 @@ export default async function SamtaleDetalj({
       .single(),
     supabase
       .from('samtale_chat')
-      .select('id, profil_id, innhold, bilde_url, opprettet')
+      .select('id, profil_id, innhold, bilde_url, video_url, opprettet')
       .eq('samtale_id', id)
       .order('opprettet', { ascending: false })
       .limit(30),

--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -15,6 +15,7 @@ import Avatar from '@/components/ui/Avatar'
 import Icon from '@/components/ui/Icon'
 import SectionLabel from '@/components/ui/SectionLabel'
 import BildeLightbox from '@/components/ui/BildeLightbox'
+import MessengerBadge from '@/components/ui/MessengerBadge'
 import { komprimer, genererFilnavn } from '@/lib/bilde-utils'
 import { lastOppBilde, slettBilde } from '@/lib/actions/bilde-opplasting'
 
@@ -27,7 +28,12 @@ export type ChatMelding = {
   profil_id: string
   innhold: string | null
   bilde_url: string | null
+  video_url: string | null
   opprettet: string
+  // fra_facebook finnes kun på klubb_chat-tabellen — markerer meldinger
+  // som er importert fra Messenger. Valgfritt så typen kan brukes i alle
+  // chat-scopes uten å late som om feltet eksisterer overalt.
+  fra_facebook?: boolean
 }
 
 export type ChatProfil = {
@@ -140,7 +146,7 @@ export default function Chat({
     async (forTidspunkt?: string): Promise<ChatMelding[]> => {
       let q = supabase
         .from(konfig.tabell)
-        .select('id, profil_id, innhold, bilde_url, opprettet')
+        .select('id, profil_id, innhold, bilde_url, video_url, opprettet')
         .order('opprettet', { ascending: false })
         .limit(SIDE_STORRELSE)
       const fkVerdi = konfig.scopeId(scope)
@@ -516,7 +522,9 @@ export default function Chat({
       profil_id: brukerId,
       innhold: melding,
       bilde_url: bildePreview, // viser blob-URL midlertidig
+      video_url: null,
       opprettet: new Date().toISOString(),
+      fra_facebook: false,
     }
     setMeldinger(prev => [...prev, optimistisk])
 
@@ -950,9 +958,26 @@ export default function Chat({
                         />
                       </button>
                     )}
+                    {m.video_url && (
+                      <video
+                        src={m.video_url}
+                        controls
+                        preload="metadata"
+                        playsInline
+                        style={{
+                          display: 'block',
+                          maxWidth: '100%',
+                          height: 'auto',
+                          maxHeight: 280,
+                          borderRadius: 8,
+                          marginBottom: m.innhold ? 8 : 0,
+                        }}
+                      />
+                    )}
                     {m.innhold && renderMedMentions(m.innhold)}
                   </div>
                   )}
+                  {m.fra_facebook && <MessengerBadge erEgen={erEgen} />}
                   {/* Reaksjons-chips — flyter på bunnkanten av bobla, ikke
                       egen linje. Negativ margin trekker dem opp slik at de
                       overlapper bobla, padding holder dem litt inn fra

--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -144,9 +144,18 @@ export default function Chat({
   // spesifikke grener her.
   const hentMeldinger = useCallback(
     async (forTidspunkt?: string): Promise<ChatMelding[]> => {
+      // klubb_chat har i tillegg `fra_facebook` for å vise Messenger-badge på
+      // historisk-importerte meldinger. Andre chat-tabeller har ikke kolonnen.
+      // UPDATE-handleren (under) tar bevisst kun innhold, så endring av
+      // fra_facebook på en eksisterende rad slår ikke gjennom i UI — i
+      // praksis er flagget skrivebeskyttet etter import.
+      const select =
+        tabell === 'klubb_chat'
+          ? 'id, profil_id, innhold, bilde_url, video_url, opprettet, fra_facebook'
+          : 'id, profil_id, innhold, bilde_url, video_url, opprettet'
       let q = supabase
         .from(konfig.tabell)
-        .select('id, profil_id, innhold, bilde_url, video_url, opprettet')
+        .select(select)
         .order('opprettet', { ascending: false })
         .limit(SIDE_STORRELSE)
       const fkVerdi = konfig.scopeId(scope)
@@ -155,7 +164,7 @@ export default function Chat({
       }
       if (forTidspunkt) q = q.lt('opprettet', forTidspunkt)
       const { data } = await q
-      return data ? [...data].reverse() : []
+      return data ? ([...data].reverse() as unknown as ChatMelding[]) : []
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
@@ -966,7 +975,7 @@ export default function Chat({
                         playsInline
                         style={{
                           display: 'block',
-                          maxWidth: '100%',
+                          maxWidth: 280,
                           height: 'auto',
                           maxHeight: 280,
                           borderRadius: 8,

--- a/components/ui/MessengerBadge.tsx
+++ b/components/ui/MessengerBadge.tsx
@@ -1,0 +1,52 @@
+// Liten visuell markør på chat-bobler som er importert fra Messenger.
+// Bevisst ikke Meta sin offisielle Messenger-logo (varemerke-beskyttet) —
+// vi tegner en stilisert chat-boble med et lyn inni for å antyde
+// «kommer fra et annet sted, men er en melding». Plasseres absolutt i
+// hjørnet av bobla via wrapper-divens position: relative (.chat-boble).
+
+type Props = {
+  erEgen: boolean
+}
+
+export default function MessengerBadge({ erEgen }: Props) {
+  return (
+    <div
+      title="Importert fra Messenger"
+      aria-label="Importert fra Messenger"
+      style={{
+        position: 'absolute',
+        bottom: -4,
+        [erEgen ? 'right' : 'left']: -4,
+        width: 16,
+        height: 16,
+        borderRadius: '50%',
+        background: 'var(--bg-elevated)',
+        border: '0.5px solid var(--border)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        pointerEvents: 'none',
+        opacity: 0.6,
+        zIndex: 2,
+      }}
+    >
+      <svg
+        width="10"
+        height="10"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        style={{ color: 'var(--text-secondary)' }}
+        aria-hidden="true"
+      >
+        {/* Stilisert chat-boble */}
+        <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />
+        {/* Lyn inni */}
+        <polyline points="13 8 9 13 12 13 11 16" />
+      </svg>
+    </div>
+  )
+}

--- a/components/ui/MessengerBadge.tsx
+++ b/components/ui/MessengerBadge.tsx
@@ -3,6 +3,10 @@
 // vi tegner en stilisert chat-boble med et lyn inni for å antyde
 // «kommer fra et annet sted, men er en melding». Plasseres absolutt i
 // hjørnet av bobla via wrapper-divens position: relative (.chat-boble).
+// Plassering: top-corner motsatt slett-knappen (slett er top: -6, samme
+// side som boblas «egen-side»). Badgen havner derfor i motsatt
+// top-hjørne, så den ikke overlapper hverken slett-knapp eller
+// reaksjons-chips som ligger nederst.
 
 type Props = {
   erEgen: boolean
@@ -15,8 +19,8 @@ export default function MessengerBadge({ erEgen }: Props) {
       aria-label="Importert fra Messenger"
       style={{
         position: 'absolute',
-        bottom: -4,
-        [erEgen ? 'right' : 'left']: -4,
+        top: -6,
+        [erEgen ? 'right' : 'left']: -6,
         width: 16,
         height: 16,
         borderRadius: '50%',
@@ -25,7 +29,6 @@ export default function MessengerBadge({ erEgen }: Props) {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        pointerEvents: 'none',
         opacity: 0.6,
         zIndex: 2,
       }}

--- a/components/ui/MessengerBadge.tsx
+++ b/components/ui/MessengerBadge.tsx
@@ -15,6 +15,7 @@ type Props = {
 export default function MessengerBadge({ erEgen }: Props) {
   return (
     <div
+      role="img"
       title="Importert fra Messenger"
       aria-label="Importert fra Messenger"
       style={{

--- a/lib/actions/chat.ts
+++ b/lib/actions/chat.ts
@@ -14,11 +14,10 @@ function validerInnhold(
   innhold: string | null,
   bildeUrl: string | null,
   charLimit: number,
-  videoUrl: string | null = null,
 ): { tekst: string | null } {
   const tekst = innhold?.trim() || null
-  if (!tekst && !bildeUrl && !videoUrl) {
-    throw new Error('Meldingen må ha tekst, bilde eller video')
+  if (!tekst && !bildeUrl) {
+    throw new Error('Meldingen må ha tekst eller bilde')
   }
   // Privat har egen min via INNLEGG_MIN_LENGDE; for chat er CHAT_MIN_LENGDE
   // det riktige. Begge er 1, så vi velger basert på charLimit-størrelsen.
@@ -37,16 +36,12 @@ async function sendVarslerEtterPost(
   tekst: string | null,
   avsenderId: string,
   bildeUrl: string | null = null,
-  videoUrl: string | null = null,
 ): Promise<void> {
   if (scope.type === 'privat') {
+    // Defensiv — validerInnhold skal ha kastet før vi når denne grenen uten
+    // tekst eller bilde, men vi beholder fallback for trygghet.
     const varselTekst =
-      tekst ??
-      (videoUrl
-        ? '🎬 Sendte deg en video'
-        : bildeUrl
-          ? '📷 Sendte deg et bilde'
-          : 'Sendte deg en melding')
+      tekst ?? (bildeUrl ? '📷 Sendte deg et bilde' : 'Sendte deg en melding')
     await sendPrivatMeldingVarsel(scope.samtaleId, varselTekst, avsenderId)
     return
   }
@@ -112,10 +107,9 @@ export async function sendChatMelding(
   scope: ChatScope,
   innhold: string | null,
   bildeUrl: string | null = null,
-  videoUrl: string | null = null,
 ): Promise<void> {
   const k = konfigFor(scope)
-  const { tekst } = validerInnhold(innhold, bildeUrl, k.charLimit, videoUrl)
+  const { tekst } = validerInnhold(innhold, bildeUrl, k.charLimit)
 
   const supabase = await createServerClient()
   const { data: { user } } = await supabase.auth.getUser()
@@ -129,12 +123,11 @@ export async function sendChatMelding(
       profil_id: user.id,
       innhold: tekst,
       bilde_url: bildeUrl,
-      video_url: videoUrl,
     })
   if (error) throw new Error(error.message)
 
   try {
-    await sendVarslerEtterPost(scope, tekst, user.id, bildeUrl, videoUrl)
+    await sendVarslerEtterPost(scope, tekst, user.id, bildeUrl)
   } catch (err) {
     // Varsel-svikt skal ikke feile selve meldingen — den er allerede skrevet
     // til DB. Logg og gå videre.
@@ -153,7 +146,7 @@ export async function oppdaterChatMelding(
   // Eksplisitt sjekk for tom/whitespace etter trim siden validerInnhold med
   // bildeUrl='placeholder' ellers ville la null-tekst slippe gjennom og
   // nulle ut innhold-kolonnen i DB.
-  const { tekst } = validerInnhold(innhold, 'placeholder', k.charLimit, null)
+  const { tekst } = validerInnhold(innhold, 'placeholder', k.charLimit)
   if (!tekst) {
     const minLengde = k.charLimit > 500 ? INNLEGG_MIN_LENGDE : CHAT_MIN_LENGDE
     throw new Error(`Meldingen må være ${minLengde}–${k.charLimit} tegn`)

--- a/lib/actions/chat.ts
+++ b/lib/actions/chat.ts
@@ -14,10 +14,11 @@ function validerInnhold(
   innhold: string | null,
   bildeUrl: string | null,
   charLimit: number,
+  videoUrl: string | null = null,
 ): { tekst: string | null } {
   const tekst = innhold?.trim() || null
-  if (!tekst && !bildeUrl) {
-    throw new Error('Meldingen må ha tekst eller bilde')
+  if (!tekst && !bildeUrl && !videoUrl) {
+    throw new Error('Meldingen må ha tekst, bilde eller video')
   }
   // Privat har egen min via INNLEGG_MIN_LENGDE; for chat er CHAT_MIN_LENGDE
   // det riktige. Begge er 1, så vi velger basert på charLimit-størrelsen.
@@ -35,9 +36,17 @@ async function sendVarslerEtterPost(
   scope: ChatScope,
   tekst: string | null,
   avsenderId: string,
+  bildeUrl: string | null = null,
+  videoUrl: string | null = null,
 ): Promise<void> {
   if (scope.type === 'privat') {
-    const varselTekst = tekst ?? '📷 Sendte deg et bilde'
+    const varselTekst =
+      tekst ??
+      (videoUrl
+        ? '🎬 Sendte deg en video'
+        : bildeUrl
+          ? '📷 Sendte deg et bilde'
+          : 'Sendte deg en melding')
     await sendPrivatMeldingVarsel(scope.samtaleId, varselTekst, avsenderId)
     return
   }
@@ -103,9 +112,10 @@ export async function sendChatMelding(
   scope: ChatScope,
   innhold: string | null,
   bildeUrl: string | null = null,
+  videoUrl: string | null = null,
 ): Promise<void> {
   const k = konfigFor(scope)
-  const { tekst } = validerInnhold(innhold, bildeUrl, k.charLimit)
+  const { tekst } = validerInnhold(innhold, bildeUrl, k.charLimit, videoUrl)
 
   const supabase = await createServerClient()
   const { data: { user } } = await supabase.auth.getUser()
@@ -114,11 +124,17 @@ export async function sendChatMelding(
   const fkData = k.fkFelt ? { [k.fkFelt]: k.scopeId(scope) } : {}
   const { error } = await supabase
     .from(k.tabell)
-    .insert({ ...fkData, profil_id: user.id, innhold: tekst, bilde_url: bildeUrl })
+    .insert({
+      ...fkData,
+      profil_id: user.id,
+      innhold: tekst,
+      bilde_url: bildeUrl,
+      video_url: videoUrl,
+    })
   if (error) throw new Error(error.message)
 
   try {
-    await sendVarslerEtterPost(scope, tekst, user.id)
+    await sendVarslerEtterPost(scope, tekst, user.id, bildeUrl, videoUrl)
   } catch (err) {
     // Varsel-svikt skal ikke feile selve meldingen — den er allerede skrevet
     // til DB. Logg og gå videre.
@@ -137,7 +153,7 @@ export async function oppdaterChatMelding(
   // Eksplisitt sjekk for tom/whitespace etter trim siden validerInnhold med
   // bildeUrl='placeholder' ellers ville la null-tekst slippe gjennom og
   // nulle ut innhold-kolonnen i DB.
-  const { tekst } = validerInnhold(innhold, 'placeholder', k.charLimit)
+  const { tekst } = validerInnhold(innhold, 'placeholder', k.charLimit, null)
   if (!tekst) {
     const minLengde = k.charLimit > 500 ? INNLEGG_MIN_LENGDE : CHAT_MIN_LENGDE
     throw new Error(`Meldingen må være ${minLengde}–${k.charLimit} tegn`)

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 191,
-  "versjon": "V2.191"
+  "nummer": 192,
+  "versjon": "V2.192"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 190,
-  "versjon": "V2.190"
+  "nummer": 191,
+  "versjon": "V2.191"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 189,
-  "versjon": "V2.189"
+  "nummer": 190,
+  "versjon": "V2.190"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.190'
+const CACHE_VERSION = 'V2.191'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.191'
+const CACHE_VERSION = 'V2.192'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.189'
+const CACHE_VERSION = 'V2.190'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
## Summary
- `components/chat/Chat.tsx` — `ChatMelding` utvidet med `video_url` og valgfri `fra_facebook`. Render `<video controls preload="metadata" playsInline>` parallelt til bilde. Render `<MessengerBadge>` i hjørnet av bobla når `m.fra_facebook`.
- `components/ui/MessengerBadge.tsx` (ny) — stilisert chat-boble + lyn (ikke Meta-logoen). Plassert top-corner motsatt slett-knappen, opacity 0.6, tooltip "Importert fra Messenger".
- 5 sidefiler — chat-select utvidet med `video_url`. `fra_facebook` kun i `app/(app)/chat/page.tsx` siden feltet kun finnes på `klubb_chat`.

Refs #117 (part of #113). Klargjør UI for #119-importen — uten dette ville videoer være usynlige etter import.

## Beslutninger underveis

**Intern review fanget (rettet):**
- `videoUrl`-parameter i `sendChatMelding`/`validerInnhold`/`sendVarslerEtterPost` ble lagt til i første runde, men det er ingen UI som trigger den. Rullet tilbake — scope er rendering, ikke opplasting. Server actions for video-opplasting (#116) er klare; UI-koblingen kommer i et eget issue når aktuelt.
- Badge-plassering var bottom-corner og kunne overlappe reaksjons-chips. Flyttet til top-corner motsatt slett-knappen.
- `pointer-events: none` på badge skjulte tooltip. Fjernet etter flytting (kolliderer ikke lenger med klikkbare elementer).

**Forsvart (ikke endret):**
- Defensiv fallback-tekst i `varselTekst`-kjede beholdt med kommentar — `validerInnhold` skal ha kastet før vi når grenen, men trygt å beholde.
- `fra_facebook` som valgfri på typen er allerede dokumentert med eksisterende kommentar.
- Magic number 280px for video-maks-høyde — konsistens med bilde > konstant-utvinning.

## Test plan
- [x] `npm run build` grønt
- [ ] Visuell verifisering på Vercel preview: SQL-update setter `fra_facebook = true` på en eksisterende klubb_chat-melding → badge dukker opp
- [ ] SQL-update setter `video_url` på en testmelding → video-spiller rendres med inline play
- [ ] iOS Safari: video åpnes ikke i fullskjerm-modal (verifiserer `playsInline`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)