### PR TITLE
Klargjør at agenda-overskriften viser delvis kommentarliste

### DIFF
--- a/components/agenda/KommentarerPaaKort.tsx
+++ b/components/agenda/KommentarerPaaKort.tsx
@@ -151,7 +151,9 @@ export default function KommentarerPaaKort({
           >
             <path d="M9 6l6 6-6 6" />
           </svg>
-          {visTall} {visTall === 1 ? 'kommentar' : 'kommentarer'}
+          {visTall > kommentarer.length
+            ? `Siste ${kommentarer.length} av ${visTall} kommentarer`
+            : `${visTall} ${visTall === 1 ? 'kommentar' : 'kommentarer'}`}
         </span>
       )}
 

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 216,
-  "versjon": "V2.216"
+  "nummer": 217,
+  "versjon": "V2.217"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.216'
+const CACHE_VERSION = 'V2.217'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Når totalen er høyere enn de 3 vi viser: "Siste 3 av 7 kommentarer". Når alle vises: "7 kommentarer" som før. Bedre enn å la 7 vs 3 stå som mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)