### PR TITLE
Skjul dock når tastatur er oppe (visualViewport-lytter)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -95,6 +95,12 @@ body {
 ::-webkit-scrollbar { display: none; }
 * { scrollbar-width: none; }
 
+/* Skjul bottom-nav når tastatur er oppe (data-attributt settes av
+   visualViewport-lytter i BottomNav). Se Policy: Dock-synlighet i CLAUDE.md. */
+html[data-tastatur-oppe] nav[aria-label="Hovednavigasjon"] {
+  display: none;
+}
+
 /* Sidetransisjon */
 @keyframes page-fadein {
   from { opacity: 0; transform: translateY(10px); }

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -60,6 +60,26 @@ export default function BottomNav({ brukerNavn, bildeUrl }: Props) {
     setMontert(true)
   }, [])
 
+  // Skjul dock når tastatur er oppe på iOS. visualViewport krymper kun når
+  // tastaturet er oppe (ikke ved URL-bar-collapse el. l.) takket være
+  // `interactive-widget=overlays-content` i layout.tsx — så denne lytteren
+  // er pålitelig nå, i motsetning til tidligere VV-baserte forsøk.
+  useEffect(() => {
+    const vv = window.visualViewport
+    if (!vv) return
+    const html = document.documentElement
+    const sjekk = () => {
+      if (vv.height < window.innerHeight - 100) html.setAttribute('data-tastatur-oppe', '')
+      else html.removeAttribute('data-tastatur-oppe')
+    }
+    vv.addEventListener('resize', sjekk)
+    sjekk()
+    return () => {
+      vv.removeEventListener('resize', sjekk)
+      html.removeAttribute('data-tastatur-oppe')
+    }
+  }, [])
+
   const containerStyle: CSSProperties = {
     position: 'fixed',
     bottom: 'calc(14px + env(safe-area-inset-bottom, 0px))',

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 226,
-  "versjon": "V2.226"
+  "nummer": 227,
+  "versjon": "V2.227"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.226'
+const CACHE_VERSION = 'V2.227'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Pålegg på #153 / PR #154. Dock-en var fortsatt synlig over tastaturet etter forrige runde — iOS Safari løfter `position: fixed`-elementer over tastaturet av default. Denne PR-en legger til en `visualViewport.resize`-lytter i BottomNav som setter `data-tastatur-oppe` på `<html>` når VV.height krymper med >100px. CSS skjuler dock da.

**Hvorfor VV-deteksjon nå er pålitelig:** Med `interactive-widget=overlays-content` (PR #154) krymper visual-viewport KUN når tastaturet er oppe — ikke ved URL-bar-collapse el.l. Det fjerner falske triggere som ødela #104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)