### PR TITLE
Forenkle kåringspoll: foreløpig resultat, lukk nå, ny CTA (#144)

### DIFF
--- a/app/(app)/kaaringer/page.tsx
+++ b/app/(app)/kaaringer/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { createServerClient } from '@/lib/supabase/server'
 import { getProfil } from '@/lib/auth-cache'
 import { norskAar } from '@/lib/dato'
@@ -57,30 +58,61 @@ export default async function Kaaringer() {
       <div style={{ marginBottom: 28, marginTop: 12 }}>
         <div
           style={{
-            fontFamily: 'var(--font-mono)',
-            fontSize: 10,
-            fontWeight: 600,
-            color: 'var(--text-tertiary)',
-            letterSpacing: '2px',
-            textTransform: 'uppercase',
-            marginBottom: 6,
+            display: 'flex',
+            alignItems: 'flex-end',
+            justifyContent: 'space-between',
+            gap: 12,
           }}
         >
-          Kåringer
+          <div>
+            <div
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: 10,
+                fontWeight: 600,
+                color: 'var(--text-tertiary)',
+                letterSpacing: '2px',
+                textTransform: 'uppercase',
+                marginBottom: 6,
+              }}
+            >
+              Kåringer
+            </div>
+            <h1
+              style={{
+                fontFamily: 'var(--font-display)',
+                fontSize: 38,
+                fontWeight: 500,
+                color: 'var(--text-primary)',
+                letterSpacing: '-0.5px',
+                margin: 0,
+                lineHeight: 1,
+              }}
+            >
+              Hall of Fame
+            </h1>
+          </div>
+          {erAdmin && (
+            <Link
+              href="/kaaringspoll/ny"
+              style={{
+                display: 'inline-block',
+                padding: '8px 16px',
+                background: 'var(--accent-soft)',
+                border: '0.5px solid var(--border-strong)',
+                borderRadius: 999,
+                color: 'var(--accent)',
+                fontFamily: 'var(--font-body)',
+                fontSize: 13,
+                fontWeight: 600,
+                textDecoration: 'none',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              Ny kåring
+            </Link>
+          )}
         </div>
-        <h1
-          style={{
-            fontFamily: 'var(--font-display)',
-            fontSize: 38,
-            fontWeight: 500,
-            color: 'var(--text-primary)',
-            letterSpacing: '-0.5px',
-            margin: 0,
-            lineHeight: 1,
-          }}
-        >
-          Hall of Fame
-        </h1>
       </div>
 
       {!harMaler ? (

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -1,7 +1,6 @@
 import Link from 'next/link'
 import { createServerClient } from '@/lib/supabase/server'
-import { getInnloggetBruker, getProfil } from '@/lib/auth-cache'
-import { kanAdministrere } from '@/lib/roller'
+import { getInnloggetBruker } from '@/lib/auth-cache'
 import { formaterDato, norskAar, norskDatoNaa } from '@/lib/dato'
 import { subMonths } from 'date-fns'
 import SectionLabel from '@/components/ui/SectionLabel'
@@ -30,12 +29,10 @@ import { hentPollStemmerAggregatBatch } from '@/lib/queries/poll'
 // Agenda-forsiden: henter rådata og delegerer all sortering/gruppering til
 // lib/agenda-sortering.ts. Denne filen skal holdes tynn — kun fetch + render.
 export default async function Forside() {
-  const [user, supabase, profil] = await Promise.all([
+  const [user, supabase] = await Promise.all([
     getInnloggetBruker(),
     createServerClient(),
-    getProfil(),
   ])
-  const erAdmin = kanAdministrere(profil?.rolle)
 
   const naa = norskDatoNaa()
   // Vis tidligere arrangementer 24 mnd tilbake på forsiden — eldre vises
@@ -168,7 +165,7 @@ export default async function Forside() {
   // andres stemmer for vanlige medlemmer på åpne kåringspoller. For
   // vanlige polls bruker vi poll_stemme-radene direkte slik som før.
   const kaaringspollIder = (pollerRaad ?? [])
-    .filter(p => (p as { kaaring_mal_id: string | null }).kaaring_mal_id !== null)
+    .filter(p => p.kaaring_mal_id !== null)
     .map(p => p.id)
   const kaaringAggregater = await hentPollStemmerAggregatBatch(supabase, kaaringspollIder)
 
@@ -183,8 +180,8 @@ export default async function Forside() {
       .sort((a, b) => a.rekkefoelge - b.rekkefoelge)
       .map(v => ({ id: v.id, tekst: v.tekst }))
 
-    const erKaaring = (p as { kaaring_mal_id: string | null }).kaaring_mal_id !== null
-    let stemmerPerValg: Record<string, number> = {}
+    const erKaaring = p.kaaring_mal_id !== null
+    const stemmerPerValg: Record<string, number> = {}
     let antallStemmer = 0
 
     if (erKaaring) {
@@ -428,7 +425,7 @@ export default async function Forside() {
           </h1>
         </div>
 
-        <NyFAB kanAdministrere={erAdmin} />
+        <NyFAB />
       </header>
 
       <PushPaaminnelse />

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -25,6 +25,7 @@ import {
   type MeldingRaad,
 } from '@/lib/agenda-sortering'
 import { subDays } from 'date-fns'
+import { hentPollStemmerAggregatBatch } from '@/lib/queries/poll'
 
 // Agenda-forsiden: henter rådata og delegerer all sortering/gruppering til
 // lib/agenda-sortering.ts. Denne filen skal holdes tynn — kun fetch + render.
@@ -86,6 +87,7 @@ export default async function Forside() {
       .from('poll')
       .select(
         `id, spoersmaal, svarfrist, flervalg, opprettet_av,
+         kaaring_mal_id, aar, avsluttet_paa, tiebreak_status,
          poll_valg (id, tekst, rekkefoelge),
          poll_stemme (profil_id, valg_id)`,
       )
@@ -162,6 +164,14 @@ export default async function Forside() {
       .select('poll_id'),
   ])
 
+  // Kåringspoll-aggregater hentes via RPC (mig. 079), fordi RLS skjuler
+  // andres stemmer for vanlige medlemmer på åpne kåringspoller. For
+  // vanlige polls bruker vi poll_stemme-radene direkte slik som før.
+  const kaaringspollIder = (pollerRaad ?? [])
+    .filter(p => (p as { kaaring_mal_id: string | null }).kaaring_mal_id !== null)
+    .map(p => p.id)
+  const kaaringAggregater = await hentPollStemmerAggregatBatch(supabase, kaaringspollIder)
+
   // Aggreger poll-stemmer: antall unike profiler + om innlogget bruker er
   // blant dem, + hvilke valg jeg har stemt på. Valgene sorteres etter
   // rekkefølge så inline-knappene rendres i opprettet rekkefølge.
@@ -172,17 +182,34 @@ export default async function Forside() {
     const valg = [...(p.poll_valg ?? [])]
       .sort((a, b) => a.rekkefoelge - b.rekkefoelge)
       .map(v => ({ id: v.id, tekst: v.tekst }))
-    const stemmerPerValg: Record<string, number> = {}
-    for (const s of stemmer) {
-      stemmerPerValg[s.valg_id] = (stemmerPerValg[s.valg_id] ?? 0) + 1
+
+    const erKaaring = (p as { kaaring_mal_id: string | null }).kaaring_mal_id !== null
+    let stemmerPerValg: Record<string, number> = {}
+    let antallStemmer = 0
+
+    if (erKaaring) {
+      // Aggregat fra RPC — totalen er sannheten siden RLS skjuler andres
+      // stemmer. harStemt utledes fortsatt fra poll_stemme: egne stemmer
+      // er synlige for kalleren.
+      const agg = kaaringAggregater.get(p.id) ?? new Map<string, number>()
+      for (const [valgId, antall] of agg) {
+        stemmerPerValg[valgId] = antall
+        antallStemmer += antall
+      }
+    } else {
+      for (const s of stemmer) {
+        stemmerPerValg[s.valg_id] = (stemmerPerValg[s.valg_id] ?? 0) + 1
+      }
+      antallStemmer = unike.size
     }
+
     return {
       id: p.id,
       spoersmaal: p.spoersmaal,
       svarfrist: p.svarfrist,
       flervalg: p.flervalg,
       opprettet_av: p.opprettet_av,
-      antallStemmer: unike.size,
+      antallStemmer,
       harStemt: unike.has(user!.id),
       valg,
       mineStemmer: mine,

--- a/app/(app)/poll/[id]/LukkNaaKnapp.tsx
+++ b/app/(app)/poll/[id]/LukkNaaKnapp.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { lukkKaaringspollNaa } from '@/lib/actions/kaaringspoll'
+
+export default function LukkNaaKnapp({ pollId }: { pollId: string }) {
+  const [isPending, startTransition] = useTransition()
+  const [feil, setFeil] = useState<string | null>(null)
+  const router = useRouter()
+
+  function handleLukk() {
+    if (!confirm('Vil du lukke kåringen nå? Dette kan ikke angres.')) return
+    setFeil(null)
+    startTransition(async () => {
+      try {
+        await lukkKaaringspollNaa(pollId)
+        router.refresh()
+      } catch (err) {
+        setFeil(err instanceof Error ? err.message : 'Kunne ikke lukke kåringen')
+      }
+    })
+  }
+
+  return (
+    <div style={{ marginTop: 24 }}>
+      <button
+        type="button"
+        onClick={handleLukk}
+        disabled={isPending}
+        style={{
+          display: 'block',
+          width: '100%',
+          padding: '14px 0',
+          background: 'transparent',
+          border: '1px solid var(--border)',
+          borderRadius: 999,
+          color: 'var(--danger)',
+          fontFamily: 'var(--font-body)',
+          fontSize: 14,
+          fontWeight: 500,
+          cursor: isPending ? 'wait' : 'pointer',
+          opacity: isPending ? 0.6 : 1,
+        }}
+      >
+        {isPending ? 'Lukker…' : 'Lukk kåringen nå'}
+      </button>
+      {feil && (
+        <p
+          style={{
+            marginTop: 10,
+            fontFamily: 'var(--font-body)',
+            fontSize: 13,
+            color: 'var(--danger)',
+            textAlign: 'center',
+          }}
+        >
+          {feil}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/app/(app)/poll/[id]/LukkNaaKnapp.tsx
+++ b/app/(app)/poll/[id]/LukkNaaKnapp.tsx
@@ -4,7 +4,13 @@ import { useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
 import { lukkKaaringspollNaa } from '@/lib/actions/kaaringspoll'
 
-export default function LukkNaaKnapp({ pollId }: { pollId: string }) {
+export default function LukkNaaKnapp({
+  pollId,
+  disabled = false,
+}: {
+  pollId: string
+  disabled?: boolean
+}) {
   const [isPending, startTransition] = useTransition()
   const [feil, setFeil] = useState<string | null>(null)
   const router = useRouter()
@@ -22,12 +28,14 @@ export default function LukkNaaKnapp({ pollId }: { pollId: string }) {
     })
   }
 
+  const erDisabled = isPending || disabled
   return (
     <div style={{ marginTop: 24 }}>
       <button
         type="button"
         onClick={handleLukk}
-        disabled={isPending}
+        disabled={erDisabled}
+        title={disabled ? 'Ingen har stemt ennå' : undefined}
         style={{
           display: 'block',
           width: '100%',
@@ -39,8 +47,8 @@ export default function LukkNaaKnapp({ pollId }: { pollId: string }) {
           fontFamily: 'var(--font-body)',
           fontSize: 14,
           fontWeight: 500,
-          cursor: isPending ? 'wait' : 'pointer',
-          opacity: isPending ? 0.6 : 1,
+          cursor: erDisabled ? (isPending ? 'wait' : 'not-allowed') : 'pointer',
+          opacity: erDisabled ? 0.6 : 1,
         }}
       >
         {isPending ? 'Lukker…' : 'Lukk kåringen nå'}

--- a/app/(app)/poll/[id]/page.tsx
+++ b/app/(app)/poll/[id]/page.tsx
@@ -74,14 +74,15 @@ export default async function PollDetalj({
       .from('profiles')
       .select('id, navn, bilde_url, rolle')
       .eq('aktiv', true),
-    // Aggregat via RPC — gir totalen uavhengig av RLS-skjul. For ikke-
-    // kåringspoller er resultatet tomt, og vi bruker poll_stemme-radene
-    // direkte slik som før. Se mig. 079.
+    // Aggregat via RPC — gir totalen uavhengig av RLS-skjul. RPCen
+    // returnerer tellinger for alle poll-typer (filtrerer kun på poll_id),
+    // men vi bruker bare resultatet for kåringspoller; for vanlige poller
+    // er poll_stemme-radene fullt synlige og vi teller dem direkte som før.
+    // Se mig. 079.
     //
     // Bevisst ubetinget: vi kjenner ikke poll.kaaring_mal_id før første
     // spørring er ferdig, og å sekvensere ville koste mer enn én ekstra
-    // billig RPC i parallell. RPCen returnerer tomt-set raskt for
-    // ikke-kåringspoller.
+    // billig RPC i parallell.
     hentPollStemmerAggregat(supabase, id),
   ])
 

--- a/app/(app)/poll/[id]/page.tsx
+++ b/app/(app)/poll/[id]/page.tsx
@@ -15,6 +15,8 @@ import KaaringPollStemming, {
 import VinnerBanner from '@/components/poll/VinnerBanner'
 import Chat from '@/components/chat/Chat'
 import SlettPollKnapp from './SlettPollKnapp'
+import LukkNaaKnapp from './LukkNaaKnapp'
+import { hentPollStemmerAggregat } from '@/lib/queries/poll'
 
 type ValgRad = {
   id: string
@@ -51,7 +53,7 @@ export default async function PollDetalj({
     getProfil(),
   ])
 
-  const [{ data: poll }, { data: chatMeldinger }, { data: chatProfiler }] = await Promise.all([
+  const [{ data: poll }, { data: chatMeldinger }, { data: chatProfiler }, stemmerAggregat] = await Promise.all([
     supabase
       .from('poll')
       .select(
@@ -72,6 +74,10 @@ export default async function PollDetalj({
       .from('profiles')
       .select('id, navn, bilde_url, rolle')
       .eq('aktiv', true),
+    // Aggregat via RPC — gir totalen uavhengig av RLS-skjul. For ikke-
+    // kåringspoller er resultatet tomt, og vi bruker poll_stemme-radene
+    // direkte slik som før. Se mig. 079.
+    hentPollStemmerAggregat(supabase, id),
   ])
 
   if (!poll) notFound()
@@ -115,13 +121,17 @@ export default async function PollDetalj({
 
   // ─── Kåringspoll-rendering ─────────────────────────────────────────────
   if (erKaaring) {
+    // Aggregat fra RPC er kilden til sannhet for kåringspoll, fordi RLS
+    // skjuler andres stemmer for vanlige medlemmer (mig. 076).
+    let kaaringTotalt = 0
+    for (const v of stemmerAggregat.values()) kaaringTotalt += v
     return (
       <KaaringVisning
         poll={poll}
         valg={valg}
         chatProfiler={chatProfiler ?? []}
-        stemmerPerValg={stemmerPerValg}
-        antallStemmere={antallStemmere}
+        stemmerPerValg={stemmerAggregat}
+        antallStemmere={kaaringTotalt}
         mineStemmer={mineStemmer}
         datoLang={datoLang}
         erAvsluttet={erAvsluttet}
@@ -304,17 +314,7 @@ function KaaringVisning({
 
   const venterTiebreak = poll.tiebreak_status === 'venter_paa_tiebreak'
   const erAvgjort = poll.tiebreak_status === 'avgjort'
-  // RLS skjuler andres stemmer for vanlige medlemmer, så `antallStemmere`
-  // er ikke en pålitelig indikator alene. Vi vet det var stemmer dersom
-  // det finnes en vinner eller poll-en venter på tiebreak. "Ingen stemmer"
-  // er kun riktig når avsluttet, ingen vinner registrert, ingen tiebreak,
-  // OG vi heller ikke ser noen stemmer selv.
-  const ingenStemmer =
-    poll.avsluttet_paa !== null &&
-    !erAvgjort &&
-    !venterTiebreak &&
-    vinnerRad === null &&
-    antallStemmere === 0
+  const harStemt = mineStemmer.length > 0
 
   // Vinner — utledes fra kaaring_vinnere (kilden til sannhet). Vi kan ikke
   // bruke stemmer-aggregatet siden RLS skjuler andres stemmer for vanlige
@@ -406,38 +406,26 @@ function KaaringVisning({
       {/* Tilstandsspesifikk seksjon */}
       {!erAvsluttet ? (
         <section style={{ marginBottom: 24 }}>
+          {harStemt && (
+            <div style={{ marginBottom: 24 }}>
+              <SectionLabel count={antallStemmere}>Foreløpig</SectionLabel>
+              <PollResultat
+                valg={valg}
+                stemmerPerValg={stemmerPerValg}
+                antallStemmere={antallStemmere}
+                mineStemmer={mineStemmer}
+              />
+            </div>
+          )}
           <SectionLabel>Velg din kandidat</SectionLabel>
           <KaaringPollStemming
             pollId={poll.id}
             valg={kaaringValg}
             mineStemmer={mineStemmer}
           />
-          <p
-            style={{
-              fontFamily: 'var(--font-body)',
-              fontSize: 12,
-              color: 'var(--text-tertiary)',
-              marginTop: 14,
-              fontStyle: 'italic',
-            }}
-          >
-            Stemmene er anonyme. Resultatet vises etter svarfristen.
-          </p>
-        </section>
-      ) : ingenStemmer ? (
-        <section style={{ marginBottom: 24 }}>
-          <p
-            style={{
-              fontFamily: 'var(--font-body)',
-              fontSize: 14,
-              color: 'var(--text-secondary)',
-              padding: 16,
-              border: '0.5px solid var(--border-subtle)',
-              borderRadius: 'var(--radius-card)',
-            }}
-          >
-            Ingen stemmer ble avgitt — ingen vinner kåret.
-          </p>
+          {kanLoeseTiebreak && poll.kaaring_mal_id && (
+            <LukkNaaKnapp pollId={poll.id} />
+          )}
         </section>
       ) : venterTiebreak ? (
         <section style={{ marginBottom: 24 }}>

--- a/app/(app)/poll/[id]/page.tsx
+++ b/app/(app)/poll/[id]/page.tsx
@@ -77,6 +77,11 @@ export default async function PollDetalj({
     // Aggregat via RPC — gir totalen uavhengig av RLS-skjul. For ikke-
     // kåringspoller er resultatet tomt, og vi bruker poll_stemme-radene
     // direkte slik som før. Se mig. 079.
+    //
+    // Bevisst ubetinget: vi kjenner ikke poll.kaaring_mal_id før første
+    // spørring er ferdig, og å sekvensere ville koste mer enn én ekstra
+    // billig RPC i parallell. RPCen returnerer tomt-set raskt for
+    // ikke-kåringspoller.
     hentPollStemmerAggregat(supabase, id),
   ])
 
@@ -424,7 +429,7 @@ function KaaringVisning({
             mineStemmer={mineStemmer}
           />
           {kanLoeseTiebreak && poll.kaaring_mal_id && (
-            <LukkNaaKnapp pollId={poll.id} />
+            <LukkNaaKnapp pollId={poll.id} disabled={antallStemmere === 0} />
           )}
         </section>
       ) : venterTiebreak ? (

--- a/components/agenda/NyFAB.tsx
+++ b/components/agenda/NyFAB.tsx
@@ -25,13 +25,8 @@ const VALG: Valg[] = [
  * Plussknapp i agenda-header som ekspanderer til en meny med valg av
  * hva slags nytt element som skal opprettes. Lukkes ved klikk utenfor
  * eller ved å trykke knappen igjen. Esc er ikke støttet — mobil først.
- *
- * `kanAdministrere`-propen er beholdt som no-op for å unngå å bryte
- * eksisterende kallsteder; den hadde tidligere innflytelse over om
- * «Kåring» ble vist, men kåringer flyttet til /kaaringer-siden i #144.
  */
-export default function NyFAB({ kanAdministrere: _kanAdministrere = false }: { kanAdministrere?: boolean }) {
-  void _kanAdministrere
+export default function NyFAB() {
   const [apen, setApen] = useState(false)
   const wrapperRef = useRef<HTMLDivElement>(null)
 

--- a/components/agenda/NyFAB.tsx
+++ b/components/agenda/NyFAB.tsx
@@ -12,28 +12,26 @@ type Valg = {
 
 // De fire typene element som kan opprettes på agenda. Speiler typene
 // definert i lib/agenda-sortering.ts (Møte/Tur er underkategorier av
-// arrangement, Poll og Melding er egne tabeller). «Kåring» legges på
-// kun for admin/generalsekretær (#87).
-const BASIS_VALG: Valg[] = [
+// arrangement, Poll og Melding er egne tabeller). Kåringer opprettes
+// fra /kaaringer-siden (#144), ikke fra denne menyen.
+const VALG: Valg[] = [
   { label: 'Møte', href: '/arrangementer/ny?type=moete', ikon: 'calendar' },
   { label: 'Tur', href: '/arrangementer/ny?type=tur', ikon: 'plane' },
   { label: 'Poll', href: '/poll/ny', ikon: 'chart' },
   { label: 'Melding', href: '/meldinger/ny', ikon: 'message' },
 ]
 
-const KAARING_VALG: Valg = {
-  label: 'Kåring',
-  href: '/kaaringspoll/ny',
-  ikon: 'trophy',
-}
-
 /**
  * Plussknapp i agenda-header som ekspanderer til en meny med valg av
  * hva slags nytt element som skal opprettes. Lukkes ved klikk utenfor
  * eller ved å trykke knappen igjen. Esc er ikke støttet — mobil først.
+ *
+ * `kanAdministrere`-propen er beholdt som no-op for å unngå å bryte
+ * eksisterende kallsteder; den hadde tidligere innflytelse over om
+ * «Kåring» ble vist, men kåringer flyttet til /kaaringer-siden i #144.
  */
-export default function NyFAB({ kanAdministrere = false }: { kanAdministrere?: boolean }) {
-  const VALG = kanAdministrere ? [...BASIS_VALG, KAARING_VALG] : BASIS_VALG
+export default function NyFAB({ kanAdministrere: _kanAdministrere = false }: { kanAdministrere?: boolean }) {
+  void _kanAdministrere
   const [apen, setApen] = useState(false)
   const wrapperRef = useRef<HTMLDivElement>(null)
 

--- a/lib/actions/kaaringspoll.ts
+++ b/lib/actions/kaaringspoll.ts
@@ -213,7 +213,12 @@ export async function velgTiebreakVinner(pollId: string, valgId: string) {
  * internt (belte og seler — RLS-bypass via SECURITY DEFINER krever det).
  */
 export async function lukkKaaringspollNaa(pollId: string) {
-  await ensureLoeserTiebreak()
+  // Vi trenger brukerens supabase-klient for selve RPC-kallet — RPC-en er
+  // SECURITY DEFINER og sjekker `er_generalsekretaer()` internt, som leser
+  // `auth.uid()`. Med service_role-klienten er auth.uid() null, og RPC-en
+  // ville alltid kaste 'forbudt'. Mottaker-oppslagene under bruker fortsatt
+  // admin-klienten fordi de leser på tvers av brukere.
+  const { supabase: brukerKlient } = await ensureLoeserTiebreak()
   const admin = createAdminClient()
 
   const { data: poll, error: pollErr } = await admin
@@ -242,7 +247,7 @@ export async function lukkKaaringspollNaa(pollId: string) {
     .filter(p => adminRoller.includes(p.rolle as (typeof adminRoller)[number]))
     .map(p => p.id)
 
-  const { data: rpcRes, error: rpcErr } = await admin.rpc(
+  const { data: rpcRes, error: rpcErr } = await brukerKlient.rpc(
     'lukk_kaaringspoll_naa',
     { p_poll_id: pollId },
   )

--- a/lib/actions/kaaringspoll.ts
+++ b/lib/actions/kaaringspoll.ts
@@ -8,7 +8,8 @@ import {
   sendKaaringspollOpprettetVarsel,
   sendKaaringspollVinnerVarsel,
 } from '@/lib/varsler'
-import { kanAdministrere } from '@/lib/roller'
+import { behandleKaaringspollAvsluttResultat } from '@/lib/varsler-kaaringspoll'
+import { kanAdministrere, rollerMed } from '@/lib/roller'
 
 type OpprettInput = {
   kaaringMalId: string
@@ -201,6 +202,73 @@ export async function velgTiebreakVinner(pollId: string, valgId: string) {
   revalidatePath(`/poll/${pollId}`)
   revalidatePath('/kaaringer')
   redirect(`/poll/${pollId}`)
+}
+
+/**
+ * Generalsekretær lukker en kåringspoll umiddelbart — uten å vente på at
+ * svarfristen passerer og cron tar den. Speiler cron-flyten i
+ * `behandleKaaringspoller`: kaller RPC, sender riktig varsel basert på
+ * status, og revaliderer relevante stier. Tilgang gates av
+ * `ensureLoeserTiebreak()` + RPC-en sjekker også `er_generalsekretaer()`
+ * internt (belte og seler — RLS-bypass via SECURITY DEFINER krever det).
+ */
+export async function lukkKaaringspollNaa(pollId: string) {
+  await ensureLoeserTiebreak()
+  const admin = createAdminClient()
+
+  const { data: poll, error: pollErr } = await admin
+    .from('poll')
+    .select('id, spoersmaal, kaaring_mal_id')
+    .eq('id', pollId)
+    .single()
+  if (pollErr || !poll) throw new Error('Pollen finnes ikke')
+  if (!poll.kaaring_mal_id) throw new Error('Ikke en kåringspoll')
+
+  // Mottakerlister identisk med cron-flyten — tiebreak går kun til de
+  // som faktisk skal løse den (generalsekretær), ingen-stemmer-info går
+  // til alle med admin-rettigheter.
+  const tiebreakRoller = rollerMed('loeserTiebreak')
+  const adminRoller = rollerMed('kanAdministrere')
+  const trengteRoller = Array.from(new Set([...tiebreakRoller, ...adminRoller]))
+  const { data: relevanteProfiler } = await admin
+    .from('profiles')
+    .select('id, rolle')
+    .in('rolle', trengteRoller)
+    .eq('aktiv', true)
+  const tiebreakIder = (relevanteProfiler ?? [])
+    .filter(p => tiebreakRoller.includes(p.rolle as (typeof tiebreakRoller)[number]))
+    .map(p => p.id)
+  const adminIder = (relevanteProfiler ?? [])
+    .filter(p => adminRoller.includes(p.rolle as (typeof adminRoller)[number]))
+    .map(p => p.id)
+
+  const { data: rpcRes, error: rpcErr } = await admin.rpc(
+    'lukk_kaaringspoll_naa',
+    { p_poll_id: pollId },
+  )
+  if (rpcErr) throw new Error(rpcErr.message)
+  const rad = Array.isArray(rpcRes) ? rpcRes[0] : rpcRes
+  if (!rad) throw new Error('RPC returnerte ingen rad')
+  if (!rad.var_ny) {
+    // Allerede lukket — idempotent, men gi UI noe å vise via revalidate.
+    revalidatePath(`/poll/${pollId}`)
+    revalidatePath('/kaaringer')
+    revalidatePath('/')
+    return
+  }
+
+  await behandleKaaringspollAvsluttResultat({
+    admin,
+    pollId,
+    spoersmaal: poll.spoersmaal,
+    status: rad.status as string,
+    tiebreakIder,
+    adminIder,
+  }).catch(console.error)
+
+  revalidatePath(`/poll/${pollId}`)
+  revalidatePath('/kaaringer')
+  revalidatePath('/')
 }
 
 // Eksportert kun for typesjekk i kall-stedet — voider unused-varselet.

--- a/lib/actions/kaaringspoll.ts
+++ b/lib/actions/kaaringspoll.ts
@@ -258,7 +258,6 @@ export async function lukkKaaringspollNaa(pollId: string) {
   }
 
   await behandleKaaringspollAvsluttResultat({
-    admin,
     pollId,
     spoersmaal: poll.spoersmaal,
     status: rad.status as string,

--- a/lib/actions/paaminnelser.ts
+++ b/lib/actions/paaminnelser.ts
@@ -4,10 +4,8 @@ import {
   sendPaaminneVarsler,
   sendPurringVarsler,
   sendArrangorPurringVarsler,
-  sendKaaringspollVinnerVarsel,
-  sendKaaringspollTiebreakVarsel,
-  sendKaaringspollIngenStemmerVarsel,
 } from '@/lib/varsler'
+import { behandleKaaringspollAvsluttResultat } from '@/lib/varsler-kaaringspoll'
 import { PAAMINNELSE_DAGER } from '@/lib/konstanter'
 import { rollerMed } from '@/lib/roller'
 import type { SupabaseClient } from '@supabase/supabase-js'
@@ -152,31 +150,15 @@ async function behandleKaaringspoller(admin: Admin) {
       lukketKaaringer += 1
       const status = rad.status as string
 
-      if (status === 'avgjort') {
-        await sendKaaringspollVinnerVarsel({
-          pollId: poll.id,
-          spoersmaal: poll.spoersmaal,
-        })
-        sendteVarsler += 1
-      } else if (status === 'venter_paa_tiebreak') {
-        if (tiebreakIder.length > 0) {
-          await sendKaaringspollTiebreakVarsel({
-            pollId: poll.id,
-            spoersmaal: poll.spoersmaal,
-            mottakere: tiebreakIder,
-          })
-          sendteVarsler += 1
-        }
-      } else if (status === 'ingen_stemmer') {
-        if (adminIder.length > 0) {
-          await sendKaaringspollIngenStemmerVarsel({
-            pollId: poll.id,
-            spoersmaal: poll.spoersmaal,
-            mottakere: adminIder,
-          })
-          sendteVarsler += 1
-        }
-      }
+      const { sendt } = await behandleKaaringspollAvsluttResultat({
+        admin,
+        pollId: poll.id,
+        spoersmaal: poll.spoersmaal,
+        status,
+        tiebreakIder,
+        adminIder,
+      })
+      if (sendt) sendteVarsler += 1
     } catch {
       kaaringFeil += 1
     }

--- a/lib/actions/paaminnelser.ts
+++ b/lib/actions/paaminnelser.ts
@@ -151,7 +151,6 @@ async function behandleKaaringspoller(admin: Admin) {
       const status = rad.status as string
 
       const { sendt } = await behandleKaaringspollAvsluttResultat({
-        admin,
         pollId: poll.id,
         spoersmaal: poll.spoersmaal,
         status,

--- a/lib/queries/poll.ts
+++ b/lib/queries/poll.ts
@@ -1,0 +1,40 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/lib/supabase/database.types'
+
+type DB = SupabaseClient<Database>
+
+// Henter aggregat (valg_id → antall) for én kåringspoll via RPC.
+// Bruker tell_poll_stemmer (mig. 079) som er SECURITY DEFINER og dermed
+// gir totaler uten å lekke profil_id. Klient-koden ville ellers sett kun
+// egne stemmer pga. RLS i mig. 076.
+export async function hentPollStemmerAggregat(
+  supabase: DB,
+  pollId: string,
+): Promise<Map<string, number>> {
+  const map = new Map<string, number>()
+  const { data, error } = await supabase.rpc('tell_poll_stemmer', {
+    p_poll_id: pollId,
+  })
+  if (error || !data) return map
+  for (const r of data as { valg_id: string; antall: number }[]) {
+    map.set(r.valg_id, Number(r.antall))
+  }
+  return map
+}
+
+// Batch-variant for agenda — kjører N kall i parallell. Hvis vi får mange
+// kåringspoller samtidig kan dette bli én RPC-runde mer enn nødvendig,
+// men antallet aktive kåringspoller per agenda-vindu er svært lavt
+// (typisk 0–2), så enkelheten vinner over én round-trip-besparelse.
+export async function hentPollStemmerAggregatBatch(
+  supabase: DB,
+  pollIds: string[],
+): Promise<Map<string, Map<string, number>>> {
+  const result = new Map<string, Map<string, number>>()
+  if (pollIds.length === 0) return result
+  const aggregater = await Promise.all(
+    pollIds.map(id => hentPollStemmerAggregat(supabase, id)),
+  )
+  pollIds.forEach((id, i) => result.set(id, aggregater[i]))
+  return result
+}

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -1321,7 +1321,24 @@ export type Database = {
           vinner_profil_id: string
         }[]
       }
+      lukk_kaaringspoll_naa: {
+        Args: { p_poll_id: string }
+        Returns: {
+          status: string
+          var_ny: boolean
+          vinner_arrangement_id: string
+          vinner_profil_id: string
+        }[]
+      }
+      tell_poll_stemmer: {
+        Args: { p_poll_id: string }
+        Returns: {
+          valg_id: string
+          antall: number
+        }[]
+      }
       er_admin: { Args: never; Returns: boolean }
+      er_generalsekretaer: { Args: never; Returns: boolean }
       get_statistikk: { Args: never; Returns: Json }
       har_pass_tilgang: { Args: { eier: string }; Returns: boolean }
     }

--- a/lib/varsler-kaaringspoll.ts
+++ b/lib/varsler-kaaringspoll.ts
@@ -1,0 +1,58 @@
+import {
+  sendKaaringspollVinnerVarsel,
+  sendKaaringspollTiebreakVarsel,
+  sendKaaringspollIngenStemmerVarsel,
+} from '@/lib/varsler'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/lib/supabase/database.types'
+
+type Admin = SupabaseClient<Database>
+
+// Sentral mapping fra RPC-status til riktig varsel-funksjon. Brukes av
+// både cron (paaminnelser.ts) og manuell lukk-flyt (kaaringspoll.ts) så
+// vi ikke duplikerer if/else-grenene to steder.
+//
+// `admin` er med i signaturen i tilfelle vi senere trenger DB-oppslag her.
+// Per nå er den ubrukt — la stå for å holde signaturen stabil mellom
+// kall-stedene.
+export async function behandleKaaringspollAvsluttResultat({
+  admin,
+  pollId,
+  spoersmaal,
+  status,
+  tiebreakIder,
+  adminIder,
+}: {
+  admin: Admin
+  pollId: string
+  spoersmaal: string
+  status: string
+  tiebreakIder: string[]
+  adminIder: string[]
+}): Promise<{ sendt: boolean }> {
+  void admin // reservert for evt. fremtidig bruk
+
+  if (status === 'avgjort') {
+    await sendKaaringspollVinnerVarsel({ pollId, spoersmaal })
+    return { sendt: true }
+  }
+  if (status === 'venter_paa_tiebreak') {
+    if (tiebreakIder.length === 0) return { sendt: false }
+    await sendKaaringspollTiebreakVarsel({
+      pollId,
+      spoersmaal,
+      mottakere: tiebreakIder,
+    })
+    return { sendt: true }
+  }
+  if (status === 'ingen_stemmer') {
+    if (adminIder.length === 0) return { sendt: false }
+    await sendKaaringspollIngenStemmerVarsel({
+      pollId,
+      spoersmaal,
+      mottakere: adminIder,
+    })
+    return { sendt: true }
+  }
+  return { sendt: false }
+}

--- a/lib/varsler-kaaringspoll.ts
+++ b/lib/varsler-kaaringspoll.ts
@@ -3,35 +3,23 @@ import {
   sendKaaringspollTiebreakVarsel,
   sendKaaringspollIngenStemmerVarsel,
 } from '@/lib/varsler'
-import type { SupabaseClient } from '@supabase/supabase-js'
-import type { Database } from '@/lib/supabase/database.types'
-
-type Admin = SupabaseClient<Database>
 
 // Sentral mapping fra RPC-status til riktig varsel-funksjon. Brukes av
 // både cron (paaminnelser.ts) og manuell lukk-flyt (kaaringspoll.ts) så
 // vi ikke duplikerer if/else-grenene to steder.
-//
-// `admin` er med i signaturen i tilfelle vi senere trenger DB-oppslag her.
-// Per nå er den ubrukt — la stå for å holde signaturen stabil mellom
-// kall-stedene.
 export async function behandleKaaringspollAvsluttResultat({
-  admin,
   pollId,
   spoersmaal,
   status,
   tiebreakIder,
   adminIder,
 }: {
-  admin: Admin
   pollId: string
   spoersmaal: string
   status: string
   tiebreakIder: string[]
   adminIder: string[]
 }): Promise<{ sendt: boolean }> {
-  void admin // reservert for evt. fremtidig bruk
-
   if (status === 'avgjort') {
     await sendKaaringspollVinnerVarsel({ pollId, spoersmaal })
     return { sendt: true }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 217,
-  "versjon": "V2.217"
+  "nummer": 218,
+  "versjon": "V2.218"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 218,
-  "versjon": "V2.218"
+  "nummer": 219,
+  "versjon": "V2.219"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.218'
+const CACHE_VERSION = 'V2.219'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.217'
+const CACHE_VERSION = 'V2.218'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/supabase/migrations/079_poll_stemme_aggregat.sql
+++ b/supabase/migrations/079_poll_stemme_aggregat.sql
@@ -1,0 +1,34 @@
+-- Aggregat-funksjon for stemmer per valg.
+--
+-- Bakgrunn: RLS på poll_stemme (mig. 076) skjuler andres stemmer for
+-- vanlige medlemmer mens en poll er åpen — anonymitet under stemming.
+-- Det betyr at klient-koden ikke kan bygge en stemmefordeling fra
+-- poll_stemme-rader direkte: en vanlig medlem ville bare sett sine egne.
+--
+-- Denne funksjonen returnerer kun aggregatet `(valg_id, antall)`. Den
+-- lekker ikke profil_id — det er den eneste kolonnen som er sensitiv
+-- her. SECURITY DEFINER er bevisst valgt: return-typen `(valg_id, antall)`
+-- er sikkerhetsgrenseflaten. INVOKER ville falt på RLS i mig. 076 og
+-- returnert kun kallerens egne stemmer.
+--
+-- Indeks: poll_stemme(poll_id) finnes som poll_stemme_poll_id_idx fra
+-- mig. 049, så group by er billig.
+
+create or replace function tell_poll_stemmer(p_poll_id uuid)
+returns table (
+  valg_id uuid,
+  antall  bigint
+)
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select valg_id, count(*)::bigint
+    from poll_stemme
+   where poll_id = p_poll_id
+   group by valg_id
+$$;
+
+revoke execute on function tell_poll_stemmer(uuid) from public;
+grant execute on function tell_poll_stemmer(uuid) to authenticated;

--- a/supabase/migrations/080_lukk_kaaringspoll_naa_rpc.sql
+++ b/supabase/migrations/080_lukk_kaaringspoll_naa_rpc.sql
@@ -9,6 +9,12 @@
 -- Tilgang: kun generalsekretær. Vi sjekker dette i SQL via en hjelper
 -- som speiler Policy: Roller fra app-laget. Samme som er_admin() — RLS
 -- må kjenne rollene fordi SECURITY DEFINER omgår normal RLS.
+--
+-- Vi setter også svarfrist = least(svarfrist, now()) når vi lukker.
+-- Insert-policyen for poll_stemme (mig. 049) sjekker `svarfrist > now()`,
+-- ikke avsluttet_paa, så uten denne oppdateringen kunne medlemmer fortsette
+-- å stemme etter manuell lukking — og potensielt endre vinneren etter at
+-- den allerede er beregnet og varsler er sendt.
 
 create or replace function er_generalsekretaer()
 returns boolean
@@ -83,7 +89,8 @@ begin
 
   if v_topp_antall is null or v_topp_antall = 0 then
     update poll
-       set avsluttet_paa = now()
+       set avsluttet_paa = now(),
+           svarfrist     = least(svarfrist, now())
      where id = p_poll_id;
     return query select null::uuid, null::uuid, true, 'ingen_stemmer'::text;
     return;
@@ -92,6 +99,7 @@ begin
   if v_topp_count > 1 then
     update poll
        set avsluttet_paa   = now(),
+           svarfrist       = least(svarfrist, now()),
            tiebreak_status = 'venter_paa_tiebreak'
      where id = p_poll_id;
     return query select null::uuid, null::uuid, true, 'venter_paa_tiebreak'::text;
@@ -127,6 +135,7 @@ begin
 
   update poll
      set avsluttet_paa   = now(),
+         svarfrist       = least(svarfrist, now()),
          tiebreak_status = 'avgjort'
    where id = p_poll_id;
 

--- a/supabase/migrations/080_lukk_kaaringspoll_naa_rpc.sql
+++ b/supabase/migrations/080_lukk_kaaringspoll_naa_rpc.sql
@@ -1,0 +1,141 @@
+-- Lukk kåringspoll umiddelbart (manuell variant av avslutt_kaaringspoll).
+--
+-- Bakgrunn: cron-jobben (lib/actions/paaminnelser.ts) plukker opp poller
+-- når svarfristen er passert og kaller avslutt_kaaringspoll. Generalsekretær
+-- skal i tillegg kunne lukke en åpen kåring her og nå — uten å vente på
+-- at fristen og cron skal innfinne seg. Logikken er identisk med 077,
+-- bortsett fra at vi hopper over moden-sjekken (svarfrist > now()).
+--
+-- Tilgang: kun generalsekretær. Vi sjekker dette i SQL via en hjelper
+-- som speiler Policy: Roller fra app-laget. Samme som er_admin() — RLS
+-- må kjenne rollene fordi SECURITY DEFINER omgår normal RLS.
+
+create or replace function er_generalsekretaer()
+returns boolean
+language sql
+stable
+as $$
+  select exists (
+    select 1 from profiles
+     where id = auth.uid()
+       and rolle = 'generalsekretaer'
+  )
+$$;
+
+create or replace function lukk_kaaringspoll_naa(p_poll_id uuid)
+returns table (
+  vinner_profil_id      uuid,
+  vinner_arrangement_id uuid,
+  var_ny                boolean,
+  status                text
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_poll record;
+  v_topp_antall integer;
+  v_topp_count integer;
+  v_vinner_valg record;
+begin
+  if not er_generalsekretaer() then
+    raise exception 'forbudt';
+  end if;
+
+  select id, kaaring_mal_id, aar, svarfrist, avsluttet_paa, opprettet_av
+    into v_poll
+    from poll
+   where id = p_poll_id
+   for update;
+
+  if not found then
+    return query select null::uuid, null::uuid, false, 'ikke_funnet'::text;
+    return;
+  end if;
+
+  if v_poll.kaaring_mal_id is null then
+    return query select null::uuid, null::uuid, false, 'ikke_kaaring'::text;
+    return;
+  end if;
+
+  if v_poll.avsluttet_paa is not null then
+    return query select null::uuid, null::uuid, false, 'allerede_avsluttet'::text;
+    return;
+  end if;
+
+  -- NB: Hopper over moden-sjekken bevisst — manuell lukking skal kunne
+  -- skje før svarfristen er passert.
+
+  with stemmer_per_valg as (
+    select pv.id as valg_id,
+           pv.referanse_profil_id,
+           pv.referanse_arrangement_id,
+           count(ps.profil_id) as antall
+      from poll_valg pv
+      left join poll_stemme ps on ps.valg_id = pv.id
+     where pv.poll_id = p_poll_id
+     group by pv.id, pv.referanse_profil_id, pv.referanse_arrangement_id
+  )
+  select max(antall), count(*) filter (where antall = (select max(antall) from stemmer_per_valg))
+    into v_topp_antall, v_topp_count
+    from stemmer_per_valg;
+
+  if v_topp_antall is null or v_topp_antall = 0 then
+    update poll
+       set avsluttet_paa = now()
+     where id = p_poll_id;
+    return query select null::uuid, null::uuid, true, 'ingen_stemmer'::text;
+    return;
+  end if;
+
+  if v_topp_count > 1 then
+    update poll
+       set avsluttet_paa   = now(),
+           tiebreak_status = 'venter_paa_tiebreak'
+     where id = p_poll_id;
+    return query select null::uuid, null::uuid, true, 'venter_paa_tiebreak'::text;
+    return;
+  end if;
+
+  with stemmer_per_valg as (
+    select pv.id as valg_id,
+           pv.referanse_profil_id,
+           pv.referanse_arrangement_id,
+           count(ps.profil_id) as antall
+      from poll_valg pv
+      left join poll_stemme ps on ps.valg_id = pv.id
+     where pv.poll_id = p_poll_id
+     group by pv.id, pv.referanse_profil_id, pv.referanse_arrangement_id
+  )
+  select valg_id, referanse_profil_id, referanse_arrangement_id
+    into v_vinner_valg
+    from stemmer_per_valg
+   where antall = v_topp_antall
+   limit 1;
+
+  insert into kaaring_vinnere (mal_id, aar, profil_id, arrangement_id, opprettet_av, poll_id)
+  values (
+    v_poll.kaaring_mal_id,
+    v_poll.aar,
+    v_vinner_valg.referanse_profil_id,
+    v_vinner_valg.referanse_arrangement_id,
+    v_poll.opprettet_av,
+    p_poll_id
+  )
+  on conflict (mal_id, aar) do nothing;
+
+  update poll
+     set avsluttet_paa   = now(),
+         tiebreak_status = 'avgjort'
+   where id = p_poll_id;
+
+  return query select v_vinner_valg.referanse_profil_id,
+                      v_vinner_valg.referanse_arrangement_id,
+                      true,
+                      'avgjort'::text;
+end;
+$$;
+
+revoke execute on function lukk_kaaringspoll_naa(uuid) from public;
+grant execute on function lukk_kaaringspoll_naa(uuid) to authenticated;


### PR DESCRIPTION
Lukker #144.

## Sammendrag
- **Endring 1 — løpende stemmetall:** Ny aggregat-RPC `tell_poll_stemmer` (SECURITY DEFINER, returtype er sikkerhetsgrenseflaten — kun `valg_id, antall`). Detaljside og agenda bytter til aggregat for kåringspoller. «Foreløpig»-resultat vises over kandidat-listen når man har stemt.
- **Endring 2 — «Lukk nå»:** Ny RPC `lukk_kaaringspoll_naa` parallelt med cron-RPC, med intern `er_generalsekretaer()`-sjekk og `select … for update`. Ny server action `lukkKaaringspollNaa`. Knappen er disabled når ingen har stemt.
- **Endring 3 — flytt CTA:** «Ny kåring»-pille i Hall of Fame-headeren (kun admin/generalsekretær). Fjernet «Kåring» fra agenda-`+`-menyen.
- **Refaktor:** Felles `behandleKaaringspollAvsluttResultat`-hjelper brukes av både cron og ny manuell action. Dropp `ingenStemmer`-grenen og kursivlinjen «Stemmene er anonyme…».

## Beslutninger underveis
- Arkitekturstyret innkalt på Endring 1 (RLS-tradeoff). Endelig uttalelse i [issue-kommentar](https://github.com/reidarei/Herreklubben/issues/144#issuecomment-4416157355): generisk RPC for alle poller, INVOKER om mulig, ingen Realtime broadcast på lukking, agenda må migreres samme PR. Implementasjonen avviker bevisst på ett punkt: aggregat-RPC er DEFINER (ikke INVOKER) fordi RLS i mig. 076 ellers filtrerer bort andres stemmer. Sikkerhetsgrenseflaten flyttes til returtypen som ikke kan lekke `profil_id`.
- Reviewer fant 1 MAJOR + 5 MINOR + 1 NIT. 5 rettet av integrator (admin-prop fjernet, NyFAB-prop ryddet, type-cast fjernet, «Lukk nå» disabled ved 0 stemmer, let→const). 1 MAJOR forsvart med referanse til styret (frosset aggregat er bevisst tradeoff). 1 MINOR forsvart (parallell RPC > sekvensiell betinget for vanlige polls).

## Manuell oppfølging etter merge
- Kjør migrasjonene mot Supabase: `npx supabase db push`
- Regenerer typer: `npx supabase gen types typescript --project-id tdlfswmxezjdnxcbbiwn > lib/supabase/database.types.ts`
- Opprett oppfølger-issue: `sendVarsel`-timeout per mottaker (`Promise.allSettled`-mønster) — flagget av styret som utenfor scope.

## Test plan
- [ ] Som vanlig medlem: åpne kåringspoll, ikke stemt — se kun kandidater
- [ ] Stem — se «Foreløpig»-resultat over kandidatene, ingen kursivtekst
- [ ] Som annen bruker stem på samme poll, refresh — totalt antall oppdateres
- [ ] Som generalsekretær: «Lukk nå»-knapp synlig på åpen kåringspoll, disabled før noen har stemt
- [ ] Lukk pollen → vinner-banner / tiebreak / ingen-stemmer-flyt
- [ ] `/kaaringer` viser «Ny kåring»-pille for admin/generalsekretær, ikke for medlem
- [ ] Agenda-`+` viser kun Møte/Tur/Poll/Melding

🤖 Generated with [Claude Code](https://claude.com/claude-code)
