### PR TITLE
Konsolider e2e auth-helper + visuell-verifikasjons-policy + versjon V3.0.1 (#150)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,4 +249,10 @@ Alle profil-avatarer (medlemsansikter) skal rendres via `components/ui/Avatar.ts
 
 App-navigasjon består av sticky TopHeader (hamburger venstre → tre ikon-knapper for Agenda/Chat/Klubb i horisontal ekspansjon; profil-sirkel høyre som snarvei til /profil) og kontekstuelle FAB-er (NyFAB på agenda for å opprette innhold). **Ingen bottom-nav.** Dette eliminerer hele bug-klassen vi traff i #99, #104, #147, #151, #153 hvor iOS-tastatur kolliderte med fixed bottom-elementer. Hvis du finner deg selv i å legge til en `position: fixed; bottom: 0` UI-flate som ikke er en modal eller toast — løft det til diskusjon først.
 
+## Policy: Visuell verifikasjon
+
+For UI-endringer på vanlig flyt: kjør Playwright lokalt før push (`npx playwright test`). Se `e2e/README.md` for setup.
+
+For iOS-PWA-quirks (visualViewport, safe-area, focus/blur på iOS): Playwright reproduserer ikke. Test manuelt på iPhone og dokumenter i PR-en at automatisk verifikasjon ikke er mulig.
+
 Supabase: Herreklubbens org, Herreklubbens webapp. Database-passordet ligger i `.env.local` som `SUPABASE_DB_PASSWORD`. Hent fra Supabase Dashboard → Project Settings → Database. Skript som trenger direkte Postgres-tilgang kjøres med `node --env-file=.env.local scripts/<navn>.mjs`.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -4,14 +4,13 @@ Verifiserer at vanlige flyter (innlogging, opprette poll, kommentere, agenda-ren
 
 ## Førstegangs-oppsett
 
-Test-suiten logger inn som en ekte bruker. Du må legge inn creds i `.env.local`:
+Test-suiten logger inn som en ekte bruker. Du må legge inn passord i `.env.local`:
 
 ```
-TEST_EPOST=reidar.haavik@gmail.com
 TEST_PASSORD=<spør Reidar>
 ```
 
-Mangler en av dem, skipper alle spec-er med en tydelig melding. Det betyr ingen «stille feil i første assertion» når en agent uten passord prøver å kjøre suiten.
+`TEST_EPOST` har default `reidar.haavik@gmail.com` og trenger bare settes hvis du vil overstyre. Mangler `TEST_PASSORD`, skipper alle spec-er med en tydelig melding. Det betyr ingen «stille feil i første assertion» når en agent uten passord prøver å kjøre suiten.
 
 ## Kjøre testene
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,42 @@
+# e2e-tester (Playwright)
+
+Verifiserer at vanlige flyter (innlogging, opprette poll, kommentere, agenda-rendering) fungerer mot en lokal dev-server. Brukes også til å fange visuelle baselines under redesign.
+
+## Førstegangs-oppsett
+
+Test-suiten logger inn som en ekte bruker. Du må legge inn creds i `.env.local`:
+
+```
+TEST_EPOST=reidar.haavik@gmail.com
+TEST_PASSORD=<spør Reidar>
+```
+
+Mangler en av dem, skipper alle spec-er med en tydelig melding. Det betyr ingen «stille feil i første assertion» når en agent uten passord prøver å kjøre suiten.
+
+## Kjøre testene
+
+```bash
+# Alle spec-er
+npx playwright test
+
+# Én spec
+npx playwright test e2e/visuell.spec.ts
+
+# Dev-server kjører på en annen port enn 3000
+PLAYWRIGHT_BASE_URL=http://localhost:3002 npx playwright test
+```
+
+Skjermbilder havner i `.screenshots/<fase>/` — visuell.spec.ts skriver også en `rapport.html` side-ved-side med designreferansene under `Design/skjermbilder/`.
+
+## Når Playwright IKKE er riktig verktøy
+
+Playwright kjører mot Chromium (og WebKit hvis vi aktiverer det). **Det er ikke ekte iOS Safari.** En del bug-klasser i denne appen reproduserer ikke i runneren:
+
+- `visualViewport`-håndtering (tastatur som dekker bottom-elementer)
+- iOS safe-area (notch, home-indikator, dock)
+- iOS PWA-quirks (focus/blur, scroll-restoration, momentum-scroll)
+- ITP-cookie-håndtering i standalone-modus
+
+Slike bugs må verifiseres manuelt på iPhone. Dokumenter i PR-en at automatisk verifikasjon ikke er mulig.
+
+WebKit-runneren er ikke aktivert i dag — kan vurderes senere, men selv da fanger den ikke alt av det over.

--- a/e2e/edit-kommentar.spec.ts
+++ b/e2e/edit-kommentar.spec.ts
@@ -1,21 +1,14 @@
-import { test, expect, Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 import fs from 'node:fs'
 import path from 'node:path'
 import { setTestPollId, ryddTestPoll, pollIdFraUrl } from './helpers/rydd-test-poll'
+import { loggInn, harTestCreds } from './helpers/auth'
 
 const UT_DIR = path.join('.screenshots', 'edit-kommentar')
-const TEST_EPOST = process.env.TEST_EPOST ?? 'reidar.aasheim@gmail.com'
-const TEST_PASSORD = process.env.TEST_PASSORD ?? 'test123'
-
-async function loggInn(page: Page) {
-  await page.goto('/login')
-  await page.fill('input[type="email"]', TEST_EPOST)
-  await page.fill('input[type="password"]', TEST_PASSORD)
-  await page.click('button[type="submit"]')
-  await page.waitForURL('**/', { timeout: 10_000 })
-}
 
 test.describe('Redigere egne meldinger inline', () => {
+  test.skip(!harTestCreds(), 'TEST_EPOST/TEST_PASSORD mangler — se e2e/README.md')
+
   test.beforeAll(() => {
     fs.mkdirSync(UT_DIR, { recursive: true })
   })

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -2,7 +2,7 @@ import type { Page } from '@playwright/test'
 
 /**
  * Felles innloggingshelper for e2e-tester. Tidligere ble samme `loggInn`
- * duplisert i hver spec-fil med en defaultet `TEST_PASSORD = 'test123'`, som
+ * duplisert i hver spec-fil med en hardkodet placeholder-passord-default, som
  * stille feilet ved første assertion. Nå sentralisert: hvis creds mangler,
  * skal spec-en kalle `test.skip(!harTestCreds(), ...)` slik at årsaken er
  * tydelig i rapporten.

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -7,7 +7,8 @@ import type { Page } from '@playwright/test'
  * skal spec-en kalle `test.skip(!harTestCreds(), ...)` slik at årsaken er
  * tydelig i rapporten.
  *
- * Sett `TEST_EPOST` og `TEST_PASSORD` i `.env.local`. Se `e2e/README.md`.
+ * Sett `TEST_PASSORD` i `.env.local` (`TEST_EPOST` har default på reidars
+ * bruker — overstyr hvis du vil teste som en annen). Se `e2e/README.md`.
  */
 
 export const TEST_EPOST = process.env.TEST_EPOST ?? 'reidar.haavik@gmail.com'

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -1,0 +1,26 @@
+import type { Page } from '@playwright/test'
+
+/**
+ * Felles innloggingshelper for e2e-tester. Tidligere ble samme `loggInn`
+ * duplisert i hver spec-fil med en defaultet `TEST_PASSORD = 'test123'`, som
+ * stille feilet ved første assertion. Nå sentralisert: hvis creds mangler,
+ * skal spec-en kalle `test.skip(!harTestCreds(), ...)` slik at årsaken er
+ * tydelig i rapporten.
+ *
+ * Sett `TEST_EPOST` og `TEST_PASSORD` i `.env.local`. Se `e2e/README.md`.
+ */
+
+export const TEST_EPOST = process.env.TEST_EPOST ?? 'reidar.haavik@gmail.com'
+export const TEST_PASSORD = process.env.TEST_PASSORD ?? ''
+
+export function harTestCreds(): boolean {
+  return Boolean(TEST_EPOST) && Boolean(TEST_PASSORD)
+}
+
+export async function loggInn(page: Page): Promise<void> {
+  await page.goto('/login')
+  await page.fill('input[type="email"]', TEST_EPOST)
+  await page.fill('input[type="password"]', TEST_PASSORD)
+  await page.click('button[type="submit"]')
+  await page.waitForURL('**/', { timeout: 15_000 })
+}

--- a/e2e/inline-kommentar-input.spec.ts
+++ b/e2e/inline-kommentar-input.spec.ts
@@ -1,20 +1,13 @@
-import { test, expect, Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 import fs from 'node:fs'
 import path from 'node:path'
+import { loggInn, harTestCreds } from './helpers/auth'
 
 const UT_DIR = path.join('.screenshots', 'inline-kommentar-input')
-const TEST_EPOST = process.env.TEST_EPOST ?? 'reidar.aasheim@gmail.com'
-const TEST_PASSORD = process.env.TEST_PASSORD ?? 'test123'
-
-async function loggInn(page: Page) {
-  await page.goto('/login')
-  await page.fill('input[type="email"]', TEST_EPOST)
-  await page.fill('input[type="password"]', TEST_PASSORD)
-  await page.click('button[type="submit"]')
-  await page.waitForURL('**/', { timeout: 10_000 })
-}
 
 test.describe('Inline kommentar-input på agenda (#89)', () => {
+  test.skip(!harTestCreds(), 'TEST_EPOST/TEST_PASSORD mangler — se e2e/README.md')
+
   test.beforeAll(() => {
     fs.mkdirSync(UT_DIR, { recursive: true })
   })

--- a/e2e/kommentarer-i-kort.spec.ts
+++ b/e2e/kommentarer-i-kort.spec.ts
@@ -1,6 +1,7 @@
-import { test, expect, Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 import fs from 'node:fs'
 import path from 'node:path'
+import { loggInn, harTestCreds } from './helpers/auth'
 
 /**
  * Verifiserer at kommentarer vises inline nederst i hvert arrangement/poll-
@@ -9,18 +10,10 @@ import path from 'node:path'
  */
 
 const UT_DIR = path.join('.screenshots', 'kommentarer-i-kort')
-const TEST_EPOST = process.env.TEST_EPOST ?? 'reidar.aasheim@gmail.com'
-const TEST_PASSORD = process.env.TEST_PASSORD ?? 'test123'
-
-async function loggInn(page: Page) {
-  await page.goto('/login')
-  await page.fill('input[type="email"]', TEST_EPOST)
-  await page.fill('input[type="password"]', TEST_PASSORD)
-  await page.click('button[type="submit"]')
-  await page.waitForURL('**/', { timeout: 10_000 })
-}
 
 test.describe('Kommentarer inne i kort', () => {
+  test.skip(!harTestCreds(), 'TEST_EPOST/TEST_PASSORD mangler — se e2e/README.md')
+
   test.beforeAll(() => {
     fs.mkdirSync(UT_DIR, { recursive: true })
   })

--- a/e2e/kommentarer.spec.ts
+++ b/e2e/kommentarer.spec.ts
@@ -1,7 +1,8 @@
-import { test, expect, Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 import fs from 'node:fs'
 import path from 'node:path'
 import { setTestPollId, ryddTestPoll, pollIdFraUrl } from './helpers/rydd-test-poll'
+import { loggInn, harTestCreds } from './helpers/auth'
 
 /**
  * Verifiserer kommentar-funksjonalitet på arrangement + poll og at siste
@@ -9,18 +10,10 @@ import { setTestPollId, ryddTestPoll, pollIdFraUrl } from './helpers/rydd-test-p
  */
 
 const UT_DIR = path.join('.screenshots', 'kommentarer')
-const TEST_EPOST = process.env.TEST_EPOST ?? 'reidar.aasheim@gmail.com'
-const TEST_PASSORD = process.env.TEST_PASSORD ?? 'test123'
-
-async function loggInn(page: Page) {
-  await page.goto('/login')
-  await page.fill('input[type="email"]', TEST_EPOST)
-  await page.fill('input[type="password"]', TEST_PASSORD)
-  await page.click('button[type="submit"]')
-  await page.waitForURL('**/', { timeout: 10_000 })
-}
 
 test.describe('Kommentarer på arrangement og poll', () => {
+  test.skip(!harTestCreds(), 'TEST_EPOST/TEST_PASSORD mangler — se e2e/README.md')
+
   test.beforeAll(() => {
     fs.mkdirSync(UT_DIR, { recursive: true })
   })

--- a/e2e/poll-inline.spec.ts
+++ b/e2e/poll-inline.spec.ts
@@ -1,7 +1,8 @@
-import { test, expect, Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 import fs from 'node:fs'
 import path from 'node:path'
 import { setTestPollId, ryddTestPoll, pollIdFraUrl } from './helpers/rydd-test-poll'
+import { loggInn, harTestCreds } from './helpers/auth'
 
 /**
  * Verifiserer inline-stemming på agenda-kortet for poll med ≤ MAKS_INLINE_VALG
@@ -10,18 +11,10 @@ import { setTestPollId, ryddTestPoll, pollIdFraUrl } from './helpers/rydd-test-p
  */
 
 const UT_DIR = path.join('.screenshots', 'poll-inline')
-const TEST_EPOST = process.env.TEST_EPOST ?? 'reidar.aasheim@gmail.com'
-const TEST_PASSORD = process.env.TEST_PASSORD ?? 'test123'
-
-async function loggInn(page: Page) {
-  await page.goto('/login')
-  await page.fill('input[type="email"]', TEST_EPOST)
-  await page.fill('input[type="password"]', TEST_PASSORD)
-  await page.click('button[type="submit"]')
-  await page.waitForURL('**/', { timeout: 10_000 })
-}
 
 test.describe('Inline-stemming på agenda', () => {
+  test.skip(!harTestCreds(), 'TEST_EPOST/TEST_PASSORD mangler — se e2e/README.md')
+
   test.beforeAll(() => {
     fs.mkdirSync(UT_DIR, { recursive: true })
   })

--- a/e2e/poll-resultat.spec.ts
+++ b/e2e/poll-resultat.spec.ts
@@ -1,21 +1,14 @@
-import { test, expect, Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 import fs from 'node:fs'
 import path from 'node:path'
 import { setTestPollId, ryddTestPoll, pollIdFraUrl } from './helpers/rydd-test-poll'
+import { loggInn, harTestCreds } from './helpers/auth'
 
 const UT_DIR = path.join('.screenshots', 'poll-resultat')
-const TEST_EPOST = process.env.TEST_EPOST ?? 'reidar.aasheim@gmail.com'
-const TEST_PASSORD = process.env.TEST_PASSORD ?? 'test123'
-
-async function loggInn(page: Page) {
-  await page.goto('/login')
-  await page.fill('input[type="email"]', TEST_EPOST)
-  await page.fill('input[type="password"]', TEST_PASSORD)
-  await page.click('button[type="submit"]')
-  await page.waitForURL('**/', { timeout: 10_000 })
-}
 
 test.describe('Resultat etter stemme (#88)', () => {
+  test.skip(!harTestCreds(), 'TEST_EPOST/TEST_PASSORD mangler — se e2e/README.md')
+
   test.beforeAll(() => {
     fs.mkdirSync(UT_DIR, { recursive: true })
   })

--- a/e2e/poll.spec.ts
+++ b/e2e/poll.spec.ts
@@ -1,7 +1,8 @@
-import { test, expect, Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 import fs from 'node:fs'
 import path from 'node:path'
 import { setTestPollId, ryddTestPoll, pollIdFraUrl } from './helpers/rydd-test-poll'
+import { loggInn, harTestCreds } from './helpers/auth'
 
 /**
  * Visuell + funksjonell verifisering av poll-funksjonaliteten (#86).
@@ -14,18 +15,10 @@ import { setTestPollId, ryddTestPoll, pollIdFraUrl } from './helpers/rydd-test-p
  */
 
 const UT_DIR = path.join('.screenshots', 'poll')
-const TEST_EPOST = process.env.TEST_EPOST ?? 'reidar.aasheim@gmail.com'
-const TEST_PASSORD = process.env.TEST_PASSORD ?? 'test123'
-
-async function loggInn(page: Page) {
-  await page.goto('/login')
-  await page.fill('input[type="email"]', TEST_EPOST)
-  await page.fill('input[type="password"]', TEST_PASSORD)
-  await page.click('button[type="submit"]')
-  await page.waitForURL('**/', { timeout: 10_000 })
-}
 
 test.describe('Poll-flyt', () => {
+  test.skip(!harTestCreds(), 'TEST_EPOST/TEST_PASSORD mangler — se e2e/README.md')
+
   test.beforeAll(() => {
     fs.mkdirSync(UT_DIR, { recursive: true })
   })

--- a/e2e/visuell.spec.ts
+++ b/e2e/visuell.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, Page } from '@playwright/test'
 import fs from 'node:fs'
 import path from 'node:path'
+import { loggInn, harTestCreds } from './helpers/auth'
 
 /**
  * Visuell baseline for Obsidian-redesign.
@@ -16,22 +17,12 @@ import path from 'node:path'
 const FASE = process.env.FASE ?? 'baseline'
 const UT_DIR = path.join('.screenshots', FASE)
 const REF_DIR = path.join('Design', 'skjermbilder')
-const TEST_EPOST = process.env.TEST_EPOST ?? 'reidar.aasheim@gmail.com'
-const TEST_PASSORD = process.env.TEST_PASSORD ?? 'test123'
 
 type Rute = {
   navn: string
   referanse: string
   besok: (page: Page) => Promise<void>
   fullPage?: boolean
-}
-
-async function loggInn(page: Page) {
-  await page.goto('/login')
-  await page.fill('input[type="email"]', TEST_EPOST)
-  await page.fill('input[type="password"]', TEST_PASSORD)
-  await page.click('button[type="submit"]')
-  await page.waitForURL('**/', { timeout: 10_000 })
 }
 
 async function foersteArrangementLenke(page: Page): Promise<string | null> {
@@ -46,6 +37,8 @@ async function foersteArrangementLenke(page: Page): Promise<string | null> {
 }
 
 test.describe('Visuell baseline', () => {
+  test.skip(!harTestCreds(), 'TEST_EPOST/TEST_PASSORD mangler — se e2e/README.md')
+
   test.beforeAll(() => {
     fs.mkdirSync(UT_DIR, { recursive: true })
   })

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 236,
-  "versjon": "V2.236"
+  "nummer": 1,
+  "versjon": "V3.0.1"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 235,
-  "versjon": "V2.235"
+  "nummer": 236,
+  "versjon": "V2.236"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "herreklubben",
-  "version": "2.28.0",
+  "version": "3.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.236'
+const CACHE_VERSION = 'V3.0.1'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V2.235'
+const CACHE_VERSION = 'V2.236'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/scripts/stamp-versjon.mjs
+++ b/scripts/stamp-versjon.mjs
@@ -1,5 +1,7 @@
-// Øker minor-nummeret i lib/versjon.json med 1. Kjøres lokalt før push.
+// Øker patch-nummeret i lib/versjon.json med 1. Kjøres lokalt før push.
 // Filen er committed, så Vercel leser bare resultatet uten git-avhengighet.
+// Format: V{major}.{minor}.{patch} der major+minor kommer fra package.json
+// og patch er det inkrementelle bygg-nummeret. F.eks. V3.0.42.
 // Speiler også versjonen inn i public/sw.js sin CACHE_VERSION-konstant
 // slik at hver deploy automatisk invaliderer service worker-cachen.
 
@@ -15,8 +17,8 @@ const fil = join(rot, 'lib', 'versjon.json')
 const forrige = JSON.parse(readFileSync(fil, 'utf8'))
 
 const neste = (forrige.nummer ?? 0) + 1
-const [major] = pkg.version.split('.')
-const versjon = `V${major}.${String(neste).padStart(3, '0')}`
+const [major, minor] = pkg.version.split('.')
+const versjon = `V${major}.${minor}.${neste}`
 
 writeFileSync(fil, JSON.stringify({ nummer: neste, versjon }, null, 2) + '\n')
 


### PR DESCRIPTION
Lukker #150. Rydder e2e/Playwright-oppsettet + bumpet versjon til V3.0.1.

## Endringer

### E2E (issue #150)
- **Ny `e2e/helpers/auth.ts`** — felles `loggInn(page)`, `TEST_EPOST`, `TEST_PASSORD`, `harTestCreds()`
- **8 spec-er konsolidert** — slettet duplikat `loggInn` og `TEST_*`-konstanter, importerer fra helper. Hver bruker `test.skip(!harTestCreds(), …)` på describe-nivå
- **Default-epost rettet:** `reidar.aasheim@gmail.com` → `reidar.haavik@gmail.com`. Falsk default `'test123'` for passord erstattet med tom string
- **Ny `e2e/README.md`** — setup-instruks, kjørekommandoer, port-override, når Playwright IKKE er rett verktøy
- **CLAUDE.md «Policy: Visuell verifikasjon»** — kort policy som lenker til README

### Versjon-bump
- **package.json:** 2.28.0 → 3.0.0
- **lib/versjon.json:** V2.236 → V3.0.1
- **stamp-script:** endret format fra `V{major}.{padded-3}` til semver-aktig `V{major}.{minor}.{patch}`. Neste stamp blir V3.0.2
- **sw.js CACHE_VERSION:** V2.236 → V3.0.1

## Beslutninger underveis

- Reviewer fant 1 MINOR + 3 NIT. NIT om gammel passord-streng i kommentar rettet. Innloggings-timeout 10s → 15s er bevisst (tåler treg dev-server)
- WebKit-runner bevisst utsatt
- Dedikert test-bruker bevisst droppet — bruker Reidars egne creds i `.env.local`
- Versjons-bump til major 3 markerer overgangen fra dock-arkitektur til TopHeader-arkitektur

🤖 Generated with [Claude Code](https://claude.com/claude-code)