### PR TITLE
Robust dock-skjul: flere event-triggere som backup

### DIFF
--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -64,6 +64,10 @@ export default function BottomNav({ brukerNavn, bildeUrl }: Props) {
   // tastaturet er oppe (ikke ved URL-bar-collapse el. l.) takket være
   // `interactive-widget=overlays-content` i layout.tsx — så denne lytteren
   // er pålitelig nå, i motsetning til tidligere VV-baserte forsøk.
+  // Lytter på BÅDE resize og scroll fordi iOS Safari kan slutte å fyre
+  // resize-event etter flere fokus-sykluser, mens scroll fortsatt fyres
+  // ved tastatur-overganger. Pluss focusin/focusout som siste sikkerhetsnett
+  // — sjekker VV-state ~100ms etter eventet (etter at iOS har oppdatert vv.height).
   useEffect(() => {
     const vv = window.visualViewport
     if (!vv) return
@@ -72,10 +76,19 @@ export default function BottomNav({ brukerNavn, bildeUrl }: Props) {
       if (vv.height < window.innerHeight - 100) html.setAttribute('data-tastatur-oppe', '')
       else html.removeAttribute('data-tastatur-oppe')
     }
+    const sjekkSenere = () => setTimeout(sjekk, 100)
+
     vv.addEventListener('resize', sjekk)
+    vv.addEventListener('scroll', sjekk)
+    document.addEventListener('focusin', sjekkSenere)
+    document.addEventListener('focusout', sjekkSenere)
     sjekk()
+
     return () => {
       vv.removeEventListener('resize', sjekk)
+      vv.removeEventListener('scroll', sjekk)
+      document.removeEventListener('focusin', sjekkSenere)
+      document.removeEventListener('focusout', sjekkSenere)
       html.removeAttribute('data-tastatur-oppe')
     }
   }, [])

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 227,
-  "versjon": "V2.227"
+  "nummer": 228,
+  "versjon": "V2.228"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.227'
+const CACHE_VERSION = 'V2.228'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Pålegg på PR #155. Reidar rapporterte at dock-skjul stoppet å virke etter flere fokus-sykluser på iPhone — kjent iOS-quirk hvor VV-resize slutter å fyre.

Legger til:
- `visualViewport.scroll` (iOS fyrer denne ved tastatur-overganger som resize ikke fanger)
- `focusin`/`focusout` med 100ms delay som siste sikkerhetsnett

Fortsatt ren VV-deteksjon for state — focus-events er bare triggere for re-sjekk, ikke kilde til state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)