### PR TITLE
Eliminér dock-bug-klassen: Chat-eid skjul-attributt + global hook (#147)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,10 +243,14 @@ Alle profil-avatarer (medlemsansikter) skal rendres via `components/ui/Avatar.ts
 
 ## Policy: Bottom-nav-skjul
 
-Bottom-nav-docken skjules automatisk når en chat-input har fokus, via attributtet `data-chat-input-fokusert` på `<html>`. **Kun Chat-komponenter** har lov til å sette dette attributtet — det skjer via hooken `useSkjulBottomNavVedFokus()` i `lib/hooks/`.
+Bottom-nav-docken skjules automatisk når et input-element med `data-chat-input="true"` har fokus.
 
-`BottomNav` er passiv: den leser ingenting selv. CSS i `globals.css` skjuler docken når attributtet er satt.
+**Slik fungerer det:**
+- Hooken `useSkjulBottomNavVedFokus()` mountes ÉN gang globalt fra `BottomNav` (som er mountet i app-layouten). Den lytter på `document` etter focusin/focusout og setter `data-chat-input-fokusert` på `<html>` når et matchende element har fokus.
+- CSS i `globals.css` skjuler docken når attributtet er satt.
 
-Hvis du legger til en ny chat-lignende komponent, kall hooken og sørg for at input-elementene har `data-chat-input="true"`.
+**Når du legger til en ny chat-lignende input:** Sett `data-chat-input="true"` på input/textarea-elementet. Det er alt — ingen import, ingen hook-kall lokalt.
+
+Hvorfor global mount: gir én lytter for hele appen, eliminerer race-conditions ved samtidige Chat-instanser, og fjerner kontrakts-risikoen der nye kalls-steder glemmer å kalle hooken.
 
 Supabase: Herreklubbens org, Herreklubbens webapp. Database-passordet ligger i `.env.local` som `SUPABASE_DB_PASSWORD`. Hent fra Supabase Dashboard → Project Settings → Database. Skript som trenger direkte Postgres-tilgang kjøres med `node --env-file=.env.local scripts/<navn>.mjs`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,4 +241,12 @@ Alle profil-avatarer (medlemsansikter) skal rendres via `components/ui/Avatar.ts
 
 **Når du legger til nye steder som viser profilbilder:** Bruk `<Avatar name={...} src={bilde_url} rolle={rolle} />`. Gul glød for generalsekretær faller da inn av seg selv — sjekker for dette skal ikke duplikeres utenfor komponenten.
 
+## Policy: Bottom-nav-skjul
+
+Bottom-nav-docken skjules automatisk når en chat-input har fokus, via attributtet `data-chat-input-fokusert` på `<html>`. **Kun Chat-komponenter** har lov til å sette dette attributtet — det skjer via hooken `useSkjulBottomNavVedFokus()` i `lib/hooks/`.
+
+`BottomNav` er passiv: den leser ingenting selv. CSS i `globals.css` skjuler docken når attributtet er satt.
+
+Hvis du legger til en ny chat-lignende komponent, kall hooken og sørg for at input-elementene har `data-chat-input="true"`.
+
 Supabase: Herreklubbens org, Herreklubbens webapp. Database-passordet ligger i `.env.local` som `SUPABASE_DB_PASSWORD`. Hent fra Supabase Dashboard → Project Settings → Database. Skript som trenger direkte Postgres-tilgang kjøres med `node --env-file=.env.local scripts/<navn>.mjs`.

--- a/app/globals.css
+++ b/app/globals.css
@@ -97,20 +97,17 @@ body {
   animation: page-fadein 0.22s cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
 }
 
-/* Dock-skjuling håndteres i BottomNav.tsx via inline `display: none`.
-   I tillegg toggler BottomNav klassen `tastatur-oppe` på <html> for å
-   la <main> fjerne sin pb-24 (bunnpadding reservert til dock). Uten det
-   blir det dødt mellomrom mellom chat-input og tastaturet. Begge styres
-   fra samme state — ingen risiko for divergens. */
-html.tastatur-oppe main {
+/* Dock-skjuling: hooken `useSkjulBottomNavVedFokus` i lib/hooks/ setter
+   attributtet `data-chat-input-fokusert` på <html> mens en chat-input har
+   fokus. Selve skjulingen og padding-nullingen skjer her. BottomNav er
+   passiv. Se CLAUDE.md → Policy: Bottom-nav-skjul. */
+html[data-chat-input-fokusert] nav[aria-label="Hovednavigasjon"] {
+  display: none;
+}
+html[data-chat-input-fokusert] main {
   padding-bottom: 0 !important;
 }
-
-/* Sider bruker inline-style `padding: 0 20px 120px` for å gi plass til
-   docken under innholdet. Når docken er skjult (tastatur oppe) blir det
-   dødt mellomrom mellom siste innhold og tastaturet. Vi nuller bunnen
-   via attribut-selektor — !important slår inline-padding-shorthand. */
-html.tastatur-oppe [style*="20px 120px"] {
+html[data-chat-input-fokusert] [style*="20px 120px"] {
   padding-bottom: 0 !important;
 }
 

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import Image from 'next/image'
 import { usePathname } from 'next/navigation'
 import { useEffect, useState, type CSSProperties, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 import Icon, { type IkonNavn } from '@/components/ui/Icon'
 
 type Tab = {
@@ -54,6 +55,18 @@ export default function BottomNav({ brukerNavn, bildeUrl }: Props) {
   //   5. Reset ved pathname-endring + 300ms polling KUN når tastaturApent
   //      er true (slik at vi ikke vekker prosessoren unødvendig)
   const [tastaturApent, setTastaturApent] = useState(false)
+
+  // Portal-mount-flagg. Dokken rendres via createPortal mot document.body
+  // for å garantere at INGEN stamfar i React-treet kan etablere ny
+  // "containing block" for position:fixed (transform/filter/backdrop-
+  // filter/perspective/will-change/contain). Dette er defense-in-depth
+  // mot regresjoner som #147 der dokken begynte å følge med scroll på iOS
+  // selv om koden i BottomNav var uendret. SSR-safe: portalen monteres
+  // først etter første client-render via useEffect.
+  const [montert, setMontert] = useState(false)
+  useEffect(() => {
+    setMontert(true)
+  }, [])
 
   // Reset ved navigasjon — fanger tilfeller der focusout aldri fyrer
   useEffect(() => {
@@ -176,7 +189,9 @@ export default function BottomNav({ brukerNavn, bildeUrl }: Props) {
     marginInline: 'auto',
   }
 
-  return (
+  if (!montert) return null
+
+  return createPortal(
     <nav className="fixed" style={containerStyle} aria-label="Hovednavigasjon">
       {/* Top glint overlay */}
       <span
@@ -256,7 +271,8 @@ export default function BottomNav({ brukerNavn, bildeUrl }: Props) {
           </NavElementer>
         )
       })}
-    </nav>
+    </nav>,
+    document.body,
   )
 }
 

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation'
 import { useEffect, useState, type CSSProperties, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import Icon, { type IkonNavn } from '@/components/ui/Icon'
+import { useSkjulBottomNavVedFokus } from '@/lib/hooks/useSkjulBottomNavVedFokus'
 
 type Tab = {
   id: 'hjem' | 'klubbinfo' | 'chat' | 'profil'
@@ -41,6 +42,12 @@ export default function BottomNav({ brukerNavn, bildeUrl }: Props) {
   const pathname = usePathname()
   const initial = initialAv(brukerNavn ?? undefined)
 
+  // Mount lytteren én gang globalt — BottomNav er mountet for hele app-layouten.
+  // Dette eliminerer race-conditions ved multi-mount og betyr at alle elementer
+  // med data-chat-input="true" automatisk skjuler docken ved fokus, uansett
+  // hvilken komponent de bor i. Se CLAUDE.md → Policy: Bottom-nav-skjul.
+  useSkjulBottomNavVedFokus()
+
   // Portal-mount-flagg. Dokken rendres via createPortal mot document.body
   // for å garantere at INGEN stamfar i React-treet kan etablere ny
   // "containing block" for position:fixed (transform/filter/backdrop-
@@ -53,11 +60,9 @@ export default function BottomNav({ brukerNavn, bildeUrl }: Props) {
     setMontert(true)
   }, [])
 
-  // Dock-skjuling ved chat-input-fokus styres av attributtet
-  // `data-chat-input-fokusert` på <html>, satt av hooken
-  // `useSkjulBottomNavVedFokus` i Chat-komponenter. CSS i globals.css
-  // gjør selve skjulingen. BottomNav er passiv her — leser ingenting selv.
-  // Se CLAUDE.md → Policy: Bottom-nav-skjul.
+  // Dock-skjuling: hooken over setter `data-chat-input-fokusert` på <html>
+  // når et element med data-chat-input="true" har fokus. CSS i globals.css
+  // gjør selve skjulingen.
   const containerStyle: CSSProperties = {
     position: 'fixed',
     bottom: 'calc(14px + env(safe-area-inset-bottom, 0px))',

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -41,21 +41,6 @@ export default function BottomNav({ brukerNavn, bildeUrl }: Props) {
   const pathname = usePathname()
   const initial = initialAv(brukerNavn ?? undefined)
 
-  // Skjul dokken når tastaturet er åpent — ellers flyter den over
-  // chat-input og skjemaer. BottomNav er den ENESTE sannhets-kilden for
-  // dock-synlighet (issue #99): tidligere fantes en parallell mekanisme
-  // i Chat.tsx + globals.css som kunne komme ut av synk og etterlate
-  // docken skjult etter iOS swipe-back.
-  //
-  // Fem cleanup-lag for å overleve iOS-edge-cases:
-  //   1. focusin/focusout på input/textarea — primær trigger
-  //   2. visualViewport.resize — toveis sjekk basert på keyboard-høyde
-  //   3. pagehide — fyrer ved iOS swipe-back før page unmount
-  //   4. visibilitychange → hidden — når app går i bakgrunnen
-  //   5. Reset ved pathname-endring + 300ms polling KUN når tastaturApent
-  //      er true (slik at vi ikke vekker prosessoren unødvendig)
-  const [tastaturApent, setTastaturApent] = useState(false)
-
   // Portal-mount-flagg. Dokken rendres via createPortal mot document.body
   // for å garantere at INGEN stamfar i React-treet kan etablere ny
   // "containing block" for position:fixed (transform/filter/backdrop-
@@ -68,106 +53,18 @@ export default function BottomNav({ brukerNavn, bildeUrl }: Props) {
     setMontert(true)
   }, [])
 
-  // Reset ved navigasjon — fanger tilfeller der focusout aldri fyrer
-  useEffect(() => {
-    setTastaturApent(false)
-  }, [pathname])
-
-  // Toggle klasse på <html> så CSS kan fjerne pb-24 fra <main> når dock
-  // er skjult. Uten dette blir det 96px dødt mellomrom mellom chat-input
-  // og tastaturet. Single source of truth — driven utelukkende fra denne
-  // statet, ingen risiko for divergens med andre mekanismer.
-  useEffect(() => {
-    const html = document.documentElement
-    if (tastaturApent) html.classList.add('tastatur-oppe')
-    else html.classList.remove('tastatur-oppe')
-    return () => html.classList.remove('tastatur-oppe')
-  }, [tastaturApent])
-
-  // Hovedeffekt: alle event-baserte signaler. Kjører hele tiden.
-  useEffect(() => {
-    function erTekstInput(el: EventTarget | null): boolean {
-      if (!el || !(el instanceof HTMLElement)) return false
-      const tag = el.tagName
-      return tag === 'INPUT' || tag === 'TEXTAREA' || el.isContentEditable
-    }
-    function onFocusIn(e: FocusEvent) {
-      if (erTekstInput(e.target)) setTastaturApent(true)
-    }
-    function onFocusOut(e: FocusEvent) {
-      if (erTekstInput(e.target)) setTastaturApent(false)
-    }
-    document.addEventListener('focusin', onFocusIn)
-    document.addEventListener('focusout', onFocusOut)
-
-    const vv = window.visualViewport
-    function onVv() {
-      if (!vv) return
-      // Enveis: kun setter til true når tastatur er detektert oppe.
-      // False-tilstanden styres av focusout, pagehide, visibilitychange,
-      // pathname-change og polling-fallback. Toveis VV var problematisk
-      // fordi iOS Safari fyrer VV-resize-events under scroll (URL-bar-
-      // kollaps, momentum, overscroll-bounce) — verdien kan kortvarig
-      // krysse 150-terskelen og flippe state under scroll i chat (#104).
-      if (window.innerHeight - vv.height > 150) setTastaturApent(true)
-    }
-    vv?.addEventListener('resize', onVv)
-
-    function reset() {
-      setTastaturApent(false)
-    }
-    function onVisibility() {
-      if (document.visibilityState === 'hidden') reset()
-    }
-    window.addEventListener('pagehide', reset)
-    document.addEventListener('visibilitychange', onVisibility)
-
-    return () => {
-      document.removeEventListener('focusin', onFocusIn)
-      document.removeEventListener('focusout', onFocusOut)
-      vv?.removeEventListener('resize', onVv)
-      window.removeEventListener('pagehide', reset)
-      document.removeEventListener('visibilitychange', onVisibility)
-    }
-  }, [])
-
-  // Polling-fallback: KUN aktiv når tastaturApent er true. Sjekker fokus
-  // hver 300ms — hvis ingen tekst-input er fokusert, reset state.
-  // Tidligere sjekket vi også VV her, men på iOS PWA/standalone matcher
-  // `window.innerHeight` ofte `visualViewport.height` selv med tastatur
-  // oppe (interactive-widget=resizes-content). Det førte til at polling
-  // feilaktig resettet state og docken dukket opp i bunnen av siden (#104).
-  // Trade-off: hvis bruker tapper iOS «Done» beholder input fokus →
-  // dock forblir skjult til input mister fokus. Akseptabelt.
-  useEffect(() => {
-    if (!tastaturApent) return
-    const id = setInterval(() => {
-      const aktiv = document.activeElement
-      const erInput =
-        !!aktiv &&
-        aktiv instanceof HTMLElement &&
-        (aktiv.tagName === 'INPUT' ||
-          aktiv.tagName === 'TEXTAREA' ||
-          aktiv.isContentEditable)
-      if (!erInput) setTastaturApent(false)
-    }, 300)
-    return () => clearInterval(id)
-  }, [tastaturApent])
-
-  // display: 'none' når tastaturet er oppe — IKKE bare opacity:0.
-  // Grunn: iOS Safari har en quirk der position:fixed-elementer kan ende
-  // opp ankret til dokument-bunn (ikke viewport-bunn) når tastaturet er
-  // oppe. Da blir docken synlig nederst i sideinnholdet (etter "Tidligere"
-  // i agendaen), spesielt på chat-siden der man alltid scroller til bunns.
-  // display:none fjerner elementet fra layout helt — det kan ikke ende opp
-  // i feil posisjon hvis det ikke finnes (#104).
+  // Dock-skjuling ved chat-input-fokus styres av attributtet
+  // `data-chat-input-fokusert` på <html>, satt av hooken
+  // `useSkjulBottomNavVedFokus` i Chat-komponenter. CSS i globals.css
+  // gjør selve skjulingen. BottomNav er passiv her — leser ingenting selv.
+  // Se CLAUDE.md → Policy: Bottom-nav-skjul.
   const containerStyle: CSSProperties = {
     position: 'fixed',
     bottom: 'calc(14px + env(safe-area-inset-bottom, 0px))',
     left: 0,
     right: 0,
     zIndex: 30,
-    display: tastaturApent ? 'none' : 'flex',
+    display: 'flex',
     borderRadius: 999,
     padding: 6,
     background: `

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -53,8 +53,15 @@ export default function BottomNav({ brukerNavn, bildeUrl }: Props) {
   // "containing block" for position:fixed (transform/filter/backdrop-
   // filter/perspective/will-change/contain). Dette er defense-in-depth
   // mot regresjoner som #147 der dokken begynte å følge med scroll på iOS
-  // selv om koden i BottomNav var uendret. SSR-safe: portalen monteres
-  // først etter første client-render via useEffect.
+  // selv om koden i BottomNav var uendret.
+  //
+  // SSR-strategi: Ved første render (server + før mount) rendres docken
+  // inline der komponenten sitter i React-treet. Etter mount flyttes den
+  // til document.body via portal. Dette unngår "tomrom" på første paint —
+  // brukeren ser dock med en gang, og portal-flyttingen skjer usynlig
+  // straks etter hydrering. Eventuell containing-block-bug fra en stamfar
+  // vil kun gjelde i det korte vinduet før hydrering, hvor scroll uansett
+  // ikke er aktivt.
   const [montert, setMontert] = useState(false)
   useEffect(() => {
     setMontert(true)
@@ -91,9 +98,7 @@ export default function BottomNav({ brukerNavn, bildeUrl }: Props) {
     marginInline: 'auto',
   }
 
-  if (!montert) return null
-
-  return createPortal(
+  const innhold = (
     <nav className="fixed" style={containerStyle} aria-label="Hovednavigasjon">
       {/* Top glint overlay */}
       <span
@@ -173,9 +178,12 @@ export default function BottomNav({ brukerNavn, bildeUrl }: Props) {
           </NavElementer>
         )
       })}
-    </nav>,
-    document.body,
+    </nav>
   )
+
+  // Server + første client-render: render inline. Etter mount: flytt til portal.
+  if (!montert) return innhold
+  return createPortal(innhold, document.body)
 }
 
 function NavElementer({ children, visSeparator }: { children: ReactNode; visSeparator: boolean }) {

--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -18,7 +18,6 @@ import BildeLightbox from '@/components/ui/BildeLightbox'
 import MessengerBadge from '@/components/ui/MessengerBadge'
 import { komprimer, genererFilnavn } from '@/lib/bilde-utils'
 import { lastOppBilde, slettBilde } from '@/lib/actions/bilde-opplasting'
-import { useSkjulBottomNavVedFokus } from '@/lib/hooks/useSkjulBottomNavVedFokus'
 
 // ChatScope er sentralt definert i lib/chat-konfig.ts og re-eksportert her
 // for kall-ergonomi (eksisterende callsites importerer fra Chat.tsx).
@@ -89,7 +88,8 @@ export default function Chat({
   visSeksjonsLabel = true,
   autoScrollTilBunn = false,
 }: Props) {
-  useSkjulBottomNavVedFokus()
+  // Dock-skjuling håndteres globalt av useSkjulBottomNavVedFokus i BottomNav.
+  // Alt vi trenger her er data-chat-input="true" på input-elementet.
 
   // initialMeldinger kommer som de siste N meldingene i stigende rekkefølge
   const [meldinger, setMeldinger] = useState<ChatMelding[]>(initialMeldinger)

--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -18,6 +18,7 @@ import BildeLightbox from '@/components/ui/BildeLightbox'
 import MessengerBadge from '@/components/ui/MessengerBadge'
 import { komprimer, genererFilnavn } from '@/lib/bilde-utils'
 import { lastOppBilde, slettBilde } from '@/lib/actions/bilde-opplasting'
+import { useSkjulBottomNavVedFokus } from '@/lib/hooks/useSkjulBottomNavVedFokus'
 
 // ChatScope er sentralt definert i lib/chat-konfig.ts og re-eksportert her
 // for kall-ergonomi (eksisterende callsites importerer fra Chat.tsx).
@@ -88,6 +89,8 @@ export default function Chat({
   visSeksjonsLabel = true,
   autoScrollTilBunn = false,
 }: Props) {
+  useSkjulBottomNavVedFokus()
+
   // initialMeldinger kommer som de siste N meldingene i stigende rekkefølge
   const [meldinger, setMeldinger] = useState<ChatMelding[]>(initialMeldinger)
   const [harMerEldre, setHarMerEldre] = useState(initialMeldinger.length >= SIDE_STORRELSE)
@@ -286,10 +289,7 @@ export default function Chat({
     if (autoScrollTilBunn && diff > 0 && diff <= 3) scrollTilBunn()
   }, [meldinger.length, scrollTilBunn, autoScrollTilBunn])
 
-  // Dock-skjuling ved tastatur-opp håndteres nå sentralt i BottomNav.tsx
-  // (issue #99). Tidligere hadde vi en parallell mekanisme her som satte
-  // klassen `chat-input-fokus` på <html>; det er fjernet for å unngå
-  // dual-system-konflikten som etterlot dock skjult etter iOS swipe-back.
+  // Dock-skjuling håndteres av useSkjulBottomNavVedFokus().
 
   // Realtime-subscription — én kanal per scope
   useEffect(() => {
@@ -829,6 +829,7 @@ export default function Chat({
                     >
                       <textarea
                         autoFocus
+                        data-chat-input="true"
                         value={editTekst}
                         onChange={e => setEditTekst(e.target.value)}
                         onKeyDown={e => {

--- a/e2e/dock-scroll-147.spec.ts
+++ b/e2e/dock-scroll-147.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect, Page } from '@playwright/test'
+import fs from 'node:fs'
+import path from 'node:path'
+
+/**
+ * Reproduserer dock-regresjon (#147): bottom-nav følger med scroll på
+ * iOS Safari/PWA istedenfor å være ankret til viewport-bunnen.
+ *
+ * Strategi:
+ *  1. Logg inn, naviger til agendaen
+ *  2. Mål nav.getBoundingClientRect().bottom før scroll
+ *  3. Scroll vinduet 800 px ned
+ *  4. Mål bottom igjen
+ *  5. Forventning: bottom-verdien er omtrent uendret (ankret til viewport)
+ *
+ * Logger samtidig ancestor-kjeden for å avdekke hvilken stamfar som
+ * etablerer ny "containing block" for position:fixed (transform/filter/
+ * backdrop-filter/perspective/will-change/contain).
+ */
+
+const UT_DIR = path.join('.screenshots', 'dock-147')
+const TEST_EPOST = process.env.TEST_EPOST ?? 'reidar.aasheim@gmail.com'
+const TEST_PASSORD = process.env.TEST_PASSORD ?? 'test123'
+
+async function loggInn(page: Page) {
+  await page.goto('/login')
+  await page.fill('input[type="email"]', TEST_EPOST)
+  await page.fill('input[type="password"]', TEST_PASSORD)
+  await page.click('button[type="submit"]')
+  await page.waitForURL('**/', { timeout: 15_000 })
+}
+
+test.describe('Dock-scroll regresjon #147', () => {
+  test.beforeAll(() => {
+    fs.mkdirSync(UT_DIR, { recursive: true })
+  })
+
+  test('dock skal være ankret til viewport-bunn ved scroll', async ({ page }) => {
+    test.setTimeout(60_000)
+
+    await loggInn(page)
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await page.waitForTimeout(500)
+
+    const navSelector = 'nav[aria-label="Hovednavigasjon"]'
+    await page.waitForSelector(navSelector)
+
+    // Diagnose: Logg containing-block-relevante egenskaper i ancestor-kjeden.
+    const ancestors = await page.evaluate((sel) => {
+      const nav = document.querySelector(sel) as HTMLElement | null
+      if (!nav) return []
+      const out: Array<Record<string, string>> = []
+      let el: HTMLElement | null = nav.parentElement
+      while (el) {
+        const cs = window.getComputedStyle(el)
+        out.push({
+          tag: el.tagName.toLowerCase(),
+          id: el.id || '',
+          className: typeof el.className === 'string' ? el.className.slice(0, 80) : '',
+          transform: cs.transform,
+          filter: cs.filter,
+          backdropFilter: cs.backdropFilter || (cs as unknown as Record<string, string>).webkitBackdropFilter || '',
+          perspective: cs.perspective,
+          willChange: cs.willChange,
+          contain: cs.contain,
+          position: cs.position,
+          backgroundAttachment: cs.backgroundAttachment,
+          overflow: cs.overflow,
+        })
+        el = el.parentElement
+      }
+      return out
+    }, navSelector)
+
+    console.log('--- Ancestor-kjede for nav (#147 diagnose) ---')
+    for (const a of ancestors) {
+      const flagg = []
+      if (a.transform !== 'none') flagg.push(`transform=${a.transform}`)
+      if (a.filter !== 'none') flagg.push(`filter=${a.filter}`)
+      if (a.backdropFilter && a.backdropFilter !== 'none') flagg.push(`backdrop-filter=${a.backdropFilter}`)
+      if (a.perspective !== 'none') flagg.push(`perspective=${a.perspective}`)
+      if (a.willChange !== 'auto') flagg.push(`will-change=${a.willChange}`)
+      if (a.contain !== 'none') flagg.push(`contain=${a.contain}`)
+      if (a.backgroundAttachment === 'fixed') flagg.push(`bg-attachment=fixed`)
+      const tag = `${a.tag}${a.id ? '#' + a.id : ''}${a.className ? '.' + a.className.replace(/\s+/g, '.') : ''}`
+      console.log(`  ${tag} :: pos=${a.position} ${flagg.join(' ') || '(ingen)'}`)
+    }
+
+    const foer = await page.evaluate((sel) => {
+      const nav = document.querySelector(sel) as HTMLElement | null
+      if (!nav) return null
+      const r = nav.getBoundingClientRect()
+      return { bottom: r.bottom, top: r.top, scrollY: window.scrollY }
+    }, navSelector)
+
+    await page.screenshot({ path: path.join(UT_DIR, '01-foer-scroll.png'), fullPage: false })
+
+    // Scroll dokument-roten 800 px ned
+    await page.evaluate(() => window.scrollTo(0, 800))
+    await page.waitForTimeout(300)
+
+    const etter = await page.evaluate((sel) => {
+      const nav = document.querySelector(sel) as HTMLElement | null
+      if (!nav) return null
+      const r = nav.getBoundingClientRect()
+      return { bottom: r.bottom, top: r.top, scrollY: window.scrollY }
+    }, navSelector)
+
+    await page.screenshot({ path: path.join(UT_DIR, '02-etter-scroll.png'), fullPage: false })
+
+    console.log('Foer scroll:', foer)
+    console.log('Etter scroll:', etter)
+
+    expect(foer).not.toBeNull()
+    expect(etter).not.toBeNull()
+    // Hvis dock er ankret til viewport, skal bottom være tilnærmet identisk
+    // før og etter scroll (innenfor 2 px slack).
+    const diff = Math.abs((etter!.bottom) - (foer!.bottom))
+    console.log('Diff bottom (px):', diff, 'scrollY:', etter!.scrollY)
+    expect(diff).toBeLessThan(2)
+  })
+})

--- a/e2e/dock-scroll-147.spec.ts
+++ b/e2e/dock-scroll-147.spec.ts
@@ -20,7 +20,12 @@ import path from 'node:path'
 
 const UT_DIR = path.join('.screenshots', 'dock-147')
 const TEST_EPOST = process.env.TEST_EPOST ?? 'reidar.aasheim@gmail.com'
-const TEST_PASSORD = process.env.TEST_PASSORD ?? 'test123'
+const TEST_PASSORD = process.env.TEST_PASSORD
+if (!TEST_PASSORD) {
+  throw new Error(
+    'e2e: TEST_PASSORD er ikke satt. Sett env-var før kjøring (ingen fallback).',
+  )
+}
 
 async function loggInn(page: Page) {
   await page.goto('/login')

--- a/e2e/dock-scroll-147.spec.ts
+++ b/e2e/dock-scroll-147.spec.ts
@@ -20,12 +20,7 @@ import path from 'node:path'
 
 const UT_DIR = path.join('.screenshots', 'dock-147')
 const TEST_EPOST = process.env.TEST_EPOST ?? 'reidar.aasheim@gmail.com'
-const TEST_PASSORD = process.env.TEST_PASSORD
-if (!TEST_PASSORD) {
-  throw new Error(
-    'e2e: TEST_PASSORD er ikke satt. Sett env-var før kjøring (ingen fallback).',
-  )
-}
+const TEST_PASSORD = process.env.TEST_PASSORD ?? ''
 
 async function loggInn(page: Page) {
   await page.goto('/login')
@@ -36,6 +31,11 @@ async function loggInn(page: Page) {
 }
 
 test.describe('Dock-scroll regresjon #147', () => {
+  // Hopp over hele suiten hvis TEST_PASSORD ikke er satt — i stedet for å
+  // kaste på toppnivå, som ville knust hele Playwright-kjøringen (også
+  // andre spec-er via --grep).
+  test.skip(!TEST_PASSORD, 'TEST_PASSORD ikke satt — hopper over dock-scroll-suiten.')
+
   test.beforeAll(() => {
     fs.mkdirSync(UT_DIR, { recursive: true })
   })

--- a/lib/hooks/useSkjulBottomNavVedFokus.ts
+++ b/lib/hooks/useSkjulBottomNavVedFokus.ts
@@ -1,11 +1,13 @@
 import { useEffect } from 'react'
 
 /**
- * Brukes av Chat-komponenter for å skjule bottom-nav-docken mens en chat-input
- * har fokus. Lytter globalt etter focusin/focusout på elementer med
- * data-chat-input="true". Se CLAUDE.md → Policy: Bottom-nav-skjul.
+ * Mountes ÉN gang globalt fra BottomNav. Lytter globalt etter focusin/focusout
+ * på elementer med `data-chat-input="true"` og setter `data-chat-input-fokusert`
+ * på <html> mens et slikt element har fokus. CSS i globals.css skjuler docken.
  *
- * Kun Chat-komponenter har lov til å sette data-chat-input-fokusert.
+ * Hookens kontrakt mot kall-stedet er triviell: alt UI som vil skjule docken
+ * setter bare attributtet på input-elementet sitt — ingen import nødvendig.
+ * Se CLAUDE.md → Policy: Bottom-nav-skjul.
  */
 export function useSkjulBottomNavVedFokus() {
   useEffect(() => {

--- a/lib/hooks/useSkjulBottomNavVedFokus.ts
+++ b/lib/hooks/useSkjulBottomNavVedFokus.ts
@@ -1,0 +1,43 @@
+import { useEffect } from 'react'
+
+/**
+ * Brukes av Chat-komponenter for å skjule bottom-nav-docken mens en chat-input
+ * har fokus. Lytter globalt etter focusin/focusout på elementer med
+ * data-chat-input="true". Se CLAUDE.md → Policy: Bottom-nav-skjul.
+ *
+ * Kun Chat-komponenter har lov til å sette data-chat-input-fokusert.
+ */
+export function useSkjulBottomNavVedFokus() {
+  useEffect(() => {
+    const html = document.documentElement
+    const ATTR = 'data-chat-input-fokusert'
+
+    function erChatInput(target: EventTarget | null): boolean {
+      return (
+        target instanceof HTMLElement &&
+        target.matches('[data-chat-input="true"]')
+      )
+    }
+
+    function onFocusIn(e: FocusEvent) {
+      if (erChatInput(e.target)) html.setAttribute(ATTR, '')
+    }
+    function onFocusOut(e: FocusEvent) {
+      if (erChatInput(e.target)) html.removeAttribute(ATTR)
+    }
+    function onPageHide() {
+      html.removeAttribute(ATTR)
+    }
+
+    document.addEventListener('focusin', onFocusIn)
+    document.addEventListener('focusout', onFocusOut)
+    window.addEventListener('pagehide', onPageHide)
+
+    return () => {
+      document.removeEventListener('focusin', onFocusIn)
+      document.removeEventListener('focusout', onFocusOut)
+      window.removeEventListener('pagehide', onPageHide)
+      html.removeAttribute(ATTR) // ubetinget cleanup
+    }
+  }, [])
+}

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 220,
-  "versjon": "V2.220"
+  "nummer": 221,
+  "versjon": "V2.221"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 221,
-  "versjon": "V2.221"
+  "nummer": 222,
+  "versjon": "V2.222"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 222,
-  "versjon": "V2.222"
+  "nummer": 223,
+  "versjon": "V2.223"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 219,
-  "versjon": "V2.219"
+  "nummer": 220,
+  "versjon": "V2.220"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.221'
+const CACHE_VERSION = 'V2.222'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.220'
+const CACHE_VERSION = 'V2.221'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.219'
+const CACHE_VERSION = 'V2.220'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.222'
+const CACHE_VERSION = 'V2.223'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Lukker #147.

## Sammendrag
- **Bug-klasse eliminert:** Tredje regresjon i samme klasse (#99, #104, #147) ryddes med arkitekturendring framfor enda en patch på state-maskinen.
- **`BottomNav` blir passiv:** hele `tastaturApent`-staten + 5 cleanup-lag (focusin/out, visualViewport, pagehide, visibilitychange, polling) er fjernet. Komponenten viser nå alltid dock; CSS skjuler den når `<html>` har `data-chat-input-fokusert`.
- **Ny hook `useSkjulBottomNavVedFokus`** mountet ÉN gang globalt i `BottomNav`. Lytter på `focusin`/`focusout` for elementer med `data-chat-input="true"` + `pagehide`-fallback. Alle nåværende og fremtidige chat-input-elementer skjuler dock automatisk.
- **Portal-fixen beholdt** som defense-in-depth mot stamfar-containing-block-bugs.
- **Ny CLAUDE.md-policy «Bottom-nav-skjul»** dokumenterer kontrakten.

## Beslutninger underveis
- Arkitekturstyret innkalt. Endelig uttalelse i [issue-kommentar](https://github.com/reidarei/Herreklubben/issues/147#issuecomment-4417669358). Reidar bekreftet «mellomvei» framfor «alltid synlig dock» — krever skjul i chat fordi dock dekker input/send-knapp.
- Reviewer fant 1 MAJOR + 4 MINOR + 2 NIT. MAJOR: `KommentarerPaaKort` har `data-chat-input` men kalte ikke hooken — løst ved å flytte hooken fra Chat til BottomNav (ÉN global lytter), eliminerer hele kontrakts-risikoen for nåværende og fremtidige chat-lignende inputs. To MINOR avvist (pageshow/bfcache hypotetisk; magisk CSS-selektor pre-existing → forfunn-issue #148 opprettet). NIT-er rettet (newline + e2e-passord-fallback fjernet).
- Telemetri og e2e bevisst utelatt etter styreuttalelse — Chromium reproduserer ikke iOS WebKit-quirken.

## Test plan
- [ ] iOS PWA: åpne chat, klikk i input → dock skjules; trykk utenfor → dock dukker opp
- [ ] iOS PWA: chat-input → swipe-tilbake → dock skal være korrekt på neste side
- [ ] iOS PWA: chat-input → bytt til Safari → tilbake til PWA → dock korrekt
- [ ] Agenda: klikk i kommentar-input på et arrangement-kort → dock skjules (`KommentarerPaaKort` dekkes nå av global hook)
- [ ] Edit en chat-melding → textarea får fokus → dock skjules
- [ ] Scroll på agenda uten chat åpen → dock stabil i bunn

🤖 Generated with [Claude Code](https://claude.com/claude-code)
