### PR TITLE
Auto-kollaps kommentarer på agenda-arrangementer etter 7 dager (#127)

### DIFF
--- a/components/agenda/ArrangementKort.tsx
+++ b/components/agenda/ArrangementKort.tsx
@@ -4,6 +4,7 @@ import Icon from '@/components/ui/Icon'
 import Card from '@/components/ui/Card'
 import KommentarerPaaKort, { type KommentarKortData } from '@/components/agenda/KommentarerPaaKort'
 import { formaterDato, aarHvisAvvik } from '@/lib/dato'
+import { KOMMENTARER_KOLLAPS_DAGER } from '@/lib/konstanter'
 
 export type ArrangementKortData = {
   id: string
@@ -62,6 +63,11 @@ export default function ArrangementKort({ arr, tidligere = false, kommentarer = 
   const tid = formaterDato(iso, 'HH:mm')
   const aar = aarHvisAvvik(iso)
   const scene = sceneFor(arr.type)
+
+  const siste = kommentarer[kommentarer.length - 1]
+  const alderMs = siste ? Date.now() - new Date(siste.opprettet).getTime() : 0
+  const skalKollapse =
+    kommentarer.length > 0 && alderMs > KOMMENTARER_KOLLAPS_DAGER * 24 * 60 * 60 * 1000
 
   return (
     <Link
@@ -249,6 +255,7 @@ export default function ArrangementKort({ arr, tidligere = false, kommentarer = 
           <KommentarerPaaKort
             kommentarer={kommentarer}
             scope={{ type: 'arrangement', id: arr.id }}
+            startKollapset={skalKollapse}
           />
         )}
       </Card>

--- a/components/agenda/KommentarerPaaKort.tsx
+++ b/components/agenda/KommentarerPaaKort.tsx
@@ -46,11 +46,13 @@ function relativTid(iso: string): string {
 export default function KommentarerPaaKort({
   kommentarer,
   scope,
+  startKollapset = false,
 }: {
   kommentarer: KommentarKortData[]
   scope: KommentarScope
+  startKollapset?: boolean
 }) {
-  const [apen, setApen] = useState(true)
+  const [apen, setApen] = useState(!startKollapset)
   const [tekst, setTekst] = useState('')
   const [sender, startTransition] = useTransition()
   const router = useRouter()

--- a/lib/konstanter.ts
+++ b/lib/konstanter.ts
@@ -21,3 +21,7 @@ export const PAAMINNELSE_DAGER = {
 // 1 dag — kort vindu reduserer eksponering hvis godkjenneren glemmer å
 // trekke tilbake.
 export const PASS_TILGANG_TIMER = 24
+
+// Kommentarseksjonen på agenda-arrangementer kollapses automatisk når
+// det er stille; brukeren kan fortsatt åpne manuelt via chevron.
+export const KOMMENTARER_KOLLAPS_DAGER = 7

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 204,
-  "versjon": "V2.204"
+  "nummer": 205,
+  "versjon": "V2.205"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.204'
+const CACHE_VERSION = 'V2.205'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
## Summary
- Kommentarseksjonen på agenda-arrangementkort starter nå kollapset når siste kommentar er eldre enn 7 dager. Brukeren kan fortsatt åpne manuelt via chevron-toggle.
- Skoper kun til `ArrangementKort` (møter og turer). `PollKort` og `MeldingKort` uendret.

Lukker #127.

## Beslutninger underveis
- `KOMMENTARER_KOLLAPS_DAGER = 7` i `lib/konstanter.ts`
- Ny prop `startKollapset?: boolean` på `KommentarerPaaKort` (default `false`)
- `ArrangementKort` beregner alder server-side — ingen hydration-mismatch

NITs fra intern review forsvart: ms-multiplikasjon ikke duplikert nok til å abstraheres; `apen`-state-init er ok siden prop er server-rendret.

## Test plan
- [x] `npm run build` grønt
- [x] `npm run lint` 0 errors
- [ ] Manuell test på preview: gammelt arrangement viser kollapset, fersk viser åpent

🤖 Generated with [Claude Code](https://claude.com/claude-code)