### PR TITLE
Prøv iOS interactive-widget=overlays-content for dock (#153)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,6 +29,11 @@ export const viewport: Viewport = {
   viewportFit: 'cover',
   maximumScale: 1,
   userScalable: false,
+  // iOS 16.4+: tastaturet overlapper viewport istedenfor å krympe det.
+  // Effekt: position:fixed-elementer (dock) blir naturlig dekket av tastatur
+  // når det er oppe, kommer tilbake når det går ned — uten JS-deteksjon.
+  // Forsøk på å løse dock-bug-klassen (#99, #104, #147, #151, #153).
+  interactiveWidget: 'overlays-content',
 }
 
 export const metadata: Metadata = {

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 225,
-  "versjon": "V2.225"
+  "nummer": 226,
+  "versjon": "V2.226"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.225'
+const CACHE_VERSION = 'V2.226'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Prøver å løse dock-bug-klassen (#99, #104, #147, #151, #153) ved å bruke iOS Safaris egen viewport-mekanisme istedenfor JS-state.

## Endring

Én linje i `app/layout.tsx`: `interactiveWidget: 'overlays-content'` på viewport-config.

## Hva det gjør

På iOS 16.4+ ber denne meta-tagen Safari om å la tastaturet **overlappe** viewporten istedenfor å krympe den. Effekten:

- `position: fixed`-elementer (som dock) blir naturlig dekket av tastaturet når det er oppe — uten at vi gjør noe i JS
- Når tastaturet går ned, kommer dock tilbake automatisk (samme containing-block som før)
- Ingen state-håndtering, ingen event-lyttere, ingen tastatur-deteksjon

Dette er Apples egen mekanisme for nettopp det Reidar har bedt om: «tastatur opp = dock vekk, tastatur ned = dock tilbake», uavhengig av hvilken rute brukeren er på.

## Hvorfor det kan funke

Forrige forsøk (PR #149, #152) prøvde å detektere tastatur-state via JS (`focusin`, `focusout`, `visualViewport.resize`, `pagehide`, `visibilitychange`). Alle feilet fordi iOS WebKit fyrer events i uforutsigbare rekkefølger under scroll/swipe-back/app-bytte. `overlays-content` flytter ansvaret til Safari selv — vi spør ikke når tastaturet er oppe, vi sier til Safari at den skal håndtere det.

## Hvorfor det kan feile

iOS 16.4+ er kravet — eldre iOS ignorerer flagget og oppfører seg som før. Empirisk testing av Reidar på iPhone er kritisk før vi vet om det faktisk treffer fixed-ankrings-bugen. Hvis det ikke gjør det, må vi vurdere andre alternativer (mini-dock, FAB-meny, Capacitor).

## Beslutninger underveis

- Arkitekturstyret innkalt på #153. Anbefalte først **rute-basert skjul (Alt E)** — drop dock på chat-flater. Reidar avviste fordi det ikke dekker kommentar-input på agenda-kort, og fordi han vil ha tastatur-basert skjul (ikke rute-basert).
- Reidar valgte **E (meta-tag)** etter at jeg gikk ut av auto-modus og presenterte fem alternativer (mini-dock, FAB, rute-basert, Capacitor, meta-tag). Meta-tag er trivielt reversibel — hvis den ikke virker er vi ikke verre stilt enn nå.
- Capacitor (Alt D) er parkert som separat fremtidig sak hvis denne meta-tag-en ikke holder.

## Test plan

Reidar tester på iPhone PWA:
- [ ] Klikk i chat-input → tastatur opp → dock skal være dekket av tastatur (visuelt borte)
- [ ] Trykk «Send» → tastatur ned → dock skal være tilbake umiddelbart
- [ ] Gjenta på agenda-kommentar-input
- [ ] Verifiser at dock ikke «svømmer» etter blur
- [ ] Sjekk at sticky-input + 200px padding fra PR #152 ikke skaper rare hopp — vurder å rive disse i oppfølger hvis meta-tag-en alene løser problemet

🤖 Generated with [Claude Code](https://claude.com/claude-code)
