### PR TITLE
Rydd hardkodet DB-passord fra scripts/ (#122)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,4 +241,4 @@ Alle profil-avatarer (medlemsansikter) skal rendres via `components/ui/Avatar.ts
 
 **Når du legger til nye steder som viser profilbilder:** Bruk `<Avatar name={...} src={bilde_url} rolle={rolle} />`. Gul glød for generalsekretær faller da inn av seg selv — sjekker for dette skal ikke duplikeres utenfor komponenten.
 
-Supabase: Herreklubbens org, Herreklubbens webapp. Database-passordet ligger i `.env.local` som `SUPABASE_DB_PASSWORD` (hent fra Supabase Dashboard → Project Settings → Database hvis det må roteres). Skript som trenger direkte Postgres-tilgang kjøres med `node --env-file=.env.local scripts/<navn>.mjs`.
+Supabase: Herreklubbens org, Herreklubbens webapp. Database-passordet ligger i `.env.local` som `SUPABASE_DB_PASSWORD`. Hent fra Supabase Dashboard → Project Settings → Database. Skript som trenger direkte Postgres-tilgang kjøres med `node --env-file=.env.local scripts/<navn>.mjs`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,4 +241,4 @@ Alle profil-avatarer (medlemsansikter) skal rendres via `components/ui/Avatar.ts
 
 **Når du legger til nye steder som viser profilbilder:** Bruk `<Avatar name={...} src={bilde_url} rolle={rolle} />`. Gul glød for generalsekretær faller da inn av seg selv — sjekker for dette skal ikke duplikeres utenfor komponenten.
 
-Supabase: Herreklubbens org, Herreklubbens webapp, Database passord: d2F3j$G!-@j!i94
+Supabase: Herreklubbens org, Herreklubbens webapp. Database-passordet ligger i `.env.local` som `SUPABASE_DB_PASSWORD` (hent fra Supabase Dashboard → Project Settings → Database hvis det må roteres). Skript som trenger direkte Postgres-tilgang kjøres med `node --env-file=.env.local scripts/<navn>.mjs`.

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 200,
-  "versjon": "V2.200"
+  "nummer": 201,
+  "versjon": "V2.201"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 199,
-  "versjon": "V2.199"
+  "nummer": 200,
+  "versjon": "V2.200"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.200'
+const CACHE_VERSION = 'V2.201'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.199'
+const CACHE_VERSION = 'V2.200'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/scripts/fb-fix.mjs
+++ b/scripts/fb-fix.mjs
@@ -1,8 +1,13 @@
 // Slett FB-duplikater og fiks navn-mapping
 import pg from 'pg'
 
-const PROJECT_REF = 'tdlfswmxezjdnxcbbiwn'
-const DB_PASSWORD = 'd2F3j$G!-@j!i94'
+const PROJECT_REF = process.env.SUPABASE_PROJECT_REF ?? 'tdlfswmxezjdnxcbbiwn'
+const DB_PASSWORD = process.env.SUPABASE_DB_PASSWORD
+
+if (!DB_PASSWORD) {
+  console.error('Mangler SUPABASE_DB_PASSWORD. Kjør med `node --env-file=.env.local ...`')
+  process.exit(1)
+}
 
 const client = new pg.Client({
   host: `db.${PROJECT_REF}.supabase.co`,

--- a/scripts/fb-kjor.mjs
+++ b/scripts/fb-kjor.mjs
@@ -9,8 +9,14 @@ import pg from 'pg'
 import { readFile, readdir } from 'node:fs/promises'
 import { AwsClient } from 'aws4fetch'
 
-const PROJECT_REF = 'tdlfswmxezjdnxcbbiwn'
-const DB_PASSWORD = 'd2F3j$G!-@j!i94'
+const PROJECT_REF = process.env.SUPABASE_PROJECT_REF ?? 'tdlfswmxezjdnxcbbiwn'
+const DB_PASSWORD = process.env.SUPABASE_DB_PASSWORD
+
+if (!DB_PASSWORD) {
+  console.error('Mangler SUPABASE_DB_PASSWORD. Kjør med `node --env-file=.env.local ...`')
+  process.exit(1)
+}
+
 // Direkte tilkobling til Supabase Postgres (ikke pooler)
 const DB_HOST = `db.${PROJECT_REF}.supabase.co`
 

--- a/scripts/fb-reimport.mjs
+++ b/scripts/fb-reimport.mjs
@@ -5,8 +5,14 @@ import pg from 'pg'
 import { readFile } from 'node:fs/promises'
 import { fromZonedTime } from 'date-fns-tz'
 
-const PROJECT_REF = 'tdlfswmxezjdnxcbbiwn'
-const DB_PASSWORD = 'd2F3j$G!-@j!i94'
+const PROJECT_REF = process.env.SUPABASE_PROJECT_REF ?? 'tdlfswmxezjdnxcbbiwn'
+const DB_PASSWORD = process.env.SUPABASE_DB_PASSWORD
+
+if (!DB_PASSWORD) {
+  console.error('Mangler SUPABASE_DB_PASSWORD. Kjør med `node --env-file=.env.local ...`')
+  process.exit(1)
+}
+
 const R2_PUBLIC_URL = 'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev'
 
 // FB-navn → DB-navn (fra profiles-tabellen). Trailing space er bevisst der

--- a/scripts/foreslaa-messenger-mapping.mjs
+++ b/scripts/foreslaa-messenger-mapping.mjs
@@ -27,7 +27,7 @@ const DB_PASSWORD = process.env.SUPABASE_DB_PASSWORD
 const DB_HOST = `db.${PROJECT_REF}.supabase.co`
 
 if (!DB_PASSWORD) {
-  console.error('Mangler SUPABASE_DB_PASSWORD. Kjør med `node --env-file=.env.local …`')
+  console.error('Mangler SUPABASE_DB_PASSWORD. Kjør med `node --env-file=.env.local ...`')
   process.exit(1)
 }
 

--- a/scripts/foreslaa-messenger-mapping.mjs
+++ b/scripts/foreslaa-messenger-mapping.mjs
@@ -22,9 +22,14 @@
 import pg from 'pg'
 import { readFile, writeFile } from 'node:fs/promises'
 
-const PROJECT_REF = 'tdlfswmxezjdnxcbbiwn'
-const DB_PASSWORD = 'd2F3j$G!-@j!i94'
+const PROJECT_REF = process.env.SUPABASE_PROJECT_REF ?? 'tdlfswmxezjdnxcbbiwn'
+const DB_PASSWORD = process.env.SUPABASE_DB_PASSWORD
 const DB_HOST = `db.${PROJECT_REF}.supabase.co`
+
+if (!DB_PASSWORD) {
+  console.error('Mangler SUPABASE_DB_PASSWORD. Kjør med `node --env-file=.env.local …`')
+  process.exit(1)
+}
 
 const KILDE = 'scripts/data/herreklubben_chat.json'
 const UTFIL = 'scripts/data/messenger-mapping.json'

--- a/scripts/import-album.mjs
+++ b/scripts/import-album.mjs
@@ -22,8 +22,8 @@ if (!bilderMappe || !arrangementId || !albumTittel) {
   process.exit(1)
 }
 
-const PROJECT_REF = 'tdlfswmxezjdnxcbbiwn'
-const DB_PASSWORD = 'd2F3j$G!-@j!i94'
+const PROJECT_REF = process.env.SUPABASE_PROJECT_REF ?? 'tdlfswmxezjdnxcbbiwn'
+const DB_PASSWORD = process.env.SUPABASE_DB_PASSWORD
 
 const R2_ACCOUNT_ID = process.env.R2_ACCOUNT_ID
 const R2_ACCESS_KEY_ID = process.env.R2_ACCESS_KEY_ID
@@ -34,6 +34,11 @@ const R2_JURISDICTION = (process.env.R2_JURISDICTION ?? 'default').toLowerCase()
 
 if (!R2_ACCOUNT_ID || !R2_ACCESS_KEY_ID || !R2_SECRET_ACCESS_KEY || !R2_PUBLIC_URL) {
   console.error('Mangler R2-env. Kjør `vercel env pull .env.local` først.')
+  process.exit(1)
+}
+
+if (!DB_PASSWORD) {
+  console.error('Mangler SUPABASE_DB_PASSWORD. Kjør med `node --env-file=.env.local …`')
   process.exit(1)
 }
 

--- a/scripts/import-album.mjs
+++ b/scripts/import-album.mjs
@@ -38,7 +38,7 @@ if (!R2_ACCOUNT_ID || !R2_ACCESS_KEY_ID || !R2_SECRET_ACCESS_KEY || !R2_PUBLIC_U
 }
 
 if (!DB_PASSWORD) {
-  console.error('Mangler SUPABASE_DB_PASSWORD. Kjør med `node --env-file=.env.local …`')
+  console.error('Mangler SUPABASE_DB_PASSWORD. Kjør med `node --env-file=.env.local ...`')
   process.exit(1)
 }
 

--- a/scripts/import-messenger-klubbchat.mjs
+++ b/scripts/import-messenger-klubbchat.mjs
@@ -45,7 +45,7 @@ const DB_PASSWORD = process.env.SUPABASE_DB_PASSWORD
 const DB_HOST = `db.${PROJECT_REF}.supabase.co`
 
 if (!DB_PASSWORD) {
-  console.error('Mangler SUPABASE_DB_PASSWORD. Kjør med `node --env-file=.env.local …`')
+  console.error('Mangler SUPABASE_DB_PASSWORD. Kjør med `node --env-file=.env.local ...`')
   process.exit(1)
 }
 

--- a/scripts/import-messenger-klubbchat.mjs
+++ b/scripts/import-messenger-klubbchat.mjs
@@ -40,9 +40,14 @@ import { AwsClient } from 'aws4fetch'
 // Konfig
 // ───────────────────────────────────────────────────────────────────────
 
-const PROJECT_REF = 'tdlfswmxezjdnxcbbiwn'
-const DB_PASSWORD = 'd2F3j$G!-@j!i94'
+const PROJECT_REF = process.env.SUPABASE_PROJECT_REF ?? 'tdlfswmxezjdnxcbbiwn'
+const DB_PASSWORD = process.env.SUPABASE_DB_PASSWORD
 const DB_HOST = `db.${PROJECT_REF}.supabase.co`
+
+if (!DB_PASSWORD) {
+  console.error('Mangler SUPABASE_DB_PASSWORD. Kjør med `node --env-file=.env.local …`')
+  process.exit(1)
+}
 
 const DRY_RUN = process.env.DRY_RUN === '1'
 const DEFAULT_KILDE_DIR = 'scripts/data'


### PR DESCRIPTION
## Summary
- Seks .mjs-skript i `scripts/` leser nå `SUPABASE_DB_PASSWORD` fra env, med fail-fast-melding hvis den mangler. Project-ref har env-overstyring med fallback (ikke en hemmelighet).
- `CLAUDE.md` peker nå til `.env.local` i stedet for å dokumentere passordet i klartekst.
- Skript som er endret: `fb-fix.mjs`, `fb-kjor.mjs`, `fb-reimport.mjs`, `foreslaa-messenger-mapping.mjs`, `import-album.mjs`, `import-messenger-klubbchat.mjs`.

Lukker #122.

## Beslutninger underveis

**Avvik fra issue:** Issuet nevnte 4 filer; planleggeren rapporterte 3, men det er faktisk 6 — fanget i runde 2 av integrator.

**Intern review fanget (rettet):**
- 3 glipte filer ryddet i runde 2.
- Ellipsis-tegn `…` byttet til `...` for Windows-terminal-kompatibilitet.
- CLAUDE.md-tekst strammet.

**Forsvart:**
- `PROJECT_REF` har hardkodet default — ikke en hemmelighet, default holder.
- Duplisert env-sjekk på tvers av seks skript — lavt-ROI å konsolidere for engangsskript.

**Sikkerhet (krever oppfølging fra deg):**
Passordet ligger fortsatt i git-historikken. Anbefalt: roter database-passordet i Supabase Dashboard → Project Settings → Database, og oppdater `.env.local` med ny verdi. Da er den gamle strengen i historikken verdiløs. Ingen Vercel-oppdatering nødvendig (appen bruker ikke direkte `pg.Client`).

## Test plan
- [x] `npm run lint` 0 errors
- [x] `npm run build` grønt
- [x] `grep "d2F3j"` matcher kun `.env.local`
- [ ] Roter passordet i Supabase Dashboard og oppdater `.env.local` lokalt

🤖 Generated with [Claude Code](https://claude.com/claude-code)