### PR TITLE
Rydd 11 ESLint-warnings: blob-preview via Image, flate scope-deps i Chat (#129)

### DIFF
--- a/app/(app)/arrangementer/[id]/rediger/RedigerSkjema.tsx
+++ b/app/(app)/arrangementer/[id]/rediger/RedigerSkjema.tsx
@@ -266,11 +266,14 @@ export default function RedigerSkjema({
         {previewUrl ? (
           <div style={{ position: 'relative', aspectRatio: '16/9' }}>
             {previewUrl.startsWith('blob:') ? (
-              // Lokal forhåndsvisning før upload
-              <img
+              // Lokal forhåndsvisning før upload — unoptimized fordi blob-URL-er ikke kan optimaliseres serverside
+              <Image
                 src={previewUrl}
                 alt=""
-                style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                fill
+                unoptimized
+                style={{ objectFit: 'cover' }}
+                sizes="(max-width: 512px) 100vw, 512px"
               />
             ) : (
               <Image

--- a/app/(app)/arrangementer/ny/NyttArrangementSkjema.tsx
+++ b/app/(app)/arrangementer/ny/NyttArrangementSkjema.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useTransition, useMemo, type CSSProperties } from 'react'
 import { useRouter } from 'next/navigation'
+import Image from 'next/image'
 import { opprettArrangement } from '@/lib/actions/arrangementer'
 import { lastOppBilde } from '@/lib/actions/bilde-opplasting'
 import SkjemaBar from '@/components/ui/SkjemaBar'
@@ -211,12 +212,14 @@ export default function NyttArrangementSkjema({
       >
         {previewUrl ? (
           <div style={{ position: 'relative', aspectRatio: '16/9' }}>
-            {/* Blob-URL for forhåndsvisning — vanlig <img> siden Next/Image
-                ikke håndterer blob-URLer */}
-            <img
+            {/* Blob-URL for forhåndsvisning — unoptimized fordi den ikke kan optimaliseres serverside */}
+            <Image
               src={previewUrl}
               alt=""
-              style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+              fill
+              unoptimized
+              style={{ objectFit: 'cover' }}
+              sizes="(max-width: 512px) 100vw, 512px"
             />
           </div>
         ) : (

--- a/app/(app)/meldinger/ny/NyMeldingSkjema.tsx
+++ b/app/(app)/meldinger/ny/NyMeldingSkjema.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState, useTransition, type CSSProperties } from 'react'
 import { useRouter } from 'next/navigation'
+import Image from 'next/image'
 import { opprettMelding } from '@/lib/actions/meldinger'
 import { lastOppBilde } from '@/lib/actions/bilde-opplasting'
 import SkjemaBar from '@/components/ui/SkjemaBar'
@@ -118,10 +119,13 @@ export default function NyMeldingSkjema() {
           {previewUrl ? (
             <div style={{ position: 'relative' }}>
               <div style={{ position: 'relative', width: '100%', aspectRatio: '4/3', borderRadius: 'var(--radius-card)', overflow: 'hidden' }}>
-                <img
+                <Image
                   src={previewUrl}
                   alt="Forhåndsvisning"
-                  style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                  fill
+                  unoptimized
+                  style={{ objectFit: 'cover' }}
+                  sizes="(max-width: 512px) 100vw, 512px"
                 />
               </div>
               <div style={{ display: 'flex', gap: 8, marginTop: 10 }}>

--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -138,6 +138,14 @@ export default function Chat({
   const tabell = konfig.tabell
   const kanalNavn = konfig.kanalNavn(scope)
 
+  // Ekstraherte scope-felter — flate verdier slik at react-hooks/exhaustive-deps
+  // kan analysere deps-arrayene under uten "complex expression"-warnings.
+  const scopeType = scope.type
+  const arrangementId = scope.type === 'arrangement' ? scope.arrangementId : ''
+  const pollId       = scope.type === 'poll'        ? scope.pollId        : ''
+  const meldingId    = scope.type === 'melding'     ? scope.meldingId     : ''
+  const samtaleId    = scope.type === 'privat'      ? scope.samtaleId     : ''
+
   // Helper — henter meldinger med riktig scope-filter. Returnerer i
   // *stigende* rekkefølge (eldste først) siden det er det UI-et ønsker.
   // Bruker CHAT_KONFIG til å slå opp tabell + FK-filter — ingen scope-
@@ -166,15 +174,11 @@ export default function Chat({
       const { data } = await q
       return data ? ([...data].reverse() as unknown as ChatMelding[]) : []
     },
+    // konfig/scope/tabell utelates bevisst — de er rent utledet av scope-feltene over,
+    // og parent sender inline scope-objekter (ny identitet per render) som ville trigget
+    // unødvendige re-fetches.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      scope.type,
-      scope.type === 'arrangement' ? scope.arrangementId : '',
-      scope.type === 'poll' ? scope.pollId : '',
-      scope.type === 'melding' ? scope.meldingId : '',
-      scope.type === 'privat' ? scope.samtaleId : '',
-      supabase,
-    ],
+    [scopeType, arrangementId, pollId, meldingId, samtaleId, supabase],
   )
 
   // Frigjør blob-URL når preview byttes
@@ -364,15 +368,11 @@ export default function Chat({
       cancelled = true
       if (channelRef) supabase.removeChannel(channelRef)
     }
+    // kanalNavn/konfig/scope/tabell utelates bevisst — alle utledet av scope-feltene over,
+    // og parent sender inline scope-objekter (ny identitet per render) som ville trigget
+    // unødvendige re-subscribes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    scope.type,
-    scope.type === 'arrangement' ? scope.arrangementId : '',
-    scope.type === 'poll' ? scope.pollId : '',
-    scope.type === 'melding' ? scope.meldingId : '',
-    scope.type === 'privat' ? scope.samtaleId : '',
-    supabase,
-  ])
+  }, [scopeType, arrangementId, pollId, meldingId, samtaleId, supabase])
 
   // Hent reaksjoner — kun for meldings-ID-er vi ikke har hentet før. På
   // mount: fetch for alle. Ved scrollback (Vis eldre): fetch for nye

--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -142,9 +142,9 @@ export default function Chat({
   // kan analysere deps-arrayene under uten "complex expression"-warnings.
   const scopeType = scope.type
   const arrangementId = scope.type === 'arrangement' ? scope.arrangementId : ''
-  const pollId       = scope.type === 'poll'        ? scope.pollId        : ''
-  const meldingId    = scope.type === 'melding'     ? scope.meldingId     : ''
-  const samtaleId    = scope.type === 'privat'      ? scope.samtaleId     : ''
+  const pollId = scope.type === 'poll' ? scope.pollId : ''
+  const meldingId = scope.type === 'melding' ? scope.meldingId : ''
+  const samtaleId = scope.type === 'privat' ? scope.samtaleId : ''
 
   // Helper — henter meldinger med riktig scope-filter. Returnerer i
   // *stigende* rekkefølge (eldste først) siden det er det UI-et ønsker.

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 206,
-  "versjon": "V2.206"
+  "nummer": 207,
+  "versjon": "V2.207"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 205,
-  "versjon": "V2.205"
+  "nummer": 206,
+  "versjon": "V2.206"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.206'
+const CACHE_VERSION = 'V2.207'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.205'
+const CACHE_VERSION = 'V2.206'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
## Summary
- 3× `<img>` → `<Image fill unoptimized>` for blob-URL forhåndsvisning i opplastings-skjemaer
- 8× `react-hooks/exhaustive-deps` ryddet i `components/chat/Chat.tsx` ved å ekstrahere flate scope-felter

`npm run lint` er nå helt rent (0 warnings, 0 errors).

Lukker #129.

## Beslutninger underveis

**Implementering:**
- Flate scope-felter (`scopeType`, `arrangementId`, `pollId`, `meldingId`, `samtaleId`) ekstrahert som primitiver så ESLint kan analysere deps-arrayene
- Beholdt 1 målrettet `eslint-disable-next-line` per hook med konkret begrunnelse om hvorfor `konfig`/`scope` ikke skal i deps (ville trigge unødvendige re-subscribes pga. inline scope-objekter fra parent)
- `unoptimized` på Image er belt-and-suspenders for blob-URL — Next/Image-loader bypasser dem uansett, men eksplisitt flagg forhindrer mulig konsoll-warning

**Forsvart (NITs fra intern review):**
- `unoptimized` teknisk overflødig — beholdt for tydelighet
- `sizes` har null effekt med `unoptimized` — dropper ikke for konsistens

## Test plan
- [x] `npm run lint` 0/0
- [x] `npm run build` grønt
- [ ] Manuell røyktest: last opp bilde i `/arrangementer/ny`, `/arrangementer/[id]/rediger`, `/meldinger/ny` — preview vises riktig
- [ ] Chat: send melding i ulike scopes (klubb/arrangement/poll/melding/samtale), realtime fungerer

🤖 Generated with [Claude Code](https://claude.com/claude-code)