### PR TITLE
Vis versjon i TopHeader (V3.0.2)

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -7,6 +7,7 @@ import DeployInfo from '@/components/DeployInfo'
 import InstallVeiledning from '@/components/InstallVeiledning'
 import { getInnloggetBruker, getProfil } from '@/lib/auth-cache'
 import { redirect } from 'next/navigation'
+import versjon from '@/lib/versjon.json'
 
 async function HeaderMedProfil() {
   const profil = await getProfil()
@@ -15,6 +16,7 @@ async function HeaderMedProfil() {
       brukerNavn={profil?.navn}
       bildeUrl={profil?.bilde_url ?? null}
       rolle={profil?.rolle ?? null}
+      versjon={versjon.versjon}
     />
   )
 }
@@ -35,7 +37,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
       <ServiceWorkerRegistrering />
       <DraNedForOppdater />
       <InstallVeiledning />
-      <Suspense fallback={<TopHeader />}>
+      <Suspense fallback={<TopHeader versjon={versjon.versjon} />}>
         <HeaderMedProfil />
       </Suspense>
       <main className="flex-1 relative z-10">

--- a/components/TopHeader.tsx
+++ b/components/TopHeader.tsx
@@ -31,6 +31,7 @@ type Props = {
   brukerNavn?: string | null
   bildeUrl?: string | null
   rolle?: string | null
+  versjon?: string
 }
 
 /**
@@ -43,7 +44,7 @@ type Props = {
  * #151, #153 hvor iOS-tastatur kolliderte med fixed bottom-elementer. Se
  * Policy: Navigasjon i CLAUDE.md.
  */
-export default function TopHeader({ brukerNavn, bildeUrl, rolle }: Props) {
+export default function TopHeader({ brukerNavn, bildeUrl, rolle, versjon }: Props) {
   const pathname = usePathname()
 
   const headerStyle: CSSProperties = {
@@ -122,6 +123,23 @@ export default function TopHeader({ brukerNavn, bildeUrl, rolle }: Props) {
           })}
         </div>
 
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+          {versjon && (
+            <span
+              aria-hidden="true"
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: 9.5,
+                color: 'var(--text-tertiary)',
+                opacity: 0.55,
+                letterSpacing: '0.5px',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {versjon}
+            </span>
+          )}
+
         {/* Profil-snarvei */}
         <Link
           href="/profil"
@@ -142,6 +160,7 @@ export default function TopHeader({ brukerNavn, bildeUrl, rolle }: Props) {
             size={36}
           />
         </Link>
+        </div>
       </div>
     </nav>
   )

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 1,
-  "versjon": "V3.0.1"
+  "nummer": 2,
+  "versjon": "V3.0.2"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V3.0.1'
+const CACHE_VERSION = 'V3.0.2'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Liten mono-label med versjonsnummer til venstre for profil-sirkel. Subtilt opacity 0.55. Beholder DeployInfo (versjon + sha + bygget-dato) i bunnen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)