### PR TITLE
Vis totalt kommentarantall i kollapset header (ikke X av Y) (#165)

### DIFF
--- a/components/agenda/KommentarerPaaKort.tsx
+++ b/components/agenda/KommentarerPaaKort.tsx
@@ -151,7 +151,7 @@ export default function KommentarerPaaKort({
           >
             <path d="M9 6l6 6-6 6" />
           </svg>
-          {apen && visTall > kommentarer.length
+          {apen && kommentarer.length > 0 && visTall > kommentarer.length
             ? `Siste ${kommentarer.length} av ${visTall} kommentarer`
             : `${visTall} ${visTall === 1 ? 'kommentar' : 'kommentarer'}`}
         </span>

--- a/components/agenda/KommentarerPaaKort.tsx
+++ b/components/agenda/KommentarerPaaKort.tsx
@@ -151,7 +151,7 @@ export default function KommentarerPaaKort({
           >
             <path d="M9 6l6 6-6 6" />
           </svg>
-          {visTall > kommentarer.length
+          {apen && visTall > kommentarer.length
             ? `Siste ${kommentarer.length} av ${visTall} kommentarer`
             : `${visTall} ${visTall === 1 ? 'kommentar' : 'kommentarer'}`}
         </span>

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 3,
-  "versjon": "V3.0.3"
+  "nummer": 4,
+  "versjon": "V3.0.4"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 2,
-  "versjon": "V3.0.2"
+  "nummer": 3,
+  "versjon": "V3.0.3"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V3.0.3'
+const CACHE_VERSION = 'V3.0.4'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V3.0.2'
+const CACHE_VERSION = 'V3.0.3'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Fikser #165.

## Endring
Når kommentar-seksjonen på et agenda-kort er kollapset, viste headeren tidligere "Siste 3 av 7 kommentarer" — selv om ingen kommentarer faktisk var synlige. Nå viser den kun "7 kommentarer" i kollapset tilstand. "Siste X av Y"-formuleringen brukes kun når seksjonen er åpen og listen er trunkert.

Ett ord lagt til i betingelsen i `components/agenda/KommentarerPaaKort.tsx`: `apen &&`.

## Beslutninger underveis
- Reviewer foreslo en forklarende kommentar over uttrykket. Avvist: variabelnavnene (`apen`, `visTall`, `kommentarer.length`) bærer betydningen, og CLAUDE.md fraråder kommentarer som refererer til task/issue.
- Ingen Copilot-runde ennå.

## Test plan
- [x] Lint
- [x] Build
- [ ] Manuell sjekk på agenda: arrangement med >3 gamle kommentarer skal vise "N kommentarer" når kollapset, "Siste 3 av N kommentarer" når ekspandert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)