### PR TITLE
Reduser chat-bunn-padding (mindre avstand mellom siste melding og input)

### DIFF
--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -715,18 +715,18 @@ export default function Chat({
         </div>
       )}
 
-      {/* Meldingsliste — padding-bottom belt-and-suspenders sammen med
-          sticky-input under, sikrer at siste melding ikke skjules av
-          dock + input-pill. Konstanten 200px er valgt for å romme worst
-          case: input-pill (~48px) + bilde-preview (120px + margin) +
-          mention-chips. Statisk verdi bevisst — alternativet (dynamisk
-          ResizeObserver) ble ansett som overkill for så liten gevinst. */}
+      {/* Meldingsliste — padding-bottom = dock + safe-area + plass til input-
+          pillen (~48px) + lite gap. Reduseert fra 200px (som romslig dekket
+          worst-case bilde-preview) — i normal-tilstand uten preview ble det
+          for stor avstand mellom siste melding og input. Hvis brukeren har
+          bilde-preview/mentions aktivt kan siste melding bli litt skjult
+          kortvarig — akseptabel kompromiss. */}
       <div
         style={{
           display: 'flex',
           flexDirection: 'column',
           marginBottom: 14,
-          paddingBottom: 'calc(var(--bottom-nav-h) + env(safe-area-inset-bottom) + 200px)',
+          paddingBottom: 'calc(var(--bottom-nav-h) + env(safe-area-inset-bottom) + 60px)',
         }}
       >
         {meldinger.length === 0 && (

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 228,
-  "versjon": "V2.228"
+  "nummer": 229,
+  "versjon": "V2.229"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.228'
+const CACHE_VERSION = 'V2.229'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Tidligere 200px-padding var dimensjonert for worst-case (input + bilde-preview + mentions). I normal-tilstand ga det "veldig lang avstand" mellom siste melding og input. Reduserer til 60px — input-pille (48) + lite gap (12).

Tradeoff: hvis bruker har bilde-preview/mentions aktivt, kan siste melding bli litt delvis skjult. Akseptabel kompromiss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)