### PR TITLE
Tell alle kommentarer på agenda-kort (oppfølger #135)

### DIFF
--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -150,19 +150,16 @@ export default async function Forside() {
       )
       .not('arrangement_id', 'is', null),
     // Totalt antall kommentarer per arrangement og poll — ren id-spørring
-    // uten join eller limit (innenfor 3-mnd-vinduet). Brukes til overskriften
-    // «X kommentarer» på agenda-kort så tallet ikke begrenses til de 3 siste
-    // vi henter for visning. For meldinger holder vi oss til limit(60)-uttrekket
-    // i meldingKommentarer over — meldinger-feeden er selv limit 60, så
-    // dekningen er praktisk talt total uten en egen tellespørring.
+    // uten join, limit eller dato-filter. Brukes til overskriften «X kommentarer»
+    // på agenda-kort så tallet er den faktiske totalen, ikke begrenset av
+    // visningsvinduet eller topp-3-uttrekket. For meldinger holder vi oss til
+    // limit(60)-uttrekket i meldingKommentarer over.
     supabase
       .from('arrangement_chat')
-      .select('arrangement_id')
-      .gte('opprettet', treMndSiden.toISOString()),
+      .select('arrangement_id'),
     supabase
       .from('poll_chat')
-      .select('poll_id')
-      .gte('opprettet', treMndSiden.toISOString()),
+      .select('poll_id'),
   ])
 
   // Aggreger poll-stemmer: antall unike profiler + om innlogget bruker er

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 215,
-  "versjon": "V2.215"
+  "nummer": 216,
+  "versjon": "V2.216"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.215'
+const CACHE_VERSION = 'V2.216'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Forrige PR (#138) begrenset totaltellingen til samme 24-mnd-vindu som visningen — Reidar vil ha ekte total. Fjerner gte-filteret på id-spørringene for arrangement_chat og poll_chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)