### PR TITLE
Trim whitespace i profiles.navn ved kilde og DB-constraint (#123)

### DIFF
--- a/app/api/admin/opprett-medlem/route.ts
+++ b/app/api/admin/opprett-medlem/route.ts
@@ -19,7 +19,8 @@ export async function POST(request: Request) {
   const { data: profil } = await supabase.from('profiles').select('rolle').eq('id', user.id).single()
   if (!kanAdministrere(profil?.rolle)) return NextResponse.json({ feil: 'Ikke admin' }, { status: 403 })
 
-  const { navn, epost } = await request.json()
+  const { navn: rawNavn, epost } = await request.json()
+  const navn = (rawNavn ?? '').trim()
   if (!navn || !epost) return NextResponse.json({ feil: 'Mangler navn eller e-post' }, { status: 400 })
 
   // Bruk service-role for å opprette bruker

--- a/app/api/admin/opprett-medlem/route.ts
+++ b/app/api/admin/opprett-medlem/route.ts
@@ -19,8 +19,9 @@ export async function POST(request: Request) {
   const { data: profil } = await supabase.from('profiles').select('rolle').eq('id', user.id).single()
   if (!kanAdministrere(profil?.rolle)) return NextResponse.json({ feil: 'Ikke admin' }, { status: 403 })
 
-  const { navn: rawNavn, epost } = await request.json()
+  const { navn: rawNavn, epost: rawEpost } = await request.json()
   const navn = (rawNavn ?? '').trim()
+  const epost = (rawEpost ?? '').trim().toLowerCase()
   if (!navn || !epost) return NextResponse.json({ feil: 'Mangler navn eller e-post' }, { status: 400 })
 
   // Bruk service-role for å opprette bruker

--- a/lib/actions/profil.ts
+++ b/lib/actions/profil.ts
@@ -11,7 +11,8 @@ export async function oppdaterEgenProfil(data: { navn: string; visningsnavn: str
   const { supabase, user } = await ensureInnlogget()
 
   const navn = data.navn.trim()
-  const visningsnavn = (data.visningsnavn || data.navn).trim()
+  if (!navn) throw new Error('Navn kan ikke være tomt')
+  const visningsnavn = (data.visningsnavn?.trim() || navn)
 
   const oppdatering: Record<string, unknown> = {
     navn,
@@ -36,7 +37,8 @@ export async function oppdaterMedlemAdmin(id: string, data: { navn: string; visn
   const { supabase } = await ensureAdmin()
 
   const navn = data.navn.trim()
-  const visningsnavn = (data.visningsnavn || data.navn).trim()
+  if (!navn) throw new Error('Navn kan ikke være tomt')
+  const visningsnavn = (data.visningsnavn?.trim() || navn)
 
   // Bruk service-role for å oppdatere profiles (RLS tillater admin å oppdatere andres)
   const { error } = await supabase

--- a/lib/actions/profil.ts
+++ b/lib/actions/profil.ts
@@ -10,9 +10,12 @@ import { normaliserTelefon } from '@/lib/telefon'
 export async function oppdaterEgenProfil(data: { navn: string; visningsnavn: string; telefon: string; fodselsdato?: string; bilde_url?: string | null }) {
   const { supabase, user } = await ensureInnlogget()
 
+  const navn = data.navn.trim()
+  const visningsnavn = (data.visningsnavn || data.navn).trim()
+
   const oppdatering: Record<string, unknown> = {
-    navn: data.navn,
-    visningsnavn: data.visningsnavn || data.navn,
+    navn,
+    visningsnavn,
     telefon: normaliserTelefon(data.telefon),
     fodselsdato: data.fodselsdato || null,
     oppdatert: naa(),
@@ -32,10 +35,13 @@ export async function oppdaterEgenProfil(data: { navn: string; visningsnavn: str
 export async function oppdaterMedlemAdmin(id: string, data: { navn: string; visningsnavn: string; telefon: string; rolle: string; aktiv: boolean; fodselsdato?: string }) {
   const { supabase } = await ensureAdmin()
 
+  const navn = data.navn.trim()
+  const visningsnavn = (data.visningsnavn || data.navn).trim()
+
   // Bruk service-role for å oppdatere profiles (RLS tillater admin å oppdatere andres)
   const { error } = await supabase
     .from('profiles')
-    .update({ navn: data.navn, visningsnavn: data.visningsnavn || data.navn, telefon: normaliserTelefon(data.telefon), fodselsdato: data.fodselsdato || null, rolle: data.rolle, aktiv: data.aktiv, oppdatert: naa() })
+    .update({ navn, visningsnavn, telefon: normaliserTelefon(data.telefon), fodselsdato: data.fodselsdato || null, rolle: data.rolle, aktiv: data.aktiv, oppdatert: naa() })
     .eq('id', id)
 
   if (error) throw new Error(error.message)

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -1376,3 +1376,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 202,
-  "versjon": "V2.202"
+  "nummer": 203,
+  "versjon": "V2.203"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 203,
-  "versjon": "V2.203"
+  "nummer": 204,
+  "versjon": "V2.204"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 201,
-  "versjon": "V2.201"
+  "nummer": 202,
+  "versjon": "V2.202"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.203'
+const CACHE_VERSION = 'V2.204'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.201'
+const CACHE_VERSION = 'V2.202'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.202'
+const CACHE_VERSION = 'V2.203'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/supabase/migrations/070_trim_profil_navn.sql
+++ b/supabase/migrations/070_trim_profil_navn.sql
@@ -1,0 +1,13 @@
+-- Trim leading/trailing whitespace fra profiles.navn og .visningsnavn.
+-- Idempotent: WHERE-klausul gjør re-kjøring til no-op.
+-- CHECK-constraint hindrer at problemet siver inn igjen — kombinert med
+-- trim i lib/actions/profil.ts gir det rene data både ved kilden og som
+-- siste-line forsvar.
+
+update profiles set navn = btrim(navn) where navn <> btrim(navn);
+update profiles set visningsnavn = btrim(visningsnavn) where visningsnavn <> btrim(visningsnavn);
+
+alter table profiles
+  add constraint profiles_navn_trimmet check (navn = btrim(navn));
+alter table profiles
+  add constraint profiles_visningsnavn_trimmet check (visningsnavn = btrim(visningsnavn));

--- a/supabase/migrations/070_trim_profil_navn.sql
+++ b/supabase/migrations/070_trim_profil_navn.sql
@@ -1,8 +1,9 @@
--- Trim leading/trailing whitespace fra profiles.navn og .visningsnavn.
--- Idempotent: WHERE-klausul gjør re-kjøring til no-op.
--- CHECK-constraint hindrer at problemet siver inn igjen — kombinert med
--- trim i lib/actions/profil.ts gir det rene data både ved kilden og som
--- siste-line forsvar.
+-- Trim leading/trailing whitespace fra profiles.navn og .visningsnavn (#123).
+-- Hvorfor: Facebook-import og fri admin-input ga sporadisk trailing space
+-- som ødela sortering og initial-rendering i Avatar.
+-- UPDATE-ene er idempotente via WHERE-klausul (no-op hvis allerede trim'd).
+-- CHECK-constraintene legges på som siste-line forsvar — application-laget
+-- (lib/actions/profil.ts + opprett-medlem/route.ts) trim-er ved kilden.
 
 update profiles set navn = btrim(navn) where navn <> btrim(navn);
 update profiles set visningsnavn = btrim(visningsnavn) where visningsnavn <> btrim(visningsnavn);

--- a/supabase/migrations/071_trim_handle_ny_bruker.sql
+++ b/supabase/migrations/071_trim_handle_ny_bruker.sql
@@ -1,8 +1,8 @@
 -- Forsvar i dybden for 070_trim_profil_navn (#123):
--- handle_ny_bruker-triggeren setter navn/visningsnavn fra auth.users-data
--- ved opprettelse. Hvis raw_user_meta_data eller email en gang skulle
--- inneholde leading/trailing whitespace, ville INSERT-en bryte CHECK-
--- constraintene profiles_navn_trimmet og profiles_visningsnavn_trimmet.
+-- handle_ny_bruker-triggeren setter navn/visningsnavn fra auth.users.email
+-- (lokaldelen før @) ved opprettelse. Hvis email-en en gang skulle inneholde
+-- leading/trailing whitespace, ville INSERT-en bryte CHECK-constraintene
+-- profiles_navn_trimmet og profiles_visningsnavn_trimmet.
 -- Vi btrim-er verdiene i triggeren slik at constrainten aldri blir
 -- brutt på vei inn — uavhengig av om application-laget glipper.
 

--- a/supabase/migrations/071_trim_handle_ny_bruker.sql
+++ b/supabase/migrations/071_trim_handle_ny_bruker.sql
@@ -1,0 +1,21 @@
+-- Forsvar i dybden for 070_trim_profil_navn (#123):
+-- handle_ny_bruker-triggeren setter navn/visningsnavn fra auth.users-data
+-- ved opprettelse. Hvis raw_user_meta_data eller email en gang skulle
+-- inneholde leading/trailing whitespace, ville INSERT-en bryte CHECK-
+-- constraintene profiles_navn_trimmet og profiles_visningsnavn_trimmet.
+-- Vi btrim-er verdiene i triggeren slik at constrainten aldri blir
+-- brutt på vei inn — uavhengig av om application-laget glipper.
+
+CREATE OR REPLACE FUNCTION handle_ny_bruker()
+RETURNS trigger AS $$
+BEGIN
+  INSERT INTO public.profiles (id, epost, navn, visningsnavn)
+  VALUES (
+    new.id,
+    new.email,
+    btrim(split_part(new.email, '@', 1)),
+    btrim(split_part(new.email, '@', 1))
+  );
+  RETURN new;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary
- Migrasjon 070: trim eksisterende `profiles.navn` og `visningsnavn`. CHECK-constraints hindrer at problemet siver inn igjen.
- Migrasjon 071: `handle_ny_bruker`-trigger bruker btrim på verdiene den setter (forsvar i dybden).
- `lib/actions/profil.ts`: trim først, kast hvis tomt navn, deretter fallback for visningsnavn.
- `app/api/admin/opprett-medlem/route.ts`: trim før split/skriv.

Lukker #123. Begge migrasjoner er allerede kjørt mot prod.

## Beslutninger underveis

**Intern review fanget (rettet):**
- BLOCKER: `opprett-medlem/route.ts` skrev ubehandlet input → ville bryte 070-constraint. Trim + tom-sjekk lagt på.
- BLOCKER: `handle_ny_bruker`-trigger kunne en gang produsere brudd → 071 wrapper btrim rundt verdiene.
- MAJOR: Tom streng som visningsnavn etter trim → trim først, kast `Error('Navn kan ikke være tomt')` hvis tomt, fallback etterpå.
- NIT: Idempotens-claim i 070 var misvisende → kommentar reformulert.

**Forsvart:**
- Interne dobbeltmellomrom (`Per  Hansen`) er ikke i scope — eget issue hvis det blir aktuelt.
- `opprett-medlem/route.ts` bruker fortsatt inline auth-mønster i stedet for `ensureAdmin()` — eget issue.

## Test plan
- [x] `npm run lint && npm run build` grønt
- [x] Migrasjon 070+071 pushet til prod
- [ ] Manuell røyktest: lim inn navn med trailing space i /profil — skal lagres pent

🤖 Generated with [Claude Code](https://claude.com/claude-code)