### PR TITLE
Kåringspoll oppå generisk poll, anonym stemming + tiebreak (#87)

### DIFF
--- a/__tests__/paaminnelser.test.ts
+++ b/__tests__/paaminnelser.test.ts
@@ -5,6 +5,7 @@ import { lagChain } from './helpers/supabase-mock'
 // Mock dato-modul
 vi.mock('@/lib/dato', () => ({
   norskDatoNaa: () => new Date(2026, 5, 10), // 10. juni 2026
+  naa: () => '2026-06-10T00:00:00.000Z',
 }))
 
 // Mock varsler

--- a/__tests__/responstid.test.ts
+++ b/__tests__/responstid.test.ts
@@ -146,6 +146,7 @@ describe('responstid – cron-jobb overhead', () => {
     // Mock alt som trengs
     vi.doMock('@/lib/dato', () => ({
       norskDatoNaa: () => new Date(2026, 5, 10),
+      naa: () => '2026-06-10T00:00:00.000Z',
     }))
     vi.doMock('@/lib/varsler', () => ({
       sendPaaminneVarsler: vi.fn().mockResolvedValue(undefined),
@@ -153,23 +154,22 @@ describe('responstid – cron-jobb overhead', () => {
       sendArrangorPurringVarsler: vi.fn().mockResolvedValue(undefined),
     }))
 
+    // Fleksibel chainable mock: alle filter-metoder returnerer chain-en
+    // selv, og hele kjeden er thenable. Dekker alle tabell-kall i
+    // kjorPaaminnelser inkludert behandleKaaringspoller (poll, profiles).
+    function lagChain(): Record<string, unknown> {
+      const chain: Record<string, unknown> = {}
+      const metoder = ['select', 'eq', 'in', 'gte', 'lt', 'is', 'not', 'limit', 'order']
+      for (const m of metoder) {
+        chain[m] = vi.fn().mockReturnValue(chain)
+      }
+      chain.then = (r: (v: unknown) => void) =>
+        Promise.resolve({ data: [], error: null }).then(r)
+      return chain
+    }
     const mockAdmin = {
-      from: vi.fn(() => ({
-        select: vi.fn().mockReturnValue({
-          gte: vi.fn().mockReturnValue({
-            lt: vi.fn().mockReturnValue({
-              then: (r: (v: unknown) => void) => Promise.resolve({ data: [] }).then(r),
-            }),
-          }),
-          eq: vi.fn().mockReturnValue({
-            is: vi.fn().mockReturnValue({
-              not: vi.fn().mockReturnValue({
-                then: (r: (v: unknown) => void) => Promise.resolve({ data: [] }).then(r),
-              }),
-            }),
-          }),
-        }),
-      })),
+      from: vi.fn(() => lagChain()),
+      rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
     }
 
     const { kjorPaaminnelser } = await import('@/lib/actions/paaminnelser')

--- a/__tests__/roller.test.ts
+++ b/__tests__/roller.test.ts
@@ -5,6 +5,7 @@ import {
   kanAdministrere,
   harGulGloed,
   faarIssueVarsler,
+  loeserTiebreak,
   tittelFor,
   rollerMed,
   rettigheterFor,
@@ -51,6 +52,20 @@ describe('roller – rettighetsmatrise', () => {
     })
   })
 
+  describe('loeserTiebreak', () => {
+    it('kun generalsekretær løser tiebreak', () => {
+      expect(loeserTiebreak('generalsekretaer')).toBe(true)
+      expect(loeserTiebreak('admin')).toBe(false)
+      expect(loeserTiebreak('medlem')).toBe(false)
+    })
+
+    it('ukjente/null-roller løser ikke tiebreak', () => {
+      expect(loeserTiebreak(null)).toBe(false)
+      expect(loeserTiebreak(undefined)).toBe(false)
+      expect(loeserTiebreak('tull')).toBe(false)
+    })
+  })
+
   describe('tittelFor', () => {
     it('gir norsk tittel for hver rolle', () => {
       expect(tittelFor('medlem')).toBe('Medlem')
@@ -69,6 +84,7 @@ describe('roller – rettighetsmatrise', () => {
       expect(rollerMed('kanAdministrere').sort()).toEqual(['admin', 'generalsekretaer'])
       expect(rollerMed('faarIssueVarsler')).toEqual(['admin'])
       expect(rollerMed('harGulGloed')).toEqual(['generalsekretaer'])
+      expect(rollerMed('loeserTiebreak')).toEqual(['generalsekretaer'])
     })
   })
 
@@ -88,6 +104,7 @@ describe('roller – rettighetsmatrise', () => {
         kanAdministrere: true,
         faarIssueVarsler: false,
         harGulGloed: true,
+        loeserTiebreak: true,
       })
     })
   })

--- a/app/(app)/arrangementer/[id]/page.tsx
+++ b/app/(app)/arrangementer/[id]/page.tsx
@@ -97,6 +97,18 @@ export default async function ArrangementDetaljer({
       .limit(1),
   ])
 
+  // Kåringspoll knyttet til arrangementet (#87). Vi henter separat for å
+  // ikke gjøre Promise.all-blokken over mer kompleks; resultatet er
+  // typisk 0 eller 1 rad.
+  const { data: koblede } = await supabase
+    .from('poll')
+    .select('id, spoersmaal, svarfrist, avsluttet_paa')
+    .eq('arrangement_id', id)
+    .not('kaaring_mal_id', 'is', null)
+    .order('svarfrist', { ascending: false })
+    .limit(1)
+  const koblet_kaaringspoll = koblede?.[0] ?? null
+
   if (!arr) notFound()
 
   const erAdmin = kanAdministrere(profil?.rolle)
@@ -582,6 +594,39 @@ export default async function ArrangementDetaljer({
               Generalsekretæren godkjenner — du får tilgang i 24 timer.
             </div>
             <PassListe arrangementId={id} deltakere={passDeltakere} />
+          </section>
+        )}
+
+        {/* Tilknyttet kåringspoll (#87) — vises bare hvis koblet */}
+        {koblet_kaaringspoll && (
+          <section style={{ marginBottom: 24 }}>
+            <Link
+              href={`/poll/${koblet_kaaringspoll.id}`}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 12,
+                padding: '14px 16px',
+                border: '0.5px solid var(--accent)',
+                borderRadius: 'var(--radius-card)',
+                background: 'var(--accent-soft)',
+                color: 'var(--text-primary)',
+                textDecoration: 'none',
+                fontFamily: 'var(--font-body)',
+                fontSize: 14,
+              }}
+            >
+              <Icon name="trophy" size={20} color="var(--accent)" />
+              <span style={{ flex: 1 }}>
+                {koblet_kaaringspoll.avsluttet_paa
+                  ? 'Kåring: avgjort'
+                  : 'Kåring: åpen for stemming'}
+                <div style={{ fontSize: 12, color: 'var(--text-secondary)', marginTop: 2 }}>
+                  {koblet_kaaringspoll.spoersmaal}
+                </div>
+              </span>
+              <Icon name="chevron" size={16} color="var(--text-tertiary)" />
+            </Link>
           </section>
         )}
 

--- a/app/(app)/kaaringspoll/[id]/tiebreak/TiebreakSkjema.tsx
+++ b/app/(app)/kaaringspoll/[id]/tiebreak/TiebreakSkjema.tsx
@@ -1,0 +1,176 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { velgTiebreakVinner } from '@/lib/actions/kaaringspoll'
+import KaaringKandidat from '@/components/poll/KaaringKandidat'
+
+type Kandidat = {
+  id: string
+  navn: string
+  bildeUrl?: string | null
+  rolle?: string | null
+  variant: 'profil' | 'arrangement'
+}
+
+type Props = {
+  pollId: string
+  tittel: string
+  undertittel: string
+  kandidater: Kandidat[]
+}
+
+// Bevisst minimal: ingen stemmetall vises, kun navn + bilde. Det er
+// generalsekretærens egen vurdering — stemmetallene er likt og hjelper
+// ikke i å bryte uavgjort.
+export default function TiebreakSkjema({ pollId, tittel, undertittel, kandidater }: Props) {
+  const [valgt, setValgt] = useState<string>('')
+  const [feil, setFeil] = useState('')
+  const [isPending, startTransition] = useTransition()
+  const router = useRouter()
+
+  function handleVelg() {
+    setFeil('')
+    if (!valgt) {
+      setFeil('Velg én kandidat.')
+      return
+    }
+    startTransition(async () => {
+      try {
+        await velgTiebreakVinner(pollId, valgt)
+      } catch (err) {
+        if (
+          typeof err === 'object' &&
+          err !== null &&
+          'digest' in err &&
+          typeof (err as Record<string, unknown>).digest === 'string' &&
+          ((err as Record<string, unknown>).digest as string).startsWith('NEXT_REDIRECT')
+        ) {
+          throw err
+        }
+        setFeil(err instanceof Error ? err.message : 'Kunne ikke lagre vinneren.')
+      }
+    })
+  }
+
+  return (
+    <div style={{ padding: '0 20px 120px' }}>
+      <header style={{ marginTop: 20, marginBottom: 24 }}>
+        <div
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 10,
+            fontWeight: 600,
+            color: 'var(--accent)',
+            letterSpacing: '1.6px',
+            textTransform: 'uppercase',
+            marginBottom: 8,
+          }}
+        >
+          Tiebreak
+        </div>
+        <h1
+          style={{
+            fontFamily: 'var(--font-display)',
+            fontSize: 26,
+            fontWeight: 500,
+            margin: '0 0 6px',
+            color: 'var(--text-primary)',
+          }}
+        >
+          {tittel}
+        </h1>
+        <p
+          style={{
+            fontFamily: 'var(--font-body)',
+            fontSize: 13,
+            color: 'var(--text-secondary)',
+            margin: 0,
+          }}
+        >
+          {undertittel}
+        </p>
+      </header>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+        {kandidater.map(k => {
+          const erValgt = valgt === k.id
+          return (
+            <button
+              key={k.id}
+              type="button"
+              onClick={() => setValgt(k.id)}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 14,
+                padding: '12px 14px',
+                border: `1px solid ${erValgt ? 'var(--accent)' : 'var(--border)'}`,
+                borderRadius: 'var(--radius-card)',
+                background: erValgt ? 'var(--accent-soft)' : 'transparent',
+                color: 'var(--text-primary)',
+                fontFamily: 'var(--font-body)',
+                fontSize: 15,
+                textAlign: 'left',
+                cursor: 'pointer',
+              }}
+            >
+              <KaaringKandidat
+                navn={k.navn}
+                bildeUrl={k.bildeUrl}
+                rolle={k.rolle}
+                variant={k.variant}
+                size={40}
+              />
+              <span style={{ flex: 1, fontWeight: erValgt ? 600 : 400 }}>{k.navn}</span>
+            </button>
+          )
+        })}
+      </div>
+
+      {feil && (
+        <p style={{ fontSize: 13, color: 'var(--danger)', marginTop: 12 }}>{feil}</p>
+      )}
+
+      <div style={{ display: 'flex', gap: 10, marginTop: 20 }}>
+        <button
+          type="button"
+          onClick={() => router.back()}
+          style={{
+            flex: 1,
+            padding: '12px 0',
+            background: 'transparent',
+            color: 'var(--text-secondary)',
+            border: '0.5px solid var(--border)',
+            borderRadius: 999,
+            fontFamily: 'var(--font-body)',
+            fontSize: 14,
+            cursor: 'pointer',
+          }}
+        >
+          Avbryt
+        </button>
+        <button
+          type="button"
+          onClick={handleVelg}
+          disabled={isPending || !valgt}
+          style={{
+            flex: 2,
+            padding: '12px 0',
+            background: 'var(--accent)',
+            color: '#0a0a0a',
+            border: 'none',
+            borderRadius: 999,
+            fontFamily: 'var(--font-body)',
+            fontSize: 14,
+            fontWeight: 600,
+            cursor: isPending || !valgt ? 'default' : 'pointer',
+            opacity: isPending || !valgt ? 0.5 : 1,
+          }}
+        >
+          {isPending ? 'Lagrer…' : 'Kåre vinneren'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/app/(app)/kaaringspoll/[id]/tiebreak/page.tsx
+++ b/app/(app)/kaaringspoll/[id]/tiebreak/page.tsx
@@ -1,5 +1,5 @@
 import { notFound, redirect } from 'next/navigation'
-import { ensureAdmin } from '@/lib/auth'
+import { ensureLoeserTiebreak } from '@/lib/auth'
 import TiebreakSkjema from './TiebreakSkjema'
 
 type ValgRad = {
@@ -16,7 +16,7 @@ export default async function TiebreakSide({
   params: Promise<{ id: string }>
 }) {
   const { id } = await params
-  const { supabase } = await ensureAdmin()
+  const { supabase } = await ensureLoeserTiebreak()
 
   const { data: poll } = await supabase
     .from('poll')

--- a/app/(app)/kaaringspoll/[id]/tiebreak/page.tsx
+++ b/app/(app)/kaaringspoll/[id]/tiebreak/page.tsx
@@ -1,0 +1,82 @@
+import { notFound, redirect } from 'next/navigation'
+import { ensureAdmin } from '@/lib/auth'
+import TiebreakSkjema from './TiebreakSkjema'
+
+type ValgRad = {
+  id: string
+  tekst: string
+  rekkefoelge: number
+  referanse_profil_id: string | null
+  referanse_arrangement_id: string | null
+}
+
+export default async function TiebreakSide({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  const { supabase } = await ensureAdmin()
+
+  const { data: poll } = await supabase
+    .from('poll')
+    .select(
+      `id, spoersmaal, aar, tiebreak_status, kaaring_mal_id,
+       poll_valg (id, tekst, rekkefoelge, referanse_profil_id, referanse_arrangement_id)`,
+    )
+    .eq('id', id)
+    .single()
+
+  if (!poll) notFound()
+  if (!poll.kaaring_mal_id) redirect(`/poll/${id}`)
+  if (poll.tiebreak_status !== 'venter_paa_tiebreak') {
+    redirect(`/poll/${id}`)
+  }
+
+  // Beriker profil-kandidater med navn/bilde for KaaringKandidat-visning.
+  const valg = [...(poll.poll_valg as ValgRad[])].sort(
+    (a, b) => a.rekkefoelge - b.rekkefoelge,
+  )
+
+  const profilIder = valg
+    .map(v => v.referanse_profil_id)
+    .filter((x): x is string => !!x)
+
+  const { data: profiler } = profilIder.length
+    ? await supabase
+        .from('profiles')
+        .select('id, navn, bilde_url, rolle')
+        .in('id', profilIder)
+    : { data: [] as { id: string; navn: string | null; bilde_url: string | null; rolle: string | null }[] }
+
+  const profilMap = new Map((profiler ?? []).map(p => [p.id, p]))
+
+  const kandidater = valg.map(v => {
+    if (v.referanse_profil_id) {
+      const p = profilMap.get(v.referanse_profil_id)
+      return {
+        id: v.id,
+        navn: p?.navn ?? v.tekst,
+        bildeUrl: p?.bilde_url ?? null,
+        rolle: p?.rolle ?? null,
+        variant: 'profil' as const,
+      }
+    }
+    return {
+      id: v.id,
+      navn: v.tekst,
+      bildeUrl: null,
+      rolle: null,
+      variant: 'arrangement' as const,
+    }
+  })
+
+  return (
+    <TiebreakSkjema
+      pollId={poll.id}
+      tittel={`${poll.spoersmaal}`}
+      undertittel={`Likt antall stemmer — velg vinneren`}
+      kandidater={kandidater}
+    />
+  )
+}

--- a/app/(app)/kaaringspoll/ny/OpprettSkjema.tsx
+++ b/app/(app)/kaaringspoll/ny/OpprettSkjema.tsx
@@ -1,0 +1,201 @@
+'use client'
+
+import { useState, useTransition, type CSSProperties } from 'react'
+import { useRouter } from 'next/navigation'
+import { opprettKaaringspoll } from '@/lib/actions/kaaringspoll'
+import SkjemaBar from '@/components/ui/SkjemaBar'
+import SkjemaSeksjon from '@/components/ui/SkjemaSeksjon'
+import Icon from '@/components/ui/Icon'
+import { formaterDato, datetimeLocalTilIso } from '@/lib/dato'
+
+type Mal = {
+  id: string
+  navn: string
+  kandidat_kilde: string
+}
+
+const monoLabel: CSSProperties = {
+  fontFamily: 'var(--font-mono)',
+  fontSize: 9.5,
+  fontWeight: 600,
+  color: 'var(--text-tertiary)',
+  letterSpacing: '1.6px',
+  textTransform: 'uppercase',
+  marginBottom: 4,
+}
+
+const inputStil: CSSProperties = {
+  width: '100%',
+  background: 'transparent',
+  border: 'none',
+  color: 'var(--text-primary)',
+  fontFamily: 'var(--font-body)',
+  fontSize: 14,
+  outline: 'none',
+  padding: 0,
+}
+
+function Rad({ last, children }: { last?: boolean; children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        padding: '10px 4px',
+        borderBottom: last ? 'none' : '0.5px solid var(--border-subtle)',
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+// Default svarfrist: én uke frem kl 20:00.
+function defaultFrist(): string {
+  const d = new Date()
+  d.setDate(d.getDate() + 7)
+  const iso = d.toISOString()
+  return `${formaterDato(iso, 'yyyy-MM-dd')}T20:00`
+}
+
+type Props = {
+  maler: Mal[]
+  defaultAar: number
+  medlemAntall: number
+  moeteAntall: number
+}
+
+export default function OpprettSkjema({ maler, defaultAar, medlemAntall, moeteAntall }: Props) {
+  const [malId, setMalId] = useState(maler[0]?.id ?? '')
+  const [aar, setAar] = useState(defaultAar)
+  const [frist, setFrist] = useState(defaultFrist())
+  const [feil, setFeil] = useState('')
+  const [isPending, startTransition] = useTransition()
+  const router = useRouter()
+
+  const valgtMal = maler.find(m => m.id === malId)
+  const antallKandidater = valgtMal?.kandidat_kilde === 'arrangement_moete' ? moeteAntall : medlemAntall
+  const forFaaKandidater = antallKandidater < 2
+
+  function handlePubliser() {
+    setFeil('')
+    if (!malId) {
+      setFeil('Velg en kåringsmal.')
+      return
+    }
+    if (!frist) {
+      setFeil('Sett en svarfrist.')
+      return
+    }
+    if (forFaaKandidater) {
+      setFeil(`Trenger minst 2 kandidater (fant ${antallKandidater}).`)
+      return
+    }
+    startTransition(async () => {
+      try {
+        await opprettKaaringspoll({
+          kaaringMalId: malId,
+          aar,
+          svarfrist: datetimeLocalTilIso(frist),
+        })
+      } catch (err) {
+        if (
+          typeof err === 'object' &&
+          err !== null &&
+          'digest' in err &&
+          typeof (err as Record<string, unknown>).digest === 'string' &&
+          ((err as Record<string, unknown>).digest as string).startsWith('NEXT_REDIRECT')
+        ) {
+          throw err
+        }
+        setFeil(err instanceof Error ? err.message : 'Noe gikk galt.')
+      }
+    })
+  }
+
+  if (maler.length === 0) {
+    return (
+      <div style={{ padding: '40px 20px' }}>
+        <p style={{ color: 'var(--text-secondary)', fontFamily: 'var(--font-body)' }}>
+          Ingen ledige kåringsmaler for {defaultAar} — alle har allerede en poll, eller ingen
+          maler er definert.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ padding: '0 20px 120px' }}>
+      <SkjemaBar
+        overtittel="Ny"
+        tittel={valgtMal ? `${valgtMal.navn} ${aar}` : 'Kåring'}
+        onAvbryt={() => router.back()}
+        onLagre={handlePubliser}
+        lagreLabel="Publiser"
+        laster={isPending}
+      />
+
+      <SkjemaSeksjon label="Kåring">
+        <Rad last>
+          <div style={monoLabel}>Mal</div>
+          <select
+            value={malId}
+            onChange={e => setMalId(e.target.value)}
+            style={{ ...inputStil, fontSize: 16 }}
+          >
+            {maler.map(m => (
+              <option key={m.id} value={m.id}>
+                {m.navn}
+              </option>
+            ))}
+          </select>
+        </Rad>
+      </SkjemaSeksjon>
+
+      <SkjemaSeksjon label="Innstillinger">
+        <Rad>
+          <div style={monoLabel}>År</div>
+          <input
+            type="number"
+            min={2008}
+            max={2100}
+            value={aar}
+            onChange={e => setAar(parseInt(e.target.value || `${defaultAar}`, 10))}
+            style={inputStil}
+          />
+        </Rad>
+        <Rad last>
+          <div style={monoLabel}>Svarfrist</div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <input
+              type="datetime-local"
+              value={frist}
+              onChange={e => setFrist(e.target.value)}
+              style={{ ...inputStil, flex: 1 }}
+            />
+            <Icon name="calendar" size={15} color="var(--text-tertiary)" />
+          </div>
+        </Rad>
+      </SkjemaSeksjon>
+
+      <div
+        style={{
+          marginTop: 16,
+          padding: 12,
+          borderRadius: 'var(--radius-card)',
+          background: forFaaKandidater ? 'rgba(220,80,80,0.08)' : 'var(--bg-elevated)',
+          color: forFaaKandidater ? 'var(--danger)' : 'var(--text-secondary)',
+          fontFamily: 'var(--font-body)',
+          fontSize: 13,
+        }}
+      >
+        {valgtMal?.kandidat_kilde === 'arrangement_moete'
+          ? `${antallKandidater} møte${antallKandidater === 1 ? '' : 'r'} blir kandidater.`
+          : `${antallKandidater} medlem${antallKandidater === 1 ? '' : 'mer'} blir kandidater.`}
+        {forFaaKandidater && ' Trenger minst 2.'}
+      </div>
+
+      {feil && (
+        <p style={{ fontSize: 13, color: 'var(--danger)', marginTop: 12 }}>{feil}</p>
+      )}
+    </div>
+  )
+}

--- a/app/(app)/kaaringspoll/ny/OpprettSkjema.tsx
+++ b/app/(app)/kaaringspoll/ny/OpprettSkjema.tsx
@@ -14,6 +14,12 @@ type Mal = {
   kandidat_kilde: string
 }
 
+type ArrangementValg = {
+  id: string
+  tittel: string
+  start_tidspunkt: string
+}
+
 const monoLabel: CSSProperties = {
   fontFamily: 'var(--font-mono)',
   fontSize: 9.5,
@@ -61,12 +67,20 @@ type Props = {
   defaultAar: number
   medlemAntall: number
   moeteAntall: number
+  arrangementer: ArrangementValg[]
 }
 
-export default function OpprettSkjema({ maler, defaultAar, medlemAntall, moeteAntall }: Props) {
+export default function OpprettSkjema({
+  maler,
+  defaultAar,
+  medlemAntall,
+  moeteAntall,
+  arrangementer,
+}: Props) {
   const [malId, setMalId] = useState(maler[0]?.id ?? '')
   const [aar, setAar] = useState(defaultAar)
   const [frist, setFrist] = useState(defaultFrist())
+  const [arrangementId, setArrangementId] = useState<string>('')
   const [feil, setFeil] = useState('')
   const [isPending, startTransition] = useTransition()
   const router = useRouter()
@@ -95,6 +109,7 @@ export default function OpprettSkjema({ maler, defaultAar, medlemAntall, moeteAn
           kaaringMalId: malId,
           aar,
           svarfrist: datetimeLocalTilIso(frist),
+          arrangementId: arrangementId || null,
         })
       } catch (err) {
         if (
@@ -162,7 +177,7 @@ export default function OpprettSkjema({ maler, defaultAar, medlemAntall, moeteAn
             style={inputStil}
           />
         </Rad>
-        <Rad last>
+        <Rad>
           <div style={monoLabel}>Svarfrist</div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
             <input
@@ -173,6 +188,34 @@ export default function OpprettSkjema({ maler, defaultAar, medlemAntall, moeteAn
             />
             <Icon name="calendar" size={15} color="var(--text-tertiary)" />
           </div>
+        </Rad>
+        <Rad last>
+          <div style={monoLabel}>Arrangement (valgfritt)</div>
+          {arrangementer.length === 0 ? (
+            <div
+              style={{
+                fontFamily: 'var(--font-body)',
+                fontSize: 13,
+                color: 'var(--text-tertiary)',
+                fontStyle: 'italic',
+              }}
+            >
+              Ingen aktuelle arrangementer å koble til — la den stå tom
+            </div>
+          ) : (
+            <select
+              value={arrangementId}
+              onChange={e => setArrangementId(e.target.value)}
+              style={{ ...inputStil, fontSize: 16 }}
+            >
+              <option value="">— ikke koblet —</option>
+              {arrangementer.map(a => (
+                <option key={a.id} value={a.id}>
+                  {a.tittel} ({formaterDato(a.start_tidspunkt, 'd. MMM yyyy')})
+                </option>
+              ))}
+            </select>
+          )}
         </Rad>
       </SkjemaSeksjon>
 

--- a/app/(app)/kaaringspoll/ny/page.tsx
+++ b/app/(app)/kaaringspoll/ny/page.tsx
@@ -1,6 +1,12 @@
+import { addDays } from 'date-fns'
 import { ensureAdmin } from '@/lib/auth'
-import { norskAar } from '@/lib/dato'
+import { norskAar, norskDatoNaa } from '@/lib/dato'
 import OpprettSkjema from './OpprettSkjema'
+
+// Hvor langt tilbake i tid vi henter arrangementer som kan kobles til en
+// kåringspoll. Sju dager er bredt nok til å fange julebordet selv om
+// kåringen opprettes dagen etter, men ikke så bredt at listen flommer.
+const ARRANGEMENT_TILBAKE_DAGER = 7
 
 // Generalsekretær-vennlig opprett-side for kåringspoll. Server-rendret
 // første halvdel henter maler + counts av potensielle kandidater så
@@ -9,21 +15,34 @@ import OpprettSkjema from './OpprettSkjema'
 export default async function NyKaaringspoll() {
   const { supabase } = await ensureAdmin()
   const aar = norskAar()
+  // Vinduet starter sju dager før norsk dato — dekker arrangementer som
+  // nettopp er ferdig (typisk julebord kvelden før). Vi caster Date til
+  // ISO via toISOString() for Postgres-sammenligning.
+  const tidligsteArrIso = addDays(norskDatoNaa(), -ARRANGEMENT_TILBAKE_DAGER).toISOString()
 
-  const [{ data: maler }, { count: medlemAntall }, { data: aaretsMoeter }] =
-    await Promise.all([
-      supabase
-        .from('kaaringmaler')
-        .select('id, navn, kandidat_kilde, rekkefolge')
-        .order('rekkefolge'),
-      supabase.from('profiles').select('id', { count: 'exact', head: true }).eq('aktiv', true),
-      supabase
-        .from('arrangementer')
-        .select('id')
-        .eq('type', 'moete')
-        .gte('start_tidspunkt', `${aar}-01-01T00:00:00Z`)
-        .lt('start_tidspunkt', `${aar + 1}-01-01T00:00:00Z`),
-    ])
+  const [
+    { data: maler },
+    { count: medlemAntall },
+    { data: aaretsMoeter },
+    { data: aktuelleArr },
+  ] = await Promise.all([
+    supabase
+      .from('kaaringmaler')
+      .select('id, navn, kandidat_kilde, rekkefolge')
+      .order('rekkefolge'),
+    supabase.from('profiles').select('id', { count: 'exact', head: true }).eq('aktiv', true),
+    supabase
+      .from('arrangementer')
+      .select('id')
+      .eq('type', 'moete')
+      .gte('start_tidspunkt', `${aar}-01-01T00:00:00Z`)
+      .lt('start_tidspunkt', `${aar + 1}-01-01T00:00:00Z`),
+    supabase
+      .from('arrangementer')
+      .select('id, tittel, start_tidspunkt')
+      .gte('start_tidspunkt', tidligsteArrIso)
+      .order('start_tidspunkt', { ascending: false }),
+  ])
 
   // Fjern maler som allerede har en åpen eller avgjort kåringspoll for året.
   const { data: brukteMaler } = await supabase
@@ -41,6 +60,7 @@ export default async function NyKaaringspoll() {
       defaultAar={aar}
       medlemAntall={medlemAntall ?? 0}
       moeteAntall={(aaretsMoeter ?? []).length}
+      arrangementer={aktuelleArr ?? []}
     />
   )
 }

--- a/app/(app)/kaaringspoll/ny/page.tsx
+++ b/app/(app)/kaaringspoll/ny/page.tsx
@@ -1,0 +1,46 @@
+import { ensureAdmin } from '@/lib/auth'
+import { norskAar } from '@/lib/dato'
+import OpprettSkjema from './OpprettSkjema'
+
+// Generalsekretær-vennlig opprett-side for kåringspoll. Server-rendret
+// første halvdel henter maler + counts av potensielle kandidater så
+// klienten kan vise antall direkte i nedtrekksmenyen uten ekstra
+// nettverkskall.
+export default async function NyKaaringspoll() {
+  const { supabase } = await ensureAdmin()
+  const aar = norskAar()
+
+  const [{ data: maler }, { count: medlemAntall }, { data: aaretsMoeter }] =
+    await Promise.all([
+      supabase
+        .from('kaaringmaler')
+        .select('id, navn, kandidat_kilde, rekkefolge')
+        .order('rekkefolge'),
+      supabase.from('profiles').select('id', { count: 'exact', head: true }).eq('aktiv', true),
+      supabase
+        .from('arrangementer')
+        .select('id')
+        .eq('type', 'moete')
+        .gte('start_tidspunkt', `${aar}-01-01T00:00:00Z`)
+        .lt('start_tidspunkt', `${aar + 1}-01-01T00:00:00Z`),
+    ])
+
+  // Fjern maler som allerede har en åpen eller avgjort kåringspoll for året.
+  const { data: brukteMaler } = await supabase
+    .from('poll')
+    .select('kaaring_mal_id')
+    .eq('aar', aar)
+    .not('kaaring_mal_id', 'is', null)
+
+  const tatt = new Set((brukteMaler ?? []).map(b => b.kaaring_mal_id))
+  const tilgjengelige = (maler ?? []).filter(m => !tatt.has(m.id))
+
+  return (
+    <OpprettSkjema
+      maler={tilgjengelige}
+      defaultAar={aar}
+      medlemAntall={medlemAntall ?? 0}
+      moeteAntall={(aaretsMoeter ?? []).length}
+    />
+  )
+}

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { createServerClient } from '@/lib/supabase/server'
-import { getInnloggetBruker } from '@/lib/auth-cache'
+import { getInnloggetBruker, getProfil } from '@/lib/auth-cache'
+import { kanAdministrere } from '@/lib/roller'
 import { formaterDato, norskAar, norskDatoNaa } from '@/lib/dato'
 import { subMonths } from 'date-fns'
 import SectionLabel from '@/components/ui/SectionLabel'
@@ -28,7 +29,12 @@ import { subDays } from 'date-fns'
 // Agenda-forsiden: henter rådata og delegerer all sortering/gruppering til
 // lib/agenda-sortering.ts. Denne filen skal holdes tynn — kun fetch + render.
 export default async function Forside() {
-  const [user, supabase] = await Promise.all([getInnloggetBruker(), createServerClient()])
+  const [user, supabase, profil] = await Promise.all([
+    getInnloggetBruker(),
+    createServerClient(),
+    getProfil(),
+  ])
+  const erAdmin = kanAdministrere(profil?.rolle)
 
   const naa = norskDatoNaa()
   // Vis tidligere arrangementer 24 mnd tilbake på forsiden — eldre vises
@@ -372,7 +378,7 @@ export default async function Forside() {
           </h1>
         </div>
 
-        <NyFAB />
+        <NyFAB kanAdministrere={erAdmin} />
       </header>
 
       <PushPaaminnelse />

--- a/app/(app)/poll/[id]/page.tsx
+++ b/app/(app)/poll/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from 'next/navigation'
+import Link from 'next/link'
 import { createServerClient } from '@/lib/supabase/server'
 import { getInnloggetBruker, getProfil } from '@/lib/auth-cache'
 import { kanAdministrere } from '@/lib/roller'
@@ -8,8 +9,20 @@ import PollStemming from '@/components/poll/PollStemming'
 import PollResultat from '@/components/poll/PollResultat'
 import PollRealtime from '@/components/poll/PollRealtime'
 import PollStemtVisning from '@/components/poll/PollStemtVisning'
+import KaaringPollStemming, {
+  type KaaringValg,
+} from '@/components/poll/KaaringPollStemming'
+import VinnerBanner from '@/components/poll/VinnerBanner'
 import Chat from '@/components/chat/Chat'
 import SlettPollKnapp from './SlettPollKnapp'
+
+type ValgRad = {
+  id: string
+  tekst: string
+  rekkefoelge: number
+  referanse_profil_id: string | null
+  referanse_arrangement_id: string | null
+}
 
 type PollRad = {
   id: string
@@ -17,7 +30,12 @@ type PollRad = {
   svarfrist: string
   flervalg: boolean
   opprettet_av: string
-  poll_valg: { id: string; tekst: string; rekkefoelge: number }[]
+  kaaring_mal_id: string | null
+  aar: number | null
+  avsluttet_paa: string | null
+  tiebreak_status: string | null
+  arrangement_id: string | null
+  poll_valg: ValgRad[]
   poll_stemme: { valg_id: string; profil_id: string }[]
 }
 
@@ -38,7 +56,8 @@ export default async function PollDetalj({
       .from('poll')
       .select(
         `id, spoersmaal, svarfrist, flervalg, opprettet_av,
-         poll_valg (id, tekst, rekkefoelge),
+         kaaring_mal_id, aar, avsluttet_paa, tiebreak_status, arrangement_id,
+         poll_valg (id, tekst, rekkefoelge, referanse_profil_id, referanse_arrangement_id),
          poll_stemme (valg_id, profil_id)`,
       )
       .eq('id', id)
@@ -57,14 +76,13 @@ export default async function PollDetalj({
 
   if (!poll) notFound()
 
-  const erAvsluttet = new Date(poll.svarfrist) <= new Date()
+  const erAvsluttet = new Date(poll.svarfrist) <= new Date() || poll.avsluttet_paa !== null
   const erAdmin = kanAdministrere(profil?.rolle)
   const kanSlette = poll.opprettet_av === user!.id || erAdmin
+  const erKaaring = poll.kaaring_mal_id !== null
 
-  // Sorter valgene etter rekkefoelge
   const valg = [...poll.poll_valg].sort((a, b) => a.rekkefoelge - b.rekkefoelge)
 
-  // Aggreger stemmer per valg + unike stemmere
   const stemmerPerValg = new Map<string, number>()
   const unikeStemmere = new Set<string>()
   for (const s of poll.poll_stemme) {
@@ -73,19 +91,36 @@ export default async function PollDetalj({
   }
   const antallStemmere = unikeStemmere.size
 
-  // Mine stemmer — brukes for å pre-utfylle stemmeformen
   const mineStemmer = poll.poll_stemme
     .filter(s => s.profil_id === user!.id)
     .map(s => s.valg_id)
 
   const datoLang = formaterDato(poll.svarfrist, "d. MMMM 'kl.' HH:mm")
 
+  // ─── Kåringspoll-rendering ─────────────────────────────────────────────
+  if (erKaaring) {
+    return (
+      <KaaringVisning
+        poll={poll}
+        valg={valg}
+        chatProfiler={chatProfiler ?? []}
+        stemmerPerValg={stemmerPerValg}
+        antallStemmere={antallStemmere}
+        mineStemmer={mineStemmer}
+        datoLang={datoLang}
+        erAvsluttet={erAvsluttet}
+        erAdmin={erAdmin}
+        chatMeldinger={chatMeldinger ?? []}
+        userId={user!.id}
+        kanSlette={kanSlette}
+      />
+    )
+  }
+
+  // ─── Vanlig poll: uendret oppførsel ────────────────────────────────────
   return (
     <div style={{ padding: '0 20px 120px' }}>
-      {/* Realtime: refresh når noen stemmer */}
       {!erAvsluttet && <PollRealtime pollId={poll.id} />}
-
-      {/* Header: label + spørsmål + frist */}
       <header style={{ marginTop: 12, marginBottom: 22 }}>
         <div
           style={{
@@ -120,13 +155,10 @@ export default async function PollDetalj({
             color: 'var(--text-secondary)',
           }}
         >
-          {erAvsluttet
-            ? `Avsluttet ${datoLang}`
-            : `Svarfrist ${datoLang}`}
+          {erAvsluttet ? `Avsluttet ${datoLang}` : `Svarfrist ${datoLang}`}
         </div>
       </header>
 
-      {/* Stemming eller resultat */}
       {erAvsluttet ? (
         <section style={{ marginBottom: 24 }}>
           <SectionLabel count={antallStemmere}>Resultat</SectionLabel>
@@ -138,7 +170,6 @@ export default async function PollDetalj({
           />
         </section>
       ) : mineStemmer.length > 0 ? (
-        // Har stemt: resultat er primær, «Endre svar» ekspanderer stemming
         <PollStemtVisning
           pollId={poll.id}
           flervalg={poll.flervalg}
@@ -148,7 +179,6 @@ export default async function PollDetalj({
           antallStemmere={antallStemmere}
         />
       ) : (
-        // Ikke stemt ennå: viser stemme-UI med foreløpig resultat under
         <section style={{ marginBottom: 24 }}>
           <SectionLabel count={antallStemmere}>
             {poll.flervalg ? 'Velg ett eller flere' : 'Velg ett'}
@@ -171,7 +201,6 @@ export default async function PollDetalj({
         </section>
       )}
 
-      {/* Kommentarer */}
       <div id="kommentarer">
         <Chat
           scope={{ type: 'poll', pollId: poll.id }}
@@ -182,10 +211,280 @@ export default async function PollDetalj({
         />
       </div>
 
-      {/* Slett-knapp for oppretter/admin */}
-      {kanSlette && (
-        <SlettPollKnapp pollId={poll.id} />
+      {kanSlette && <SlettPollKnapp pollId={poll.id} />}
+    </div>
+  )
+}
+
+// ─── Hjelper for kåringspoll-rendering ────────────────────────────────────
+type ChatProfil = { id: string; navn: string | null; bilde_url: string | null; rolle: string | null }
+type ChatMelding = {
+  id: string
+  profil_id: string
+  innhold: string | null
+  bilde_url: string | null
+  video_url: string | null
+  opprettet: string
+}
+
+function KaaringVisning({
+  poll,
+  valg,
+  chatProfiler,
+  stemmerPerValg,
+  antallStemmere,
+  mineStemmer,
+  datoLang,
+  erAvsluttet,
+  erAdmin,
+  chatMeldinger,
+  userId,
+  kanSlette,
+}: {
+  poll: PollRad
+  valg: ValgRad[]
+  chatProfiler: ChatProfil[]
+  stemmerPerValg: Map<string, number>
+  antallStemmere: number
+  mineStemmer: string[]
+  datoLang: string
+  erAvsluttet: boolean
+  erAdmin: boolean
+  chatMeldinger: ChatMelding[]
+  userId: string
+  kanSlette: boolean
+}) {
+  // Bygg KaaringValg-liste med denormalisert kandidat-data.
+  const profilMap = new Map(chatProfiler.map(p => [p.id, p]))
+
+  // Hent også arrangement-titler for ev. arrangement-kandidater.
+  // Vi har dem ikke i propsene — kandidatens tekst-felt brukes som navn,
+  // som er forutsetningen i opprettKaaringspoll.
+  const kaaringValg: KaaringValg[] = valg.map(v => {
+    if (v.referanse_profil_id) {
+      const p = profilMap.get(v.referanse_profil_id)
+      return {
+        id: v.id,
+        navn: p?.navn ?? v.tekst,
+        bildeUrl: p?.bilde_url ?? null,
+        rolle: p?.rolle ?? null,
+        variant: 'profil',
+      }
+    }
+    return {
+      id: v.id,
+      navn: v.tekst,
+      bildeUrl: null,
+      rolle: null,
+      variant: 'arrangement',
+    }
+  })
+
+  const venterTiebreak = poll.tiebreak_status === 'venter_paa_tiebreak'
+  const erAvgjort = poll.tiebreak_status === 'avgjort'
+  const ingenStemmer = poll.avsluttet_paa !== null && antallStemmere === 0
+
+  // Vinner — velg fra valg-rad med høyest stemmetall (ved avgjort).
+  let vinner: KaaringValg | null = null
+  if (erAvgjort) {
+    let topp = 0
+    for (const v of kaaringValg) {
+      const n = stemmerPerValg.get(v.id) ?? 0
+      if (n > topp) {
+        topp = n
+        vinner = v
+      }
+    }
+    // Hvis tiebreak ble avgjort manuelt og tellingen er lik, kan vi ikke
+    // tippe vinneren her — kaaring_vinnere er kilden til sannhet. Vi
+    // viser i så fall en fallback uten banner.
+  }
+
+  return (
+    <div style={{ padding: '0 20px 120px' }}>
+      {!erAvsluttet && <PollRealtime pollId={poll.id} />}
+
+      {erAvgjort && vinner && (
+        <VinnerBanner
+          navn={vinner.navn}
+          bildeUrl={vinner.bildeUrl}
+          rolle={vinner.rolle}
+          variant={vinner.variant}
+          undertittel={`${poll.spoersmaal}`}
+        />
       )}
+
+      <header style={{ marginTop: 12, marginBottom: 22 }}>
+        <div
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 10,
+            fontWeight: 600,
+            color: 'var(--accent)',
+            letterSpacing: '1.6px',
+            textTransform: 'uppercase',
+            marginBottom: 8,
+          }}
+        >
+          Kåring · {poll.aar}
+        </div>
+        <h1
+          style={{
+            fontFamily: 'var(--font-display)',
+            fontSize: 28,
+            fontWeight: 500,
+            letterSpacing: '-0.4px',
+            lineHeight: 1.15,
+            margin: '0 0 10px',
+            color: 'var(--text-primary)',
+          }}
+        >
+          {poll.spoersmaal}
+        </h1>
+        <div
+          style={{
+            fontFamily: 'var(--font-body)',
+            fontSize: 13,
+            color: 'var(--text-secondary)',
+          }}
+        >
+          {erAvsluttet ? `Avsluttet ${datoLang}` : `Svarfrist ${datoLang}`}
+        </div>
+        {poll.arrangement_id && (
+          <div style={{ marginTop: 8 }}>
+            <Link
+              href={`/arrangementer/${poll.arrangement_id}`}
+              style={{
+                fontFamily: 'var(--font-body)',
+                fontSize: 13,
+                color: 'var(--accent)',
+                textDecoration: 'none',
+              }}
+            >
+              ← Tilbake til arrangementet
+            </Link>
+          </div>
+        )}
+      </header>
+
+      {/* Tilstandsspesifikk seksjon */}
+      {!erAvsluttet ? (
+        <section style={{ marginBottom: 24 }}>
+          <SectionLabel>Velg din kandidat</SectionLabel>
+          <KaaringPollStemming
+            pollId={poll.id}
+            valg={kaaringValg}
+            mineStemmer={mineStemmer}
+          />
+          <p
+            style={{
+              fontFamily: 'var(--font-body)',
+              fontSize: 12,
+              color: 'var(--text-tertiary)',
+              marginTop: 14,
+              fontStyle: 'italic',
+            }}
+          >
+            Stemmene er anonyme. Resultatet vises etter svarfristen.
+          </p>
+        </section>
+      ) : ingenStemmer ? (
+        <section style={{ marginBottom: 24 }}>
+          <p
+            style={{
+              fontFamily: 'var(--font-body)',
+              fontSize: 14,
+              color: 'var(--text-secondary)',
+              padding: 16,
+              border: '0.5px solid var(--border-subtle)',
+              borderRadius: 'var(--radius-card)',
+            }}
+          >
+            Ingen stemmer ble avgitt — ingen vinner kåret.
+          </p>
+        </section>
+      ) : venterTiebreak ? (
+        <section style={{ marginBottom: 24 }}>
+          {erAdmin ? (
+            <div
+              style={{
+                padding: 16,
+                border: '0.5px solid var(--accent)',
+                background: 'var(--accent-soft)',
+                borderRadius: 'var(--radius-card)',
+              }}
+            >
+              <p style={{ fontFamily: 'var(--font-body)', fontSize: 14, marginTop: 0 }}>
+                Det er likt antall stemmer på topp. Du må velge vinneren.
+              </p>
+              <Link
+                href={`/kaaringspoll/${poll.id}/tiebreak`}
+                style={{
+                  display: 'inline-block',
+                  marginTop: 8,
+                  padding: '10px 18px',
+                  background: 'var(--accent)',
+                  color: '#0a0a0a',
+                  borderRadius: 999,
+                  fontFamily: 'var(--font-body)',
+                  fontSize: 14,
+                  fontWeight: 600,
+                  textDecoration: 'none',
+                }}
+              >
+                Velg vinner
+              </Link>
+            </div>
+          ) : (
+            <p
+              style={{
+                fontFamily: 'var(--font-body)',
+                fontSize: 14,
+                color: 'var(--text-secondary)',
+                padding: 16,
+                border: '0.5px solid var(--border-subtle)',
+                borderRadius: 'var(--radius-card)',
+              }}
+            >
+              Det ble likt — generalsekretær bestemmer nå.
+            </p>
+          )}
+        </section>
+      ) : erAdmin ? (
+        // Avgjort, admin/generalsekretær: vis stemmefordeling
+        <section style={{ marginBottom: 24 }}>
+          <SectionLabel count={antallStemmere}>Stemmefordeling</SectionLabel>
+          <PollResultat
+            valg={valg}
+            stemmerPerValg={stemmerPerValg}
+            antallStemmere={antallStemmere}
+            mineStemmer={mineStemmer}
+          />
+          <p
+            style={{
+              fontFamily: 'var(--font-body)',
+              fontSize: 11,
+              color: 'var(--text-tertiary)',
+              marginTop: 8,
+              fontStyle: 'italic',
+            }}
+          >
+            Kun synlig for admin og generalsekretær.
+          </p>
+        </section>
+      ) : null /* Vanlige medlemmer ser bare vinnerbanneret */}
+
+      <div id="kommentarer">
+        <Chat
+          scope={{ type: 'poll', pollId: poll.id }}
+          brukerId={userId}
+          erAdmin={erAdmin}
+          initialMeldinger={[...chatMeldinger].reverse()}
+          profiler={chatProfiler}
+        />
+      </div>
+
+      {kanSlette && <SlettPollKnapp pollId={poll.id} />}
     </div>
   )
 }

--- a/app/(app)/poll/[id]/page.tsx
+++ b/app/(app)/poll/[id]/page.tsx
@@ -76,6 +76,21 @@ export default async function PollDetalj({
 
   if (!poll) notFound()
 
+  // Vinner hentes fra kaaring_vinnere (lesbar for alle, RLS skjuler stemmer
+  // for vanlige medlemmer så vi kan ikke utlede vinner fra stemmetall i
+  // klienten). Tabellen er kilden til sannhet — RPC eller manuell tiebreak
+  // skriver dit.
+  let vinnerRad: { profil_id: string | null; arrangement_id: string | null } | null = null
+  if (poll.kaaring_mal_id && poll.aar !== null) {
+    const { data: v } = await supabase
+      .from('kaaring_vinnere')
+      .select('profil_id, arrangement_id')
+      .eq('mal_id', poll.kaaring_mal_id)
+      .eq('aar', poll.aar)
+      .maybeSingle()
+    vinnerRad = v ?? null
+  }
+
   const erAvsluttet = new Date(poll.svarfrist) <= new Date() || poll.avsluttet_paa !== null
   const erAdmin = kanAdministrere(profil?.rolle)
   const kanSlette = poll.opprettet_av === user!.id || erAdmin
@@ -113,6 +128,7 @@ export default async function PollDetalj({
         chatMeldinger={chatMeldinger ?? []}
         userId={user!.id}
         kanSlette={kanSlette}
+        vinnerRad={vinnerRad}
       />
     )
   }
@@ -240,6 +256,7 @@ function KaaringVisning({
   chatMeldinger,
   userId,
   kanSlette,
+  vinnerRad,
 }: {
   poll: PollRad
   valg: ValgRad[]
@@ -253,6 +270,7 @@ function KaaringVisning({
   chatMeldinger: ChatMelding[]
   userId: string
   kanSlette: boolean
+  vinnerRad: { profil_id: string | null; arrangement_id: string | null } | null
 }) {
   // Bygg KaaringValg-liste med denormalisert kandidat-data.
   const profilMap = new Map(chatProfiler.map(p => [p.id, p]))
@@ -284,20 +302,24 @@ function KaaringVisning({
   const erAvgjort = poll.tiebreak_status === 'avgjort'
   const ingenStemmer = poll.avsluttet_paa !== null && antallStemmere === 0
 
-  // Vinner — velg fra valg-rad med høyest stemmetall (ved avgjort).
+  // Vinner — utledes fra kaaring_vinnere (kilden til sannhet). Vi kan ikke
+  // bruke stemmer-aggregatet siden RLS skjuler andres stemmer for vanlige
+  // medlemmer. Vinneren er enten en profil-kandidat eller en arrangement-
+  // kandidat; vi finner riktig poll_valg-rad og bruker den til
+  // banner-rendering, slik at navn/bilde/rolle blir konsistente.
   let vinner: KaaringValg | null = null
-  if (erAvgjort) {
-    let topp = 0
-    for (const v of kaaringValg) {
-      const n = stemmerPerValg.get(v.id) ?? 0
-      if (n > topp) {
-        topp = n
-        vinner = v
-      }
+  if (erAvgjort && vinnerRad) {
+    if (vinnerRad.profil_id) {
+      vinner =
+        kaaringValg.find(
+          v => valg.find(r => r.id === v.id)?.referanse_profil_id === vinnerRad.profil_id,
+        ) ?? null
+    } else if (vinnerRad.arrangement_id) {
+      vinner =
+        kaaringValg.find(
+          v => valg.find(r => r.id === v.id)?.referanse_arrangement_id === vinnerRad.arrangement_id,
+        ) ?? null
     }
-    // Hvis tiebreak ble avgjort manuelt og tellingen er lik, kan vi ikke
-    // tippe vinneren her — kaaring_vinnere er kilden til sannhet. Vi
-    // viser i så fall en fallback uten banner.
   }
 
   return (

--- a/app/(app)/poll/[id]/page.tsx
+++ b/app/(app)/poll/[id]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { createServerClient } from '@/lib/supabase/server'
 import { getInnloggetBruker, getProfil } from '@/lib/auth-cache'
-import { kanAdministrere } from '@/lib/roller'
+import { kanAdministrere, loeserTiebreak } from '@/lib/roller'
 import { formaterDato } from '@/lib/dato'
 import SectionLabel from '@/components/ui/SectionLabel'
 import PollStemming from '@/components/poll/PollStemming'
@@ -93,6 +93,7 @@ export default async function PollDetalj({
 
   const erAvsluttet = new Date(poll.svarfrist) <= new Date() || poll.avsluttet_paa !== null
   const erAdmin = kanAdministrere(profil?.rolle)
+  const kanLoeseTiebreak = loeserTiebreak(profil?.rolle)
   const kanSlette = poll.opprettet_av === user!.id || erAdmin
   const erKaaring = poll.kaaring_mal_id !== null
 
@@ -128,6 +129,7 @@ export default async function PollDetalj({
         chatMeldinger={chatMeldinger ?? []}
         userId={user!.id}
         kanSlette={kanSlette}
+        kanLoeseTiebreak={kanLoeseTiebreak}
         vinnerRad={vinnerRad}
       />
     )
@@ -256,6 +258,7 @@ function KaaringVisning({
   chatMeldinger,
   userId,
   kanSlette,
+  kanLoeseTiebreak,
   vinnerRad,
 }: {
   poll: PollRad
@@ -270,6 +273,7 @@ function KaaringVisning({
   chatMeldinger: ChatMelding[]
   userId: string
   kanSlette: boolean
+  kanLoeseTiebreak: boolean
   vinnerRad: { profil_id: string | null; arrangement_id: string | null } | null
 }) {
   // Bygg KaaringValg-liste med denormalisert kandidat-data.
@@ -427,7 +431,7 @@ function KaaringVisning({
         </section>
       ) : venterTiebreak ? (
         <section style={{ marginBottom: 24 }}>
-          {erAdmin ? (
+          {kanLoeseTiebreak ? (
             <div
               style={{
                 padding: 16,

--- a/app/(app)/poll/[id]/page.tsx
+++ b/app/(app)/poll/[id]/page.tsx
@@ -304,7 +304,17 @@ function KaaringVisning({
 
   const venterTiebreak = poll.tiebreak_status === 'venter_paa_tiebreak'
   const erAvgjort = poll.tiebreak_status === 'avgjort'
-  const ingenStemmer = poll.avsluttet_paa !== null && antallStemmere === 0
+  // RLS skjuler andres stemmer for vanlige medlemmer, så `antallStemmere`
+  // er ikke en pålitelig indikator alene. Vi vet det var stemmer dersom
+  // det finnes en vinner eller poll-en venter på tiebreak. "Ingen stemmer"
+  // er kun riktig når avsluttet, ingen vinner registrert, ingen tiebreak,
+  // OG vi heller ikke ser noen stemmer selv.
+  const ingenStemmer =
+    poll.avsluttet_paa !== null &&
+    !erAvgjort &&
+    !venterTiebreak &&
+    vinnerRad === null &&
+    antallStemmere === 0
 
   // Vinner — utledes fra kaaring_vinnere (kilden til sannhet). Vi kan ikke
   // bruke stemmer-aggregatet siden RLS skjuler andres stemmer for vanlige
@@ -476,8 +486,11 @@ function KaaringVisning({
             </p>
           )}
         </section>
-      ) : erAdmin ? (
-        // Avgjort, admin/generalsekretær: vis stemmefordeling
+      ) : erAdmin && poll.avsluttet_paa !== null ? (
+        // Avgjort, admin/generalsekretær: vis stemmefordeling.
+        // Gates eksplisitt på `avsluttet_paa` slik at admin ikke ser
+        // RLS-filtrert (kun egne) stemmer i vinduet mellom svarfrist
+        // passert og cron-kjøringen som setter avsluttet_paa.
         <section style={{ marginBottom: 24 }}>
           <SectionLabel count={antallStemmere}>Stemmefordeling</SectionLabel>
           <PollResultat

--- a/app/api/cron/paaminne/route.ts
+++ b/app/api/cron/paaminne/route.ts
@@ -9,8 +9,11 @@ async function handle(req: NextRequest) {
   }
 
   const admin = createAdminClient()
-  const { behandlet, feil } = await kjorPaaminnelser(admin)
-  return NextResponse.json({ ok: true, behandlet, feil })
+  const result = await kjorPaaminnelser(admin)
+  // Returner 500 hvis noe feilet — synliggjør cron-feil i GitHub Actions-loggen
+  // i stedet for å skjule dem bak en 200.
+  const status = result.feil > 0 ? 500 : 200
+  return NextResponse.json({ ok: result.feil === 0, ...result }, { status })
 }
 
 // Vercel Cron sender GET-requests

--- a/components/agenda/NyFAB.tsx
+++ b/components/agenda/NyFAB.tsx
@@ -12,20 +12,28 @@ type Valg = {
 
 // De fire typene element som kan opprettes på agenda. Speiler typene
 // definert i lib/agenda-sortering.ts (Møte/Tur er underkategorier av
-// arrangement, Poll og Melding er egne tabeller).
-const VALG: Valg[] = [
+// arrangement, Poll og Melding er egne tabeller). «Kåring» legges på
+// kun for admin/generalsekretær (#87).
+const BASIS_VALG: Valg[] = [
   { label: 'Møte', href: '/arrangementer/ny?type=moete', ikon: 'calendar' },
   { label: 'Tur', href: '/arrangementer/ny?type=tur', ikon: 'plane' },
   { label: 'Poll', href: '/poll/ny', ikon: 'chart' },
   { label: 'Melding', href: '/meldinger/ny', ikon: 'message' },
 ]
 
+const KAARING_VALG: Valg = {
+  label: 'Kåring',
+  href: '/kaaringspoll/ny',
+  ikon: 'trophy',
+}
+
 /**
  * Plussknapp i agenda-header som ekspanderer til en meny med valg av
  * hva slags nytt element som skal opprettes. Lukkes ved klikk utenfor
  * eller ved å trykke knappen igjen. Esc er ikke støttet — mobil først.
  */
-export default function NyFAB() {
+export default function NyFAB({ kanAdministrere = false }: { kanAdministrere?: boolean }) {
+  const VALG = kanAdministrere ? [...BASIS_VALG, KAARING_VALG] : BASIS_VALG
   const [apen, setApen] = useState(false)
   const wrapperRef = useRef<HTMLDivElement>(null)
 

--- a/components/poll/KaaringKandidat.tsx
+++ b/components/poll/KaaringKandidat.tsx
@@ -1,0 +1,45 @@
+import Avatar from '@/components/ui/Avatar'
+import Icon from '@/components/ui/Icon'
+
+// Lokal wrapper rundt Avatar — viser enten medlem (med bilde + initialer)
+// eller arrangement (med møte-ikon). Holder Avatar-komponenten enkel
+// (jf. CLAUDE.md «Policy: Avatar») ved å pakke arrangement-varianten her.
+
+type Props = {
+  navn: string
+  bildeUrl?: string | null
+  rolle?: string | null
+  variant: 'profil' | 'arrangement'
+  size?: number
+}
+
+export default function KaaringKandidat({
+  navn,
+  bildeUrl,
+  rolle,
+  variant,
+  size = 44,
+}: Props) {
+  if (variant === 'profil') {
+    return <Avatar name={navn} src={bildeUrl} rolle={rolle} size={size} />
+  }
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        background: 'var(--bg-elevated)',
+        border: '0.5px solid var(--border)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: 'var(--accent)',
+        flexShrink: 0,
+      }}
+    >
+      <Icon name="calendar" size={Math.round(size * 0.5)} color="var(--accent)" />
+    </div>
+  )
+}

--- a/components/poll/KaaringPollStemming.tsx
+++ b/components/poll/KaaringPollStemming.tsx
@@ -1,0 +1,139 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { stemPaaPoll } from '@/lib/actions/poll'
+import KaaringKandidat from './KaaringKandidat'
+
+export type KaaringValg = {
+  id: string
+  navn: string
+  bildeUrl?: string | null
+  rolle?: string | null
+  variant: 'profil' | 'arrangement'
+}
+
+type Props = {
+  pollId: string
+  valg: KaaringValg[]
+  mineStemmer: string[] // valg-id-er jeg har stemt på (max 1 — kåring er enkeltvalg)
+}
+
+export default function KaaringPollStemming({ pollId, valg, mineStemmer }: Props) {
+  const initial = mineStemmer[0] ?? ''
+  const [valgt, setValgt] = useState<string>(initial)
+  const [feil, setFeil] = useState('')
+  const [isPending, startTransition] = useTransition()
+  const router = useRouter()
+
+  function handleStem() {
+    setFeil('')
+    if (!valgt) {
+      setFeil('Velg en kandidat.')
+      return
+    }
+    startTransition(async () => {
+      try {
+        await stemPaaPoll(pollId, [valgt])
+        router.refresh()
+      } catch (err) {
+        setFeil(err instanceof Error ? err.message : 'Kunne ikke registrere stemmen.')
+      }
+    })
+  }
+
+  const harEndret = valgt !== initial
+
+  return (
+    <div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+        {valg.map(v => {
+          const erValgt = valgt === v.id
+          return (
+            <button
+              key={v.id}
+              type="button"
+              onClick={() => setValgt(v.id)}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 14,
+                padding: '12px 14px',
+                border: `1px solid ${erValgt ? 'var(--accent)' : 'var(--border)'}`,
+                borderRadius: 'var(--radius-card)',
+                background: erValgt ? 'var(--accent-soft)' : 'transparent',
+                color: 'var(--text-primary)',
+                fontFamily: 'var(--font-body)',
+                fontSize: 15,
+                textAlign: 'left',
+                cursor: 'pointer',
+                transition: 'background 120ms, border-color 120ms',
+              }}
+            >
+              <KaaringKandidat
+                navn={v.navn}
+                bildeUrl={v.bildeUrl}
+                rolle={v.rolle}
+                variant={v.variant}
+                size={40}
+              />
+              <span style={{ flex: 1, fontWeight: erValgt ? 600 : 400 }}>{v.navn}</span>
+              <span
+                aria-hidden="true"
+                style={{
+                  width: 18,
+                  height: 18,
+                  borderRadius: '50%',
+                  border: `1.5px solid ${erValgt ? 'var(--accent)' : 'var(--border-strong)'}`,
+                  background: erValgt ? 'var(--accent)' : 'transparent',
+                  flexShrink: 0,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                {erValgt && (
+                  <span
+                    style={{
+                      width: 8,
+                      height: 8,
+                      borderRadius: '50%',
+                      background: '#0a0a0a',
+                    }}
+                  />
+                )}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+
+      {feil && (
+        <p style={{ fontSize: 13, color: 'var(--danger)', marginTop: 12 }}>{feil}</p>
+      )}
+
+      <button
+        type="button"
+        onClick={handleStem}
+        disabled={isPending || !harEndret}
+        style={{
+          display: 'block',
+          width: '100%',
+          marginTop: 16,
+          padding: '12px 0',
+          background: 'var(--accent)',
+          color: '#0a0a0a',
+          border: 'none',
+          borderRadius: 999,
+          fontFamily: 'var(--font-body)',
+          fontSize: 14,
+          fontWeight: 600,
+          cursor: isPending || !harEndret ? 'default' : 'pointer',
+          opacity: isPending || !harEndret ? 0.5 : 1,
+        }}
+      >
+        {isPending ? 'Lagrer…' : initial ? 'Oppdater stemme' : 'Stem'}
+      </button>
+    </div>
+  )
+}

--- a/components/poll/VinnerBanner.tsx
+++ b/components/poll/VinnerBanner.tsx
@@ -1,0 +1,78 @@
+import KaaringKandidat from './KaaringKandidat'
+
+type Props = {
+  navn: string
+  bildeUrl?: string | null
+  rolle?: string | null
+  variant: 'profil' | 'arrangement'
+  undertittel?: string
+}
+
+// Sticky-top vinnerbanner for avgjort kåringspoll.
+export default function VinnerBanner({ navn, bildeUrl, rolle, variant, undertittel }: Props) {
+  return (
+    <div
+      style={{
+        position: 'sticky',
+        top: 0,
+        zIndex: 5,
+        margin: '0 -20px 24px',
+        padding: '18px 20px',
+        background: 'var(--accent-soft)',
+        borderBottom: '0.5px solid var(--border)',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 14,
+      }}
+    >
+      <KaaringKandidat
+        navn={navn}
+        bildeUrl={bildeUrl}
+        rolle={rolle}
+        variant={variant}
+        size={56}
+      />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 9.5,
+            fontWeight: 600,
+            color: 'var(--accent)',
+            letterSpacing: '1.6px',
+            textTransform: 'uppercase',
+            marginBottom: 4,
+          }}
+        >
+          Vinner
+        </div>
+        <div
+          style={{
+            fontFamily: 'var(--font-display)',
+            fontSize: 22,
+            fontWeight: 500,
+            color: 'var(--text-primary)',
+            letterSpacing: '-0.3px',
+            lineHeight: 1.15,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {navn}
+        </div>
+        {undertittel && (
+          <div
+            style={{
+              fontFamily: 'var(--font-body)',
+              fontSize: 12,
+              color: 'var(--text-secondary)',
+              marginTop: 2,
+            }}
+          >
+            {undertittel}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/lib/actions/kaaringspoll.ts
+++ b/lib/actions/kaaringspoll.ts
@@ -1,0 +1,207 @@
+'use server'
+
+import { ensureAdmin } from '@/lib/auth'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
+import {
+  sendKaaringspollOpprettetVarsel,
+  sendKaaringspollVinnerVarsel,
+} from '@/lib/varsler'
+import { kanAdministrere } from '@/lib/roller'
+
+type OpprettInput = {
+  kaaringMalId: string
+  aar: number
+  svarfrist: string // ISO UTC
+  arrangementId?: string | null
+}
+
+/**
+ * Oppretter en kåringspoll for gitt mal + år. Henter `kandidat_kilde` fra
+ * malen og bygger valg-listen automatisk:
+ *   - 'profil':            alle aktive medlemmer
+ *   - 'arrangement_moete': årets møter (type='moete' med start_tidspunkt
+ *                          innenfor kalenderåret etter norsk tid)
+ *
+ * Krever admin/generalsekretær — RLS dobbeltsjekker via 073.
+ */
+export async function opprettKaaringspoll(input: OpprettInput) {
+  const { user } = await ensureAdmin()
+  const admin = createAdminClient()
+
+  const frist = new Date(input.svarfrist)
+  if (Number.isNaN(frist.getTime()) || frist.getTime() <= Date.now()) {
+    throw new Error('Svarfristen må være i fremtiden')
+  }
+  if (!Number.isInteger(input.aar) || input.aar < 2000 || input.aar > 2100) {
+    throw new Error('Ugyldig år')
+  }
+
+  const { data: mal, error: malErr } = await admin
+    .from('kaaringmaler')
+    .select('id, navn, kandidat_kilde')
+    .eq('id', input.kaaringMalId)
+    .single()
+  if (malErr || !mal) throw new Error('Kåringsmal finnes ikke')
+
+  const kilde = (mal as { kandidat_kilde: string }).kandidat_kilde
+
+  // Bygg kandidat-rader.
+  type Kandidat = {
+    tekst: string
+    referanse_profil_id?: string
+    referanse_arrangement_id?: string
+  }
+  const kandidater: Kandidat[] = []
+
+  if (kilde === 'profil') {
+    const { data: medlemmer } = await admin
+      .from('profiles')
+      .select('id, navn')
+      .eq('aktiv', true)
+      .order('navn')
+    for (const m of medlemmer ?? []) {
+      if (!m.navn) continue
+      kandidater.push({ tekst: m.navn, referanse_profil_id: m.id })
+    }
+  } else if (kilde === 'arrangement_moete') {
+    // Et møte tilhører året hvis start_tidspunkt faller innenfor
+    // kalenderåret. Vi bruker UTC-grenser for query — det er noen
+    // timers slingring men tilstrekkelig for vårt bruk (et møte
+    // 31. desember kl 23:30 norsk tid telles ikke som neste år).
+    const fra = `${input.aar}-01-01T00:00:00Z`
+    const til = `${input.aar + 1}-01-01T00:00:00Z`
+    const { data: arr } = await admin
+      .from('arrangementer')
+      .select('id, tittel, start_tidspunkt')
+      .eq('type', 'moete')
+      .gte('start_tidspunkt', fra)
+      .lt('start_tidspunkt', til)
+      .order('start_tidspunkt')
+    for (const a of arr ?? []) {
+      kandidater.push({ tekst: a.tittel, referanse_arrangement_id: a.id })
+    }
+  } else {
+    throw new Error(`Ukjent kandidat_kilde: ${kilde}`)
+  }
+
+  if (kandidater.length < 2) {
+    throw new Error(
+      `Trenger minst 2 kandidater (fant ${kandidater.length}). ` +
+        `Sjekk at det finnes nok ${kilde === 'profil' ? 'aktive medlemmer' : 'møter'}.`,
+    )
+  }
+
+  const spoersmaal = `${(mal as { navn: string }).navn} ${input.aar}`
+
+  const { data: poll, error: pollErr } = await admin
+    .from('poll')
+    .insert({
+      spoersmaal,
+      svarfrist: frist.toISOString(),
+      flervalg: false,
+      opprettet_av: user.id,
+      kaaring_mal_id: input.kaaringMalId,
+      aar: input.aar,
+      arrangement_id: input.arrangementId ?? null,
+    })
+    .select('id')
+    .single()
+  if (pollErr || !poll) throw new Error(pollErr?.message ?? 'Kunne ikke opprette poll')
+
+  const valgRader = kandidater.map((k, i) => ({
+    poll_id: poll.id,
+    tekst: k.tekst,
+    rekkefoelge: i,
+    referanse_profil_id: k.referanse_profil_id ?? null,
+    referanse_arrangement_id: k.referanse_arrangement_id ?? null,
+  }))
+
+  const { error: valgErr } = await admin.from('poll_valg').insert(valgRader)
+  if (valgErr) {
+    await admin.from('poll').delete().eq('id', poll.id)
+    throw new Error(valgErr.message)
+  }
+
+  await sendKaaringspollOpprettetVarsel({
+    pollId: poll.id,
+    spoersmaal,
+    svarfrist: frist.toISOString(),
+  }).catch(console.error)
+
+  revalidatePath('/')
+  revalidatePath('/kaaringer')
+  redirect(`/poll/${poll.id}`)
+}
+
+/**
+ * Generalsekretær velger vinner ved tiebreak. Validerer at pollen faktisk
+ * venter på avgjørelse, henter referansen fra valg-raden, skriver til
+ * kaaring_vinnere og sender ett vinner-varsel.
+ */
+export async function velgTiebreakVinner(pollId: string, valgId: string) {
+  const { user, profil } = await ensureAdmin()
+  const admin = createAdminClient()
+
+  const { data: poll } = await admin
+    .from('poll')
+    .select('id, spoersmaal, kaaring_mal_id, aar, tiebreak_status')
+    .eq('id', pollId)
+    .single()
+  if (!poll) throw new Error('Pollen finnes ikke')
+  if (!poll.kaaring_mal_id) throw new Error('Ikke en kåringspoll')
+  if (poll.tiebreak_status !== 'venter_paa_tiebreak') {
+    throw new Error('Pollen venter ikke på tiebreak')
+  }
+  if (poll.aar === null) throw new Error('Kåringspoll mangler årstall')
+
+  const { data: valg } = await admin
+    .from('poll_valg')
+    .select('id, referanse_profil_id, referanse_arrangement_id')
+    .eq('id', valgId)
+    .eq('poll_id', pollId)
+    .single()
+  if (!valg) throw new Error('Ugyldig valg')
+
+  // Sanity: profil eller arrangement, ikke ingen.
+  if (!valg.referanse_profil_id && !valg.referanse_arrangement_id) {
+    throw new Error('Valget mangler kandidatreferanse')
+  }
+  // ensureAdmin ga oss profil — bruk den hvis admin-sjekken vil bygges ut.
+  void profil
+
+  const { error: vinnerErr } = await admin
+    .from('kaaring_vinnere')
+    .insert({
+      mal_id: poll.kaaring_mal_id,
+      aar: poll.aar,
+      profil_id: valg.referanse_profil_id,
+      arrangement_id: valg.referanse_arrangement_id,
+      opprettet_av: user.id,
+      poll_id: poll.id,
+    })
+  // Hvis manuell vinner allerede er satt (race), unique-constraint slår
+  // inn. Da hopper vi over insert men markerer fortsatt pollen avgjort.
+  if (vinnerErr && !vinnerErr.message.toLowerCase().includes('duplicate')) {
+    throw new Error(vinnerErr.message)
+  }
+
+  const { error: oppdErr } = await admin
+    .from('poll')
+    .update({ tiebreak_status: 'avgjort' })
+    .eq('id', pollId)
+  if (oppdErr) throw new Error(oppdErr.message)
+
+  await sendKaaringspollVinnerVarsel({
+    pollId: poll.id,
+    spoersmaal: poll.spoersmaal,
+  }).catch(console.error)
+
+  revalidatePath(`/poll/${pollId}`)
+  revalidatePath('/kaaringer')
+  redirect(`/poll/${pollId}`)
+}
+
+// Eksportert kun for typesjekk i kall-stedet — voider unused-varselet.
+export type _RoleSjekk = typeof kanAdministrere

--- a/lib/actions/kaaringspoll.ts
+++ b/lib/actions/kaaringspoll.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { ensureAdmin } from '@/lib/auth'
+import { ensureAdmin, ensureLoeserTiebreak } from '@/lib/auth'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
@@ -141,7 +141,7 @@ export async function opprettKaaringspoll(input: OpprettInput) {
  * kaaring_vinnere og sender ett vinner-varsel.
  */
 export async function velgTiebreakVinner(pollId: string, valgId: string) {
-  const { user, profil } = await ensureAdmin()
+  const { user, profil } = await ensureLoeserTiebreak()
   const admin = createAdminClient()
 
   const { data: poll } = await admin

--- a/lib/actions/paaminnelser.ts
+++ b/lib/actions/paaminnelser.ts
@@ -1,5 +1,5 @@
 import { addDays } from 'date-fns'
-import { norskDatoNaa } from '@/lib/dato'
+import { norskDatoNaa, naa } from '@/lib/dato'
 import {
   sendPaaminneVarsler,
   sendPurringVarsler,
@@ -109,16 +109,17 @@ async function behandleKaaringspoller(admin: Admin) {
     .select('id, spoersmaal')
     .not('kaaring_mal_id', 'is', null)
     .is('avsluttet_paa', null)
-    .lt('svarfrist', new Date().toISOString())
+    .lt('svarfrist', naa())
 
   if (!aapne || aapne.length === 0) {
     return { lukketKaaringer, sendteVarsler, kaaringFeil }
   }
 
-  // Profiler som skal varsles ved tiebreak — typisk generalsekretær.
-  // Vi bruker faarIssueVarsler-rettigheten (admin + generalsekretær) som
-  // proxy: alle som har den får også tiebreak-varsel. Generalsekretær
-  // har den per definisjon false i dag, så vi bytter til kanAdministrere.
+  // Mottakere av tiebreak- og ingen-stemmer-varsel: alle med
+  // admin-rettigheter (admin + generalsekretær). Hvorvidt det burde
+  // begrenses til kun generalsekretær er en åpen produkt-beslutning —
+  // se PR-kommentar #87. Hvis det skal smalne, lag rettighet
+  // `loeserTiebreak` i lib/roller.ts og bruk den her i stedet.
   const adminRoller = rollerMed('kanAdministrere')
   const { data: adminProfiler } = await admin
     .from('profiles')

--- a/lib/actions/paaminnelser.ts
+++ b/lib/actions/paaminnelser.ts
@@ -115,18 +115,26 @@ async function behandleKaaringspoller(admin: Admin) {
     return { lukketKaaringer, sendteVarsler, kaaringFeil }
   }
 
-  // Mottakere av tiebreak- og ingen-stemmer-varsel: alle med
-  // admin-rettigheter (admin + generalsekretær). Hvorvidt det burde
-  // begrenses til kun generalsekretær er en åpen produkt-beslutning —
-  // se PR-kommentar #87. Hvis det skal smalne, lag rettighet
-  // `loeserTiebreak` i lib/roller.ts og bruk den her i stedet.
+  // To ulike mottaker-grupper:
+  //  - Tiebreak-varsel: kun de som faktisk skal løse den (generalsekretær).
+  //    Det er han som har siste ord ved likt antall stemmer — admin-flokken
+  //    skal ikke pinges på et valg de ikke kan ta.
+  //  - Ingen-stemmer-varsel: går til alle med admin-rettigheter, fordi
+  //    dette er ren info om at en kåring ble avlyst og bør følges opp.
+  const tiebreakRoller = rollerMed('loeserTiebreak')
   const adminRoller = rollerMed('kanAdministrere')
-  const { data: adminProfiler } = await admin
+  const trengteRoller = Array.from(new Set([...tiebreakRoller, ...adminRoller]))
+  const { data: relevanteProfiler } = await admin
     .from('profiles')
-    .select('id')
-    .in('rolle', adminRoller)
+    .select('id, rolle')
+    .in('rolle', trengteRoller)
     .eq('aktiv', true)
-  const adminIder = (adminProfiler ?? []).map(p => p.id)
+  const tiebreakIder = (relevanteProfiler ?? [])
+    .filter(p => tiebreakRoller.includes(p.rolle as (typeof tiebreakRoller)[number]))
+    .map(p => p.id)
+  const adminIder = (relevanteProfiler ?? [])
+    .filter(p => adminRoller.includes(p.rolle as (typeof adminRoller)[number]))
+    .map(p => p.id)
 
   for (const poll of aapne) {
     try {
@@ -151,11 +159,11 @@ async function behandleKaaringspoller(admin: Admin) {
         })
         sendteVarsler += 1
       } else if (status === 'venter_paa_tiebreak') {
-        if (adminIder.length > 0) {
+        if (tiebreakIder.length > 0) {
           await sendKaaringspollTiebreakVarsel({
             pollId: poll.id,
             spoersmaal: poll.spoersmaal,
-            mottakere: adminIder,
+            mottakere: tiebreakIder,
           })
           sendteVarsler += 1
         }

--- a/lib/actions/paaminnelser.ts
+++ b/lib/actions/paaminnelser.ts
@@ -1,7 +1,15 @@
 import { addDays } from 'date-fns'
 import { norskDatoNaa } from '@/lib/dato'
-import { sendPaaminneVarsler, sendPurringVarsler, sendArrangorPurringVarsler } from '@/lib/varsler'
+import {
+  sendPaaminneVarsler,
+  sendPurringVarsler,
+  sendArrangorPurringVarsler,
+  sendKaaringspollVinnerVarsel,
+  sendKaaringspollTiebreakVarsel,
+  sendKaaringspollIngenStemmerVarsel,
+} from '@/lib/varsler'
 import { PAAMINNELSE_DAGER } from '@/lib/konstanter'
+import { rollerMed } from '@/lib/roller'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import type { Database } from '@/lib/supabase/database.types'
 
@@ -76,7 +84,94 @@ export async function kjorPaaminnelser(admin: Admin) {
   const behandlet = utfall
     .filter((r): r is PromiseFulfilledResult<{ id: string; type: string }> => r.status === 'fulfilled')
     .map(r => r.value)
-  const feil = utfall.filter(r => r.status === 'rejected').length
+  let feil = utfall.filter(r => r.status === 'rejected').length
 
-  return { behandlet, feil }
+  // ─── Kåringspoll: lukk de som har passert frist ───────────────────────────
+  // RPC-en avslutt_kaaringspoll er idempotent, så å kjøre den hver dag på
+  // samme poll er trygt — den returnerer var_ny=false andre gang. Status-
+  // verdien styrer hvilket varsel vi sender.
+  const { lukketKaaringer, sendteVarsler, kaaringFeil } =
+    await behandleKaaringspoller(admin)
+  feil += kaaringFeil
+
+  return { behandlet, feil, lukketKaaringer, sendteVarsler }
+}
+
+async function behandleKaaringspoller(admin: Admin) {
+  let lukketKaaringer = 0
+  let sendteVarsler = 0
+  let kaaringFeil = 0
+
+  // Hent åpne kåringspoller med utløpt frist. partial-indexen
+  // poll_kaaring_aapne dekker dette filteret presist.
+  const { data: aapne } = await admin
+    .from('poll')
+    .select('id, spoersmaal')
+    .not('kaaring_mal_id', 'is', null)
+    .is('avsluttet_paa', null)
+    .lt('svarfrist', new Date().toISOString())
+
+  if (!aapne || aapne.length === 0) {
+    return { lukketKaaringer, sendteVarsler, kaaringFeil }
+  }
+
+  // Profiler som skal varsles ved tiebreak — typisk generalsekretær.
+  // Vi bruker faarIssueVarsler-rettigheten (admin + generalsekretær) som
+  // proxy: alle som har den får også tiebreak-varsel. Generalsekretær
+  // har den per definisjon false i dag, så vi bytter til kanAdministrere.
+  const adminRoller = rollerMed('kanAdministrere')
+  const { data: adminProfiler } = await admin
+    .from('profiles')
+    .select('id')
+    .in('rolle', adminRoller)
+    .eq('aktiv', true)
+  const adminIder = (adminProfiler ?? []).map(p => p.id)
+
+  for (const poll of aapne) {
+    try {
+      const { data: rpcRes, error: rpcErr } = await admin.rpc(
+        'avslutt_kaaringspoll',
+        { p_poll_id: poll.id },
+      )
+      if (rpcErr) {
+        kaaringFeil += 1
+        continue
+      }
+      const rad = Array.isArray(rpcRes) ? rpcRes[0] : rpcRes
+      if (!rad || !rad.var_ny) continue
+
+      lukketKaaringer += 1
+      const status = rad.status as string
+
+      if (status === 'avgjort') {
+        await sendKaaringspollVinnerVarsel({
+          pollId: poll.id,
+          spoersmaal: poll.spoersmaal,
+        })
+        sendteVarsler += 1
+      } else if (status === 'venter_paa_tiebreak') {
+        if (adminIder.length > 0) {
+          await sendKaaringspollTiebreakVarsel({
+            pollId: poll.id,
+            spoersmaal: poll.spoersmaal,
+            mottakere: adminIder,
+          })
+          sendteVarsler += 1
+        }
+      } else if (status === 'ingen_stemmer') {
+        if (adminIder.length > 0) {
+          await sendKaaringspollIngenStemmerVarsel({
+            pollId: poll.id,
+            spoersmaal: poll.spoersmaal,
+            mottakere: adminIder,
+          })
+          sendteVarsler += 1
+        }
+      }
+    } catch {
+      kaaringFeil += 1
+    }
+  }
+
+  return { lukketKaaringer, sendteVarsler, kaaringFeil }
 }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,5 +1,5 @@
 import { createServerClient } from '@/lib/supabase/server'
-import { kanAdministrere } from '@/lib/roller'
+import { kanAdministrere, loeserTiebreak } from '@/lib/roller'
 
 // Sentral autorisasjons-helper for server actions og route handlers.
 // Bruk denne i stedet for å duplisere "hent user → hent profil → sjekk
@@ -22,6 +22,28 @@ export async function ensureAdmin() {
     .single()
 
   if (!kanAdministrere(profil?.rolle)) throw new Error('Ikke admin')
+
+  return { supabase, user, profil }
+}
+
+// Variant for handlinger som kun generalsekretær (eller andre roller med
+// `loeserTiebreak`-rettighet) skal kunne gjøre — i praksis: avgjøre
+// kåringspoller som endte uavgjort. Admin har ikke denne tilgangen,
+// selv om de ellers har full CRUD i appen.
+export async function ensureLoeserTiebreak() {
+  const supabase = await createServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) throw new Error('Ikke innlogget')
+
+  const { data: profil } = await supabase
+    .from('profiles')
+    .select('rolle')
+    .eq('id', user.id)
+    .single()
+
+  if (!loeserTiebreak(profil?.rolle)) throw new Error('Kun generalsekretær kan løse tiebreak')
 
   return { supabase, user, profil }
 }

--- a/lib/roller.ts
+++ b/lib/roller.ts
@@ -22,6 +22,8 @@ export type Rettigheter = {
   faarIssueVarsler: boolean
   /** Spesiell gul glød rundt profilbildet */
   harGulGloed: boolean
+  /** Løser tiebreak når en kåringspoll ender uavgjort */
+  loeserTiebreak: boolean
 }
 
 export const ROLLER: Record<Rolle, Rettigheter> = {
@@ -30,18 +32,21 @@ export const ROLLER: Record<Rolle, Rettigheter> = {
     kanAdministrere: false,
     faarIssueVarsler: false,
     harGulGloed: false,
+    loeserTiebreak: false,
   },
   admin: {
     tittel: 'Admin',
     kanAdministrere: true,
     faarIssueVarsler: true,
     harGulGloed: false,
+    loeserTiebreak: false,
   },
   generalsekretaer: {
     tittel: 'Generalsekretær',
     kanAdministrere: true,
     faarIssueVarsler: false,
     harGulGloed: true,
+    loeserTiebreak: true,
   },
 }
 
@@ -65,6 +70,9 @@ export const harGulGloed = (rolle: string | null | undefined): boolean =>
 
 export const faarIssueVarsler = (rolle: string | null | undefined): boolean =>
   rettigheterFor(rolle).faarIssueVarsler
+
+export const loeserTiebreak = (rolle: string | null | undefined): boolean =>
+  rettigheterFor(rolle).loeserTiebreak
 
 export const tittelFor = (rolle: string | null | undefined): string =>
   rettigheterFor(rolle).tittel

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -338,6 +338,7 @@ export type Database = {
           oppdatert: string
           opprettet: string
           opprettet_av: string
+          poll_id: string | null
           profil_id: string | null
         }
         Insert: {
@@ -349,6 +350,7 @@ export type Database = {
           oppdatert?: string
           opprettet?: string
           opprettet_av: string
+          poll_id?: string | null
           profil_id?: string | null
         }
         Update: {
@@ -360,6 +362,7 @@ export type Database = {
           oppdatert?: string
           opprettet?: string
           opprettet_av?: string
+          poll_id?: string | null
           profil_id?: string | null
         }
         Relationships: [
@@ -396,18 +399,21 @@ export type Database = {
       kaaringmaler: {
         Row: {
           id: string
+          kandidat_kilde: string
           navn: string
           opprettet: string
           rekkefolge: number
         }
         Insert: {
           id?: string
+          kandidat_kilde?: string
           navn: string
           opprettet?: string
           rekkefolge?: number
         }
         Update: {
           id?: string
+          kandidat_kilde?: string
           navn?: string
           opprettet?: string
           rekkefolge?: number
@@ -703,34 +709,49 @@ export type Database = {
       }
       poll: {
         Row: {
+          arrangement_id: string | null
+          aar: number | null
+          avsluttet_paa: string | null
           flervalg: boolean
           id: string
+          kaaring_mal_id: string | null
           kontekst: string | null
           kontekst_data: Json | null
           opprettet: string
           opprettet_av: string
           spoersmaal: string
           svarfrist: string
+          tiebreak_status: string | null
         }
         Insert: {
+          arrangement_id?: string | null
+          aar?: number | null
+          avsluttet_paa?: string | null
           flervalg?: boolean
           id?: string
+          kaaring_mal_id?: string | null
           kontekst?: string | null
           kontekst_data?: Json | null
           opprettet?: string
           opprettet_av: string
           spoersmaal: string
           svarfrist: string
+          tiebreak_status?: string | null
         }
         Update: {
+          arrangement_id?: string | null
+          aar?: number | null
+          avsluttet_paa?: string | null
           flervalg?: boolean
           id?: string
+          kaaring_mal_id?: string | null
           kontekst?: string | null
           kontekst_data?: Json | null
           opprettet?: string
           opprettet_av?: string
           spoersmaal?: string
           svarfrist?: string
+          tiebreak_status?: string | null
         }
         Relationships: [
           {
@@ -833,19 +854,28 @@ export type Database = {
       poll_valg: {
         Row: {
           id: string
+          opprettet: string
           poll_id: string
+          referanse_arrangement_id: string | null
+          referanse_profil_id: string | null
           rekkefoelge: number
           tekst: string
         }
         Insert: {
           id?: string
+          opprettet?: string
           poll_id: string
+          referanse_arrangement_id?: string | null
+          referanse_profil_id?: string | null
           rekkefoelge?: number
           tekst: string
         }
         Update: {
           id?: string
+          opprettet?: string
           poll_id?: string
+          referanse_arrangement_id?: string | null
+          referanse_profil_id?: string | null
           rekkefoelge?: number
           tekst?: string
         }
@@ -1058,6 +1088,7 @@ export type Database = {
           lest: boolean
           melding: string
           opprettet: string | null
+          poll_id: string | null
           profil_id: string
           tittel: string
           type: string | null
@@ -1070,6 +1101,7 @@ export type Database = {
           lest?: boolean
           melding: string
           opprettet?: string | null
+          poll_id?: string | null
           profil_id: string
           tittel: string
           type?: string | null
@@ -1082,6 +1114,7 @@ export type Database = {
           lest?: boolean
           melding?: string
           opprettet?: string | null
+          poll_id?: string | null
           profil_id?: string
           tittel?: string
           type?: string | null
@@ -1237,6 +1270,15 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      avslutt_kaaringspoll: {
+        Args: { p_poll_id: string }
+        Returns: {
+          vinner_profil_id: string | null
+          vinner_arrangement_id: string | null
+          var_ny: boolean
+          status: string
+        }[]
+      }
       er_admin: { Args: never; Returns: boolean }
       get_statistikk: { Args: never; Returns: Json }
       har_pass_tilgang: { Args: { eier: string }; Returns: boolean }
@@ -1376,4 +1418,3 @@ export const Constants = {
     },
   },
 } as const
-

--- a/lib/varsler.ts
+++ b/lib/varsler.ts
@@ -104,6 +104,7 @@ export async function sendVarsel({
   knappTekst = 'Åpne i appen',
   type,
   arrangementId,
+  pollId,
   tillatDuplikat = false,
 }: {
   mottakere?: string[]
@@ -113,6 +114,7 @@ export async function sendVarsel({
   knappTekst?: string
   type: string
   arrangementId?: string
+  pollId?: string
   tillatDuplikat?: boolean
 }) {
   // Dev-guard: Blokker utsending fra lokal dev-server mot prod-DB.
@@ -137,13 +139,23 @@ export async function sendVarsel({
 
   const supabase = createAdminClient()
 
-  // 1. Dedup-sjekk
+  // 1. Dedup-sjekk — gjelder enten arrangement_id eller poll_id alt etter
+  // hvilken referanse varselet bærer. Først match som finnes vinner.
   if (!tillatDuplikat && arrangementId) {
     const { data: eksisterende } = await supabase
       .from('varsel_logg')
       .select('id')
       .eq('type', type)
       .eq('arrangement_id', arrangementId)
+      .limit(1)
+    if (eksisterende && eksisterende.length > 0) return
+  }
+  if (!tillatDuplikat && pollId) {
+    const { data: eksisterende } = await supabase
+      .from('varsel_logg')
+      .select('id')
+      .eq('type', type)
+      .eq('poll_id', pollId)
       .limit(1)
     if (eksisterende && eksisterende.length > 0) return
   }
@@ -212,6 +224,7 @@ export async function sendVarsel({
           kanal,
           url: url ?? null,
           arrangement_id: arrangementId ?? null,
+          poll_id: pollId ?? null,
         })
         .select('id')
         .single()
@@ -340,6 +353,84 @@ export async function sendNyPollVarsler({
     // for dedup, men vår pollId peker ikke dit. Sett tillatDuplikat for å
     // unngå at den uansett tolker vår context feil.
     tillatDuplikat: true,
+  })
+}
+
+// ─── KÅRINGSPOLL-VARSLER (#87) ──────────────────────────────────────────────
+
+export async function sendKaaringspollOpprettetVarsel({
+  pollId,
+  spoersmaal,
+  svarfrist,
+}: {
+  pollId: string
+  spoersmaal: string
+  svarfrist: string
+}) {
+  const frist = formaterDatoKlokke(svarfrist)
+  await sendVarsel({
+    tittel: 'Ny kåring',
+    melding: `${spoersmaal} — svarfrist ${frist}`,
+    url: `${BASE_URL}/poll/${pollId}`,
+    knappTekst: 'Stem nå',
+    type: 'kaaringspoll_opprettet',
+    pollId,
+  })
+}
+
+export async function sendKaaringspollVinnerVarsel({
+  pollId,
+  spoersmaal,
+}: {
+  pollId: string
+  spoersmaal: string
+}) {
+  await sendVarsel({
+    tittel: 'Kåringen er avgjort',
+    melding: `${spoersmaal} — vinneren er kåret`,
+    url: `${BASE_URL}/poll/${pollId}`,
+    knappTekst: 'Se vinneren',
+    type: 'kaaringspoll_vinner',
+    pollId,
+  })
+}
+
+export async function sendKaaringspollTiebreakVarsel({
+  pollId,
+  spoersmaal,
+  mottakere,
+}: {
+  pollId: string
+  spoersmaal: string
+  mottakere: string[]
+}) {
+  await sendVarsel({
+    mottakere,
+    tittel: 'Likt antall stemmer',
+    melding: `${spoersmaal} — du må velge vinneren`,
+    url: `${BASE_URL}/kaaringspoll/${pollId}/tiebreak`,
+    knappTekst: 'Velg vinner',
+    type: 'kaaringspoll_tiebreak',
+    pollId,
+  })
+}
+
+export async function sendKaaringspollIngenStemmerVarsel({
+  pollId,
+  spoersmaal,
+  mottakere,
+}: {
+  pollId: string
+  spoersmaal: string
+  mottakere: string[]
+}) {
+  await sendVarsel({
+    mottakere,
+    tittel: 'Kåring uten stemmer',
+    melding: `${spoersmaal} — ingen stemte, ingen vinner kåret`,
+    url: `${BASE_URL}/poll/${pollId}`,
+    type: 'kaaringspoll_ingen_stemmer',
+    pollId,
   })
 }
 

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 207,
-  "versjon": "V2.207"
+  "nummer": 208,
+  "versjon": "V2.208"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 208,
-  "versjon": "V2.208"
+  "nummer": 209,
+  "versjon": "V2.209"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 210,
-  "versjon": "V2.210"
+  "nummer": 211,
+  "versjon": "V2.211"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 209,
-  "versjon": "V2.209"
+  "nummer": 210,
+  "versjon": "V2.210"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.209'
+const CACHE_VERSION = 'V2.210'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.207'
+const CACHE_VERSION = 'V2.208'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.210'
+const CACHE_VERSION = 'V2.211'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.208'
+const CACHE_VERSION = 'V2.209'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/supabase/migrations/072_kaaringspoll_schema.sql
+++ b/supabase/migrations/072_kaaringspoll_schema.sql
@@ -1,0 +1,80 @@
+-- Kåringspoll (#87): bygger oppå generisk poll-tabell (#86) for å la
+-- generalsekretæren kjøre årlige kåringer som anonym avstemming. Vi
+-- legger meta-kolonner på poll/poll_valg framfor å lage egne tabeller,
+-- slik at chat, realtime og stemming-RLS gjenbrukes.
+--
+-- Kandidat-kilden velges per mal: enten alle aktive medlemmer
+-- (klassiske «Årets X»), eller årets møter (for kåringer som «Årets
+-- møte»). Backfill nedenfor antar dagens to navn — om nye maler kommer
+-- til må admin sette `kandidat_kilde` manuelt.
+--
+-- NB: kolonnen i `kaaring_vinnere` heter `mal_id` (fra migr. 023).
+-- Vi beholder navnet og refererer til det fra ny `poll_id`-kolonnen
+-- — rename ville krevd endring i `lib/actions/kaaring_vinnere.ts` og
+-- `app/(app)/kaaringer/page.tsx`, og hadde ingen praktisk gevinst.
+
+-- === kaaringmaler: hvor kommer kandidatene fra? ===========================
+
+alter table kaaringmaler
+  add column kandidat_kilde text not null default 'profil'
+    check (kandidat_kilde in ('profil', 'arrangement_moete'));
+
+-- Backfill: «Årets møte» trekker kandidater fra årets møte-arrangementer.
+-- Andre kåringer beholder default 'profil'.
+update kaaringmaler
+   set kandidat_kilde = 'arrangement_moete'
+ where lower(navn) like '%årets møte%';
+
+-- === poll: kåring-spesifikke felter =======================================
+
+alter table poll
+  add column kaaring_mal_id   uuid references kaaringmaler(id) on delete restrict,
+  add column aar              integer,
+  add column avsluttet_paa    timestamptz,
+  add column tiebreak_status  text check (tiebreak_status in ('venter_paa_tiebreak', 'avgjort')),
+  add column arrangement_id   uuid references arrangementer(id) on delete set null;
+
+-- Én aktiv kåringspoll per mal+år. Partial index slik at vanlige polls
+-- (kaaring_mal_id is null) ikke blir berørt.
+create unique index poll_kaaring_unik
+  on poll (kaaring_mal_id, aar)
+  where kaaring_mal_id is not null;
+
+-- Lookup for cron som finner åpne kåringspoller med utløpt frist.
+create index poll_kaaring_aapne
+  on poll (svarfrist)
+  where avsluttet_paa is null and kaaring_mal_id is not null;
+
+-- === poll_valg: kandidat-referanser =======================================
+-- Vi denormaliserer kandidaten inn på selve valget heller enn å lage en
+-- egen kandidat-tabell. Tekst-kolonnen brukes fortsatt til vist navn.
+
+alter table poll_valg
+  add column referanse_profil_id       uuid references profiles(id) on delete cascade,
+  add column referanse_arrangement_id  uuid references arrangementer(id) on delete cascade,
+  add column opprettet                 timestamptz not null default now();
+
+-- XOR: et kåringsvalg kan referere én kandidat-type, men ikke begge.
+-- Vanlige polls bruker ingen av referansene (begge null) — det er OK.
+alter table poll_valg
+  add constraint poll_valg_referanse_xor
+  check (referanse_profil_id is null or referanse_arrangement_id is null);
+
+-- === kaaring_vinnere: hvilken poll avgjorde kåringen? =====================
+-- on delete set null fordi vi ikke vil miste historiske vinnere selv om
+-- pollen slettes. Manuelt satte vinnere har poll_id = null.
+
+alter table kaaring_vinnere
+  add column poll_id uuid references poll(id) on delete set null;
+
+-- === varsel_logg: dedup på poll_id ========================================
+-- Eksisterende dedup går på (type, arrangement_id). Kåringsvarsler
+-- kobles til pollen, ikke arrangementet, så vi trenger egen kolonne +
+-- partial index.
+
+alter table varsel_logg
+  add column poll_id uuid references poll(id) on delete set null;
+
+create index idx_varsel_logg_poll_dedup
+  on varsel_logg (type, poll_id)
+  where poll_id is not null;

--- a/supabase/migrations/073_kaaringspoll_rls.sql
+++ b/supabase/migrations/073_kaaringspoll_rls.sql
@@ -1,0 +1,66 @@
+-- RLS for kåringspoll (#87). To kritiske endringer:
+--
+-- 1. Opprettelse av kåringspoll begrenses til admin/generalsekretær.
+--    Vanlige polls (kaaring_mal_id is null) skal fortsatt være åpne for
+--    alle medlemmer slik #86-flyten krever.
+--
+-- 2. Stemme-synlighet anonymiseres FØR fristen for kåringspoll. Dagens
+--    "alle ser alle stemmer" beholdes for vanlige polls — ellers ville
+--    forelopig-resultatet i PollResultat slutte å fungere. Etter at
+--    fristen er passert kan admin/generalsekretær se totalene (men
+--    ikke hvem stemte hva — det vises aldri ut over egen stemme).
+
+-- === poll: insert-policy strammes inn for kåringspoll =====================
+-- Den eksisterende "Alle kan opprette polls"-policyen krever at
+-- opprettet_av = auth.uid(). Den fortsetter å gjelde for vanlige polls.
+-- Vi legger til et restriktivt with check på kåringsfeltet via en
+-- erstatningspolicy som dekker begge tilfellene atomisk.
+
+drop policy "Alle kan opprette polls" on poll;
+
+create policy "Alle kan opprette polls"
+  on poll for insert
+  with check (
+    opprettet_av = auth.uid()
+    and (kaaring_mal_id is null or er_admin())
+  );
+
+-- === poll_stemme: anonymiser kåringsstemmer før frist =====================
+-- Eksisterende read-policy gir alle authenticated lesetilgang. Vi
+-- erstatter den med en variant som:
+--   - lar alle lese stemmer på vanlige polls (uendret oppførsel)
+--   - lar brukeren alltid se sine egne stemmer
+--   - lar admin/generalsekretær se kåringsstemmer ETTER svarfrist
+--   - skjuler andres kåringsstemmer for vanlige medlemmer hele tiden
+--
+-- Vi joiner mot poll for å vite om dette er en kåringspoll. RLS-koden
+-- evalueres på hver rad; partial-indexen poll_kaaring_aapne hjelper
+-- ikke direkte her, men poll_id er PK-indeksert så join-en er billig.
+
+drop policy "Alle kan lese stemmer" on poll_stemme;
+
+create policy "Stemmer leses med kåring-anonymitet"
+  on poll_stemme for select
+  using (
+    -- Egen stemme: alltid synlig
+    profil_id = auth.uid()
+    or exists (
+      select 1 from poll p
+      where p.id = poll_stemme.poll_id
+        and (
+          -- Vanlig poll: alle ser alt (uendret #86-oppførsel)
+          p.kaaring_mal_id is null
+          -- Kåringspoll: kun admin/generalsekretær, og kun etter frist
+          or (er_admin() and p.svarfrist <= now())
+        )
+    )
+  );
+
+-- === kaaring_vinnere: skriving låses til admin eller RPC =================
+-- Tabellen er fra migr. 023 og hadde admin-CRUD-policyer. Vi sjekker
+-- at de fortsatt finnes (admin via er_admin) — RPC-en i 074 bruker
+-- security definer og bypasser RLS uansett.
+--
+-- Ingen endringer her: eksisterende admin-policyer dekker både manuell
+-- inntasting og RPC-fallback. Hvis nye policyer trengs senere, gjør
+-- det i en egen migrasjon.

--- a/supabase/migrations/074_avslutt_kaaringspoll_rpc.sql
+++ b/supabase/migrations/074_avslutt_kaaringspoll_rpc.sql
@@ -1,0 +1,138 @@
+-- RPC som avslutter en kåringspoll: telles stemmer, avgjør vinner (eller
+-- markér tiebreak), og skriv til kaaring_vinnere. Kjøres typisk av
+-- påminnelses-cronen kl 06 UTC, men kan også triggeres manuelt.
+--
+-- SECURITY DEFINER fordi cron-en bruker service-role allerede, men
+-- definer-bypass gir oss en garanti om at samme funksjon kan brukes
+-- senere fra en bruker-action uten å måtte tenke på RLS-policyer på
+-- kaaring_vinnere. search_path er låst til public+pg_temp slik PG
+-- 15+ best practice tilsier (forhindrer at en angriper med skrivetilgang
+-- til en annen schema kan kapre tabellnavn).
+--
+-- Idempotent: kjøres samme poll to ganger blir andre kall en no-op
+-- (avsluttet_paa er allerede satt → returnerer var_ny = false).
+
+create or replace function avslutt_kaaringspoll(p_poll_id uuid)
+returns table (
+  vinner_profil_id      uuid,
+  vinner_arrangement_id uuid,
+  var_ny                boolean,
+  status                text
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_poll record;
+  v_topp_antall integer;
+  v_topp_count integer;
+  v_vinner_valg record;
+begin
+  -- Lås raden så vi ikke får race condition mellom to cron-kjøringer.
+  select id, kaaring_mal_id, aar, svarfrist, avsluttet_paa
+    into v_poll
+    from poll
+   where id = p_poll_id
+   for update;
+
+  if not found then
+    return query select null::uuid, null::uuid, false, 'ikke_funnet'::text;
+    return;
+  end if;
+
+  if v_poll.kaaring_mal_id is null then
+    return query select null::uuid, null::uuid, false, 'ikke_kaaring'::text;
+    return;
+  end if;
+
+  -- Allerede avsluttet — idempotent retur.
+  if v_poll.avsluttet_paa is not null then
+    return query select null::uuid, null::uuid, false, 'allerede_avsluttet'::text;
+    return;
+  end if;
+
+  -- Ikke moden — frist ikke passert ennå.
+  if v_poll.svarfrist > now() then
+    return query select null::uuid, null::uuid, false, 'ikke_moden'::text;
+    return;
+  end if;
+
+  -- Aggregér stemmer per valg.
+  with stemmer_per_valg as (
+    select pv.id as valg_id,
+           pv.referanse_profil_id,
+           pv.referanse_arrangement_id,
+           count(ps.profil_id) as antall
+      from poll_valg pv
+      left join poll_stemme ps on ps.valg_id = pv.id
+     where pv.poll_id = p_poll_id
+     group by pv.id, pv.referanse_profil_id, pv.referanse_arrangement_id
+  )
+  select max(antall), count(*) filter (where antall = (select max(antall) from stemmer_per_valg))
+    into v_topp_antall, v_topp_count
+    from stemmer_per_valg;
+
+  -- Ingen stemmer i det hele tatt.
+  if v_topp_antall is null or v_topp_antall = 0 then
+    update poll
+       set avsluttet_paa = now()
+     where id = p_poll_id;
+    return query select null::uuid, null::uuid, true, 'ingen_stemmer'::text;
+    return;
+  end if;
+
+  -- Likt antall på topp → generalsekretær må velge i UI.
+  if v_topp_count > 1 then
+    update poll
+       set avsluttet_paa   = now(),
+           tiebreak_status = 'venter_paa_tiebreak'
+     where id = p_poll_id;
+    return query select null::uuid, null::uuid, true, 'venter_paa_tiebreak'::text;
+    return;
+  end if;
+
+  -- Entydig vinner — finn raden og skriv til kaaring_vinnere.
+  with stemmer_per_valg as (
+    select pv.id as valg_id,
+           pv.referanse_profil_id,
+           pv.referanse_arrangement_id,
+           count(ps.profil_id) as antall
+      from poll_valg pv
+      left join poll_stemme ps on ps.valg_id = pv.id
+     where pv.poll_id = p_poll_id
+     group by pv.id, pv.referanse_profil_id, pv.referanse_arrangement_id
+  )
+  select valg_id, referanse_profil_id, referanse_arrangement_id
+    into v_vinner_valg
+    from stemmer_per_valg
+   where antall = v_topp_antall
+   limit 1;
+
+  -- on conflict do nothing fordi (mal_id, aar) er unik — om noen har
+  -- satt vinneren manuelt før cronen rakk det, så vinner manuell.
+  insert into kaaring_vinnere (mal_id, aar, profil_id, arrangement_id, opprettet_av, poll_id)
+  select v_poll.kaaring_mal_id,
+         v_poll.aar,
+         v_vinner_valg.referanse_profil_id,
+         v_vinner_valg.referanse_arrangement_id,
+         coalesce(
+           (select opprettet_av from poll where id = p_poll_id),
+           '00000000-0000-0000-0000-000000000000'::uuid
+         ),
+         p_poll_id
+   on conflict (mal_id, aar) do nothing;
+
+  update poll
+     set avsluttet_paa   = now(),
+         tiebreak_status = 'avgjort'
+   where id = p_poll_id;
+
+  return query select v_vinner_valg.referanse_profil_id,
+                      v_vinner_valg.referanse_arrangement_id,
+                      true,
+                      'avgjort'::text;
+end;
+$$;
+
+grant execute on function avslutt_kaaringspoll(uuid) to authenticated;

--- a/supabase/migrations/075_kaaringspoll_varsler_innstilling.sql
+++ b/supabase/migrations/075_kaaringspoll_varsler_innstilling.sql
@@ -1,0 +1,10 @@
+-- Slå på fire varseltyper for kåringspoll-flyten i admin-panelet.
+-- on conflict do nothing slik at re-kjøring ikke overskriver evt.
+-- avslåtte innstillinger.
+
+insert into varsel_innstillinger (noekkel, aktiv, beskrivelse) values
+  ('kaaringspoll_opprettet',    true, 'Varsel ved ny kåringspoll'),
+  ('kaaringspoll_vinner',       true, 'Varsel når en kåringspoll har fått vinner'),
+  ('kaaringspoll_tiebreak',     true, 'Varsel til generalsekretær ved likt antall stemmer'),
+  ('kaaringspoll_ingen_stemmer',true, 'Varsel når en kåringspoll lukkes uten stemmer')
+on conflict (noekkel) do nothing;

--- a/supabase/migrations/076_kaaringspoll_rls_avsluttet.sql
+++ b/supabase/migrations/076_kaaringspoll_rls_avsluttet.sql
@@ -1,0 +1,29 @@
+-- Justering av RLS-vinduet i 073: stemmer ble åpnet for admin idet
+-- svarfristen passerte, men appen behandler en kåringspoll som "fortsatt
+-- åpen" til cron har satt `avsluttet_paa`. I praksis fikk admin se
+-- stemmer på poller UI-et fortsatt rendret som åpne — inkonsistent.
+--
+-- Vi binder synligheten til `avsluttet_paa is not null` i stedet, slik
+-- at både UI og RLS bruker samme sannhet om når kåringen er låst.
+-- Idempotent RPC + cron sørger for at vinduet lukkes innen rimelig tid.
+-- Også samme låsedato brukes for det "tilfellet" der admin avslutter
+-- manuelt (RPC setter `avsluttet_paa`).
+
+drop policy "Stemmer leses med kåring-anonymitet" on poll_stemme;
+
+create policy "Stemmer leses med kåring-anonymitet"
+  on poll_stemme for select
+  using (
+    -- Egen stemme: alltid synlig
+    profil_id = auth.uid()
+    or exists (
+      select 1 from poll p
+      where p.id = poll_stemme.poll_id
+        and (
+          -- Vanlig poll: alle ser alt (uendret #86-oppførsel)
+          p.kaaring_mal_id is null
+          -- Kåringspoll: kun admin/generalsekretær, og kun etter avslutning
+          or (er_admin() and p.avsluttet_paa is not null)
+        )
+    )
+  );

--- a/supabase/migrations/077_avslutt_kaaringspoll_rpc_harden.sql
+++ b/supabase/migrations/077_avslutt_kaaringspoll_rpc_harden.sql
@@ -1,0 +1,126 @@
+-- Sikkerhetsharding av RPC-en fra 074:
+--   1. Trekk tilbake default execute-grant fra `public`. SECURITY
+--      DEFINER betyr at funksjonen kjører med skjema-eierens rettigheter,
+--      og uten revoke kan `anon` (uautentisert) kalle den.
+--   2. Drop coalesce-fallback til null-UUID for opprettet_av — `poll.opprettet_av`
+--      er `not null` i skjemaet, så fallbacken kunne aldri trigge i
+--      praksis, men den maskerer en ekte bug hvis invarianten brytes
+--      senere. Bedre å feile hardt.
+
+create or replace function avslutt_kaaringspoll(p_poll_id uuid)
+returns table (
+  vinner_profil_id      uuid,
+  vinner_arrangement_id uuid,
+  var_ny                boolean,
+  status                text
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_poll record;
+  v_topp_antall integer;
+  v_topp_count integer;
+  v_vinner_valg record;
+begin
+  select id, kaaring_mal_id, aar, svarfrist, avsluttet_paa, opprettet_av
+    into v_poll
+    from poll
+   where id = p_poll_id
+   for update;
+
+  if not found then
+    return query select null::uuid, null::uuid, false, 'ikke_funnet'::text;
+    return;
+  end if;
+
+  if v_poll.kaaring_mal_id is null then
+    return query select null::uuid, null::uuid, false, 'ikke_kaaring'::text;
+    return;
+  end if;
+
+  if v_poll.avsluttet_paa is not null then
+    return query select null::uuid, null::uuid, false, 'allerede_avsluttet'::text;
+    return;
+  end if;
+
+  if v_poll.svarfrist > now() then
+    return query select null::uuid, null::uuid, false, 'ikke_moden'::text;
+    return;
+  end if;
+
+  with stemmer_per_valg as (
+    select pv.id as valg_id,
+           pv.referanse_profil_id,
+           pv.referanse_arrangement_id,
+           count(ps.profil_id) as antall
+      from poll_valg pv
+      left join poll_stemme ps on ps.valg_id = pv.id
+     where pv.poll_id = p_poll_id
+     group by pv.id, pv.referanse_profil_id, pv.referanse_arrangement_id
+  )
+  select max(antall), count(*) filter (where antall = (select max(antall) from stemmer_per_valg))
+    into v_topp_antall, v_topp_count
+    from stemmer_per_valg;
+
+  if v_topp_antall is null or v_topp_antall = 0 then
+    update poll
+       set avsluttet_paa = now()
+     where id = p_poll_id;
+    return query select null::uuid, null::uuid, true, 'ingen_stemmer'::text;
+    return;
+  end if;
+
+  if v_topp_count > 1 then
+    update poll
+       set avsluttet_paa   = now(),
+           tiebreak_status = 'venter_paa_tiebreak'
+     where id = p_poll_id;
+    return query select null::uuid, null::uuid, true, 'venter_paa_tiebreak'::text;
+    return;
+  end if;
+
+  with stemmer_per_valg as (
+    select pv.id as valg_id,
+           pv.referanse_profil_id,
+           pv.referanse_arrangement_id,
+           count(ps.profil_id) as antall
+      from poll_valg pv
+      left join poll_stemme ps on ps.valg_id = pv.id
+     where pv.poll_id = p_poll_id
+     group by pv.id, pv.referanse_profil_id, pv.referanse_arrangement_id
+  )
+  select valg_id, referanse_profil_id, referanse_arrangement_id
+    into v_vinner_valg
+    from stemmer_per_valg
+   where antall = v_topp_antall
+   limit 1;
+
+  -- Drop coalesce — opprettet_av er not null på poll, så fallback maskerte
+  -- bare evt. invariant-brudd. La det feile.
+  insert into kaaring_vinnere (mal_id, aar, profil_id, arrangement_id, opprettet_av, poll_id)
+  values (
+    v_poll.kaaring_mal_id,
+    v_poll.aar,
+    v_vinner_valg.referanse_profil_id,
+    v_vinner_valg.referanse_arrangement_id,
+    v_poll.opprettet_av,
+    p_poll_id
+  )
+  on conflict (mal_id, aar) do nothing;
+
+  update poll
+     set avsluttet_paa   = now(),
+         tiebreak_status = 'avgjort'
+   where id = p_poll_id;
+
+  return query select v_vinner_valg.referanse_profil_id,
+                      v_vinner_valg.referanse_arrangement_id,
+                      true,
+                      'avgjort'::text;
+end;
+$$;
+
+revoke execute on function avslutt_kaaringspoll(uuid) from public;
+grant execute on function avslutt_kaaringspoll(uuid) to authenticated;

--- a/supabase/migrations/078_kaaringspoll_rpc_lock_og_indeks.sql
+++ b/supabase/migrations/078_kaaringspoll_rpc_lock_og_indeks.sql
@@ -1,0 +1,22 @@
+-- To rettelser etter Copilot-review på #87:
+--
+--  1. Lås EXECUTE på avslutt_kaaringspoll() ned til service_role.
+--     RPC-en kjøres kun fra cron (lib/actions/paaminnelser.ts), som bruker
+--     service_role-klienten. Tidligere lå grant på `authenticated`, hvilket
+--     betyr at hvilken som helst innlogget bruker kunne forhåndskalle den
+--     på en moden poll. Etterpå ville cron skippe pga `avsluttet_paa is not
+--     null` → ingen vinner-/tiebreak-varsel ble sendt. velgTiebreakVinner
+--     i app-koden bruker IKKE denne RPC-en — den skriver direkte til
+--     kaaring_vinnere — så app-flyten påvirkes ikke.
+--
+--  2. Partial-indeks på poll(arrangement_id, svarfrist desc) for å støtte
+--     arrangement-detaljsidens lookup `.eq('arrangement_id', id)`. Speiler
+--     mønsteret fra poll_kaaring_aapne i 072.
+
+revoke execute on function avslutt_kaaringspoll(uuid) from authenticated;
+revoke execute on function avslutt_kaaringspoll(uuid) from public;
+grant execute on function avslutt_kaaringspoll(uuid) to service_role;
+
+create index if not exists poll_arrangement_id_idx
+  on poll (arrangement_id, svarfrist desc)
+  where arrangement_id is not null;


### PR DESCRIPTION
Closes #87.

## Hva
Bygger kåringspoll oppå den generiske poll-funksjonen fra #86. Generalsekretær får en «Kåring»-knapp i NyFAB som starter en avstemning med forhåndsutfylte kandidater (alle aktive medlemmer for «Årets herre», alle årets møter for «Årets møte»). Ved frist-utløp lukker `paaminne`-cron pollen via en SECURITY DEFINER RPC, skriver vinner til `kaaring_vinnere` og sender ett varsel.

## Beslutninger underveis

Saken gikk gjennom det nye **arkitekturstyret** (4 perspektiv-agenter + styreleder) før koding. Endelig uttalelse er postet som kommentar på issuet med full sporbarhet.

**Reidars produkt-beslutninger som ble tatt mens vi jobbet:**
- Tiebreak: kun generalsekretær velger via egen UI-side (ikke automatisk «først-opprettet vinner»)
- Hall of Fame: alle vinnere likeverdige — ingen markering av kåringskilde, ingen stemmetall
- Frist: generalsekretær velger fritt (ingen system-default)
- Varsler: kun ved opprettelse — droppet 10-min-påminnelse (kåring skjer på julebordet hvor alle er fysisk samlet)
- Generalsekretærs innsyn: ser stemmefordeling først etter frist, aldri underveis. Aldri hvem som stemte hva
- Julebord-kobling: valgfri arrangement-velger (inkl. arrangementer fra siste 7 dager for å fange julebord-kvelden + dagen etter)
- Tiebreak-siden viser **ikke** stemmetall — kun kandidatene

**Reviewer fant 1 BLOCKER + 5 MAJOR:**
- BLOCKER (rettet): vinner-banneret hentet vinner fra `stemmerPerValg` som RLS skjuler for vanlige medlemmer. Endret til å hente fra `kaaring_vinnere` direkte
- MAJOR (rettet): RLS-vindu inkonsistent med `avsluttet_paa` → migrasjon 076
- MAJOR (rettet): `new Date()` i stedet for `naa()` i `paaminnelser.ts`
- MAJOR (rettet): RPC manglet `revoke from public` → migrasjon 077
- MAJOR (rettet): nullguid-fallback i RPC fjernet
- MAJOR (rettet): `loeserTiebreak`-rettighet erstattet bredt admin-utvalg

## Tekniske kjernevalg
- **Schema:** `kaaringmaler.kandidat_kilde`, `poll.kaaring_mal_id` + `aar` + `tiebreak_status` + `arrangement_id`, `poll_valg.referanse_profil_id`/`referanse_arrangement_id` med XOR-CHECK, `poll_valg.opprettet`, `kaaring_vinnere.poll_id`, `varsel_logg.poll_id`
- **Stengning:** SECURITY DEFINER RPC `avslutt_kaaringspoll(uuid)` med `select … for update` + `on conflict do nothing`. Returnerer `{vinner_id, var_ny, status}`. Cron sender varsel kun når `var_ny=true`. Statuser: `avgjort`, `venter_paa_tiebreak`, `ingen_stemmer`
- **RLS:** anonymitet bevares — vanlige medlemmer ser ikke andres stemmer på kåringspoller før `avsluttet_paa`. Vanlige polls beholder full synlighet for prosent-beregning
- **Roller:** ny rettighet `loeserTiebreak` (true kun for `generalsekretaer`) styrer både varsel-mottaker og UI-tilgang til tiebreak-siden
- **Cron:** utvider eksisterende `paaminne`-endepunkt (ikke nytt). Returnerer `{paamint, lukketKaaringer, sendteVarsler, feil}`. HTTP 500 hvis `feil > 0`

## Migrasjoner
6 nye (072–077). Anbefalt rekkefølge: kjør alle på én `db push`. Etter push: regenerer typer (`npx supabase gen types ... > lib/supabase/database.types.ts`) — manuell type-patching i denne PR-en er en mellomløsning som overskrives ved regenerering.

## Test plan
- [ ] `npx supabase db push` på Supabase-prosjektet
- [ ] Regenerer typer
- [ ] Manuell test som generalsekretær: opprett «Årets herre 2026»-poll med kort frist, stem som flere brukere, vent på cron, verifiser vinner-banner + Hall of Fame + ett varsel
- [ ] Tiebreak-test: lag scenario med likt antall, verifiser at kun generalsekretær får varsel + lenke
- [ ] Anonymitets-test: vanlig medlem skal IKKE se andres stemmer før frist
- [ ] Idempotens: kjør cron to ganger, ingen duplikate varsler
- [ ] Vanlige polls upåvirket: opprett en, sjekk at prosent-resultat fortsatt vises etter frist

🤖 Generated with [Claude Code](https://claude.com/claude-code)
