### PR TITLE
Sentraliser @-mention-logikk + aktiver mentions på inline kommentarer (#167)

### DIFF
--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -60,6 +60,7 @@ export default async function Forside() {
     { data: albumMedArrangement },
     { data: arrKommTotalt },
     { data: pollKommTotalt },
+    { data: aktiveProfiler },
   ] = await Promise.all([
     supabase
       .from('arrangementer')
@@ -159,6 +160,12 @@ export default async function Forside() {
     supabase
       .from('poll_chat')
       .select('poll_id'),
+    // Aktive profiler — sendes til kortene for @mention-forslag i inline
+    // kommentar-felt. Samme select-form som /chat-siden bruker.
+    supabase
+      .from('profiles')
+      .select('id, navn, bilde_url, rolle')
+      .eq('aktiv', true),
   ])
 
   // Kåringspoll-aggregater hentes via RPC (mig. 079), fordi RLS skjuler
@@ -383,6 +390,7 @@ export default async function Forside() {
   })
 
   const antallGutta = aktiveMedlemmer ?? 0
+  const chatProfiler = aktiveProfiler ?? []
 
   return (
     <div style={{ padding: '0 20px 20px' }}>
@@ -443,6 +451,7 @@ export default async function Forside() {
                   melding={i.data}
                   brukerId={user!.id}
                   kommentarer={kommentarerPerMelding.get(i.data.id) ?? []}
+                  profiler={chatProfiler}
                 />
               )
             })}
@@ -463,9 +472,9 @@ export default async function Forside() {
               if (i.kind === 'klubbjubileum') return <KlubbJubileumKort key={i.data.id} jubileum={i.data} />
               if (i.kind === 'utkast') return <UtkastKort key={i.data.id} utkast={i.data} meg={user!.id} />
               if (i.kind === 'poll')
-                return <PollKort key={i.data.id} poll={i.data} kommentarer={kommentarerPerPoll.get(i.data.id) ?? []} totaltKommentarer={totaltPerPoll.get(i.data.id) ?? 0} />
+                return <PollKort key={i.data.id} poll={i.data} kommentarer={kommentarerPerPoll.get(i.data.id) ?? []} totaltKommentarer={totaltPerPoll.get(i.data.id) ?? 0} profiler={chatProfiler} brukerId={user!.id} />
               if (i.kind === 'arrangement')
-                return <ArrangementKort key={i.data.id} arr={i.data} kommentarer={kommentarerPerArr.get(i.data.id) ?? []} totaltKommentarer={totaltPerArr.get(i.data.id) ?? 0} />
+                return <ArrangementKort key={i.data.id} arr={i.data} kommentarer={kommentarerPerArr.get(i.data.id) ?? []} totaltKommentarer={totaltPerArr.get(i.data.id) ?? 0} profiler={chatProfiler} brukerId={user!.id} />
               // Meldinger plasseres kun i toppseksjonen (eller Tidligere) — ikke her
               return null
             })}
@@ -479,12 +488,12 @@ export default async function Forside() {
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
           {kommende.map(i => {
             if (i.kind === 'arrangement')
-              return <ArrangementKort key={i.data.id} arr={i.data} kommentarer={kommentarerPerArr.get(i.data.id) ?? []} totaltKommentarer={totaltPerArr.get(i.data.id) ?? 0} />
+              return <ArrangementKort key={i.data.id} arr={i.data} kommentarer={kommentarerPerArr.get(i.data.id) ?? []} totaltKommentarer={totaltPerArr.get(i.data.id) ?? 0} profiler={chatProfiler} brukerId={user!.id} />
             if (i.kind === 'bursdag') return <BursdagKort key={i.data.id} bursdag={i.data} />
             if (i.kind === 'klubbjubileum') return <KlubbJubileumKort key={i.data.id} jubileum={i.data} />
             if (i.kind === 'utkast') return <UtkastKort key={i.data.id} utkast={i.data} meg={user!.id} />
             if (i.kind === 'poll')
-              return <PollKort key={i.data.id} poll={i.data} kommentarer={kommentarerPerPoll.get(i.data.id) ?? []} totaltKommentarer={totaltPerPoll.get(i.data.id) ?? 0} />
+              return <PollKort key={i.data.id} poll={i.data} kommentarer={kommentarerPerPoll.get(i.data.id) ?? []} totaltKommentarer={totaltPerPoll.get(i.data.id) ?? 0} profiler={chatProfiler} brukerId={user!.id} />
             if (i.kind === 'highlight') return <HighlightKort key={i.data.id} arr={i.data} />
             // Meldinger plasseres kun i toppseksjonen eller Tidligere
             return null

--- a/components/agenda/ArrangementKort.tsx
+++ b/components/agenda/ArrangementKort.tsx
@@ -5,6 +5,7 @@ import Card from '@/components/ui/Card'
 import KommentarerPaaKort, { type KommentarKortData } from '@/components/agenda/KommentarerPaaKort'
 import { formaterDato, aarHvisAvvik } from '@/lib/dato'
 import { KOMMENTARER_KOLLAPS_DAGER } from '@/lib/konstanter'
+import type { ChatProfil } from '@/lib/mention'
 
 export type ArrangementKortData = {
   id: string
@@ -56,9 +57,13 @@ type Props = {
   kommentarer?: KommentarKortData[]
   /** Totalt antall kommentarer (overskrift kan ellers vise maks 3). */
   totaltKommentarer?: number
+  /** Aktive profiler for @mention-forslag i inline kommentar-felt. */
+  profiler?: ChatProfil[]
+  /** Innlogget brukers id — ekskluderes fra mention-forslag. */
+  brukerId?: string
 }
 
-export default function ArrangementKort({ arr, tidligere = false, kommentarer = [], totaltKommentarer }: Props) {
+export default function ArrangementKort({ arr, tidligere = false, kommentarer = [], totaltKommentarer, profiler, brukerId }: Props) {
   const iso = arr.start_tidspunkt
   const mnd = formaterDato(iso, 'MMM').toUpperCase()
   const dag = formaterDato(iso, 'd')
@@ -259,6 +264,8 @@ export default function ArrangementKort({ arr, tidligere = false, kommentarer = 
             scope={{ type: 'arrangement', id: arr.id }}
             startKollapset={skalKollapse}
             totaltAntall={totaltKommentarer}
+            profiler={profiler}
+            brukerId={brukerId}
           />
         )}
       </Card>

--- a/components/agenda/KommentarerPaaKort.tsx
+++ b/components/agenda/KommentarerPaaKort.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useTransition, type MouseEvent, type KeyboardEvent } from 'react'
+import { useRef, useState, useTransition, type MouseEvent, type KeyboardEvent } from 'react'
 import { useRouter } from 'next/navigation'
 import Avatar from '@/components/ui/Avatar'
 import Icon from '@/components/ui/Icon'
@@ -8,6 +8,14 @@ import { sendChatMelding } from '@/lib/actions/chat'
 import type { ChatScope } from '@/lib/chat-konfig'
 import { formatDistanceToNowStrict } from 'date-fns'
 import { nb } from 'date-fns/locale'
+import { CHAT_MAKS_LENGDE } from '@/lib/konstanter'
+import {
+  oppdaterMentionSøk as beregnMentionSøk,
+  velgMentionTekst,
+  lagMentionForslag,
+  type ChatProfil,
+} from '@/lib/mention'
+import MentionVelger from '@/components/agenda/MentionVelger'
 
 export type KommentarKortData = {
   id: string
@@ -48,18 +56,35 @@ export default function KommentarerPaaKort({
   scope,
   startKollapset = false,
   totaltAntall,
+  profiler = [],
+  brukerId,
 }: {
   kommentarer: KommentarKortData[]
   scope: KommentarScope
   startKollapset?: boolean
   /** Totalt antall kommentarer (for korrekt overskrift når listen er begrenset til 3). */
   totaltAntall?: number
+  /** Aktive profiler — brukes til @mention-forslag. Kan utelates (tomt) hvis kalleren ikke trenger mentions. */
+  profiler?: ChatProfil[]
+  /** Innlogget brukers id — ekskluderes fra mention-forslag (han nevner ikke seg selv). */
+  brukerId?: string
 }) {
   const visTall = totaltAntall ?? kommentarer.length
   const [apen, setApen] = useState(!startKollapset)
   const [tekst, setTekst] = useState('')
+  const [mentionSøk, setMentionSøk] = useState<string | null>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
   const [sender, startTransition] = useTransition()
   const router = useRouter()
+
+  const mentionForslag = lagMentionForslag(mentionSøk, profiler, brukerId)
+
+  function velgMention(navn: string) {
+    const ny = velgMentionTekst(tekst, navn)
+    setTekst(ny)
+    setMentionSøk(null)
+    inputRef.current?.focus()
+  }
 
   function toggle(e: MouseEvent<HTMLSpanElement> | KeyboardEvent<HTMLSpanElement>) {
     e.preventDefault()
@@ -80,6 +105,7 @@ export default function KommentarerPaaKort({
     const melding = tekst.trim()
     if (!melding || sender) return
     setTekst('')
+    setMentionSøk(null)
 
     // Map fra det lokale KommentarScope til CHAT_KONFIG-scopet.
     const chatScope: ChatScope =
@@ -226,12 +252,16 @@ export default function KommentarerPaaKort({
       {/* Inline kommentar-input — alltid synlig når seksjonen er åpen (eller
           når det ikke er kommentarer ennå) */}
       {(apen || kommentarer.length === 0) && (
+        <div style={{ marginTop: kommentarer.length > 0 ? 10 : 0 }}>
+        {/* Mention-velger ligger over selve input-pillen så chips ikke krysser
+            den runde rammen. Komponenten returnerer null når det ikke er
+            forslag, så ingen tom margin. */}
+        <MentionVelger forslag={mentionForslag} onVelg={velgMention} />
         <div
           style={{
             display: 'flex',
             alignItems: 'center',
             gap: 8,
-            marginTop: kommentarer.length > 0 ? 10 : 0,
             padding: '6px 6px 6px 12px',
             border: '0.5px solid var(--border)',
             borderRadius: 999,
@@ -240,9 +270,13 @@ export default function KommentarerPaaKort({
           onClick={stopp}
         >
           <input
+            ref={inputRef}
             type="text"
             value={tekst}
-            onChange={e => setTekst(e.target.value)}
+            onChange={e => {
+              setTekst(e.target.value)
+              setMentionSøk(beregnMentionSøk(e.target.value))
+            }}
             onClick={stopp}
             onKeyDown={e => {
               if (e.key === 'Enter' && !e.shiftKey) {
@@ -250,7 +284,7 @@ export default function KommentarerPaaKort({
               }
             }}
             placeholder="Skriv en kommentar…"
-            maxLength={500}
+            maxLength={CHAT_MAKS_LENGDE}
             enterKeyHint="send"
             autoComplete="off"
             disabled={sender}
@@ -286,6 +320,7 @@ export default function KommentarerPaaKort({
           >
             <Icon name="arrowRight" size={12} color="#0a0a0a" strokeWidth={2.5} />
           </button>
+        </div>
         </div>
       )}
     </div>

--- a/components/agenda/KommentarerPaaKort.tsx
+++ b/components/agenda/KommentarerPaaKort.tsx
@@ -64,7 +64,7 @@ export default function KommentarerPaaKort({
   startKollapset?: boolean
   /** Totalt antall kommentarer (for korrekt overskrift når listen er begrenset til 3). */
   totaltAntall?: number
-  /** Aktive profiler — brukes til @mention-forslag. Kan utelates (tomt) hvis kalleren ikke trenger mentions. */
+  /** Aktive profiler — brukes til @mention-forslag på navn. `@alle` er alltid tilgjengelig uansett, siden den ikke krever profil-data. */
   profiler?: ChatProfil[]
   /** Innlogget brukers id — ekskluderes fra mention-forslag (han nevner ikke seg selv). */
   brukerId?: string

--- a/components/agenda/KommentarerPaaKort.tsx
+++ b/components/agenda/KommentarerPaaKort.tsx
@@ -10,7 +10,7 @@ import { formatDistanceToNowStrict } from 'date-fns'
 import { nb } from 'date-fns/locale'
 import { CHAT_MAKS_LENGDE } from '@/lib/konstanter'
 import {
-  oppdaterMentionSøk as beregnMentionSøk,
+  beregnMentionSøk,
   velgMentionTekst,
   lagMentionForslag,
   type ChatProfil,
@@ -252,7 +252,7 @@ export default function KommentarerPaaKort({
       {/* Inline kommentar-input — alltid synlig når seksjonen er åpen (eller
           når det ikke er kommentarer ennå) */}
       {(apen || kommentarer.length === 0) && (
-        <div style={{ marginTop: kommentarer.length > 0 ? 10 : 0 }}>
+        <div style={{ marginTop: kommentarer.length > 0 ? 10 : 0 }} onClick={stopp}>
         {/* Mention-velger ligger over selve input-pillen så chips ikke krysser
             den runde rammen. Komponenten returnerer null når det ikke er
             forslag, så ingen tom margin. */}

--- a/components/agenda/MeldingKort.tsx
+++ b/components/agenda/MeldingKort.tsx
@@ -7,6 +7,7 @@ import Avatar from '@/components/ui/Avatar'
 import Card from '@/components/ui/Card'
 import KommentarerPaaKort, { type KommentarKortData } from '@/components/agenda/KommentarerPaaKort'
 import MeldingReaksjoner, { type ReaksjonGruppe } from '@/components/agenda/MeldingReaksjoner'
+import type { ChatProfil } from '@/lib/mention'
 import { formatDistanceToNowStrict } from 'date-fns'
 import { nb } from 'date-fns/locale'
 
@@ -40,6 +41,8 @@ type Props = {
   melding: MeldingKortData
   brukerId: string
   kommentarer?: KommentarKortData[]
+  /** Aktive profiler for @mention-forslag i inline kommentar-felt. */
+  profiler?: ChatProfil[]
 }
 
 /**
@@ -51,7 +54,7 @@ type Props = {
  * Long-press på selve innlegget åpner reaksjons-picker — samme mønster
  * som chat-bobler bruker. Vanlig click navigerer til detaljsiden.
  */
-export default function MeldingKort({ melding, brukerId, kommentarer = [] }: Props) {
+export default function MeldingKort({ melding, brukerId, kommentarer = [], profiler }: Props) {
   const [pickerApen, setPickerApen] = useState(false)
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const longPressFired = useRef(false)
@@ -224,6 +227,8 @@ export default function MeldingKort({ melding, brukerId, kommentarer = [] }: Pro
             kommentarer={kommentarer}
             scope={{ type: 'melding', id: melding.id }}
             totaltAntall={melding.antallKommentarer}
+            profiler={profiler}
+            brukerId={brukerId}
           />
         )}
       </Card>

--- a/components/agenda/MentionVelger.tsx
+++ b/components/agenda/MentionVelger.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { ALLE_VALG, type ChatProfil } from '@/lib/mention'
+
+type Props = {
+  forslag: ChatProfil[]
+  onVelg: (navn: string) => void
+}
+
+/**
+ * Presentational chip-rad over input-feltet for @mention-forslag.
+ * Bruksområde: full chat (`Chat.tsx`) og inline kommentar-felt på agenda
+ * (`KommentarerPaaKort.tsx`). Holder ingen egen state — kalleren styrer
+ * søk og valgt-tekst via `lib/mention.ts`.
+ *
+ * To subtile valg som er verdt å forklare:
+ *
+ * 1. `onMouseDown preventDefault` — uten dette mister input-feltet fokus
+ *    i det øyeblikket brukeren klikker på chipen. Det fjerner mention-søket
+ *    før `onClick` rekker å trigge, og chipen blir effektivt udelelig.
+ *    `preventDefault` på mousedown holder fokus på input gjennom klikket.
+ *
+ * 2. `onClick stopPropagation` — agenda-kortene wrapper innholdet i en
+ *    `<Link>`, så et chip-klikk uten propagasjons-stopp ville navigert til
+ *    detaljsiden. Vi stopper propagasjon her i stedet for å la hver kaller
+ *    huske det. (I full chat skader det heller ikke.)
+ */
+export default function MentionVelger({ forslag, onVelg }: Props) {
+  if (forslag.length === 0) return null
+
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 10 }}>
+      {forslag.map(p => {
+        const erAlle = p.id === ALLE_VALG.id
+        return (
+          <button
+            key={p.id}
+            type="button"
+            onMouseDown={e => e.preventDefault()}
+            onClick={e => {
+              e.preventDefault()
+              e.stopPropagation()
+              onVelg(p.navn!)
+            }}
+            style={{
+              padding: '6px 12px',
+              borderRadius: 999,
+              background: erAlle ? 'var(--accent-soft)' : 'var(--bg-elevated)',
+              border: `0.5px solid ${erAlle ? 'var(--accent)' : 'var(--border)'}`,
+              color: 'var(--accent)',
+              fontFamily: 'var(--font-body)',
+              fontSize: 12,
+              fontWeight: erAlle ? 600 : 500,
+              cursor: 'pointer',
+            }}
+          >
+            @{p.navn}
+            {erAlle && (
+              <span
+                style={{
+                  marginLeft: 6,
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 9,
+                  letterSpacing: '1.2px',
+                  textTransform: 'uppercase',
+                  color: 'var(--text-tertiary)',
+                }}
+              >
+                varsler hele klubben
+              </span>
+            )}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/agenda/MentionVelger.tsx
+++ b/components/agenda/MentionVelger.tsx
@@ -17,7 +17,7 @@ type Props = {
  *
  * 1. `onMouseDown preventDefault` — uten dette mister input-feltet fokus
  *    i det øyeblikket brukeren klikker på chipen. Det fjerner mention-søket
- *    før `onClick` rekker å trigge, og chipen blir effektivt udelelig.
+ *    før `onClick` rekker å trigge, og chipen blir effektivt uklikkbar.
  *    `preventDefault` på mousedown holder fokus på input gjennom klikket.
  *
  * 2. `onClick stopPropagation` — agenda-kortene wrapper innholdet i en

--- a/components/agenda/PollKort.tsx
+++ b/components/agenda/PollKort.tsx
@@ -4,6 +4,7 @@ import Card from '@/components/ui/Card'
 import KommentarerPaaKort, { type KommentarKortData } from '@/components/agenda/KommentarerPaaKort'
 import { formaterDato, aarHvisAvvik } from '@/lib/dato'
 import PollInlineStemme from '@/components/poll/PollInlineStemme'
+import type { ChatProfil } from '@/lib/mention'
 
 // Terskel for når alternativene vises som inline stemmeknapper på agenda-
 // kortet. Justeres fritt — 2 gir et rent Ja/Nei-oppsett som ligner RSVP-
@@ -31,6 +32,10 @@ type Props = {
   kommentarer?: KommentarKortData[]
   /** Totalt antall kommentarer (overskrift kan ellers vise maks 3). */
   totaltKommentarer?: number
+  /** Aktive profiler for @mention-forslag i inline kommentar-felt. */
+  profiler?: ChatProfil[]
+  /** Innlogget brukers id — ekskluderes fra mention-forslag. */
+  brukerId?: string
 }
 
 function fristLabel(avsluttet: boolean, iso: string): string {
@@ -42,7 +47,7 @@ function fristLabel(avsluttet: boolean, iso: string): string {
   return `frist ${dag}. ${mnd}${aar ? ` ${aar}` : ''} ${tid}`
 }
 
-export default function PollKort({ poll, tidligere = false, kommentarer = [], totaltKommentarer }: Props) {
+export default function PollKort({ poll, tidligere = false, kommentarer = [], totaltKommentarer, profiler, brukerId }: Props) {
   const erInline = !poll.avsluttet && !tidligere && poll.valg.length <= MAKS_INLINE_VALG
 
   // Felles topp-innhold (label + spørsmål). Både inline og kompakt bruker
@@ -146,6 +151,8 @@ export default function PollKort({ poll, tidligere = false, kommentarer = [], to
             kommentarer={kommentarer}
             scope={{ type: 'poll', id: poll.id }}
             totaltAntall={totaltKommentarer}
+            profiler={profiler}
+            brukerId={brukerId}
           />
         </Card>
       </Link>
@@ -227,6 +234,8 @@ export default function PollKort({ poll, tidligere = false, kommentarer = [], to
             kommentarer={kommentarer}
             scope={{ type: 'poll', id: poll.id }}
             totaltAntall={totaltKommentarer}
+            profiler={profiler}
+            brukerId={brukerId}
           />
         )}
       </Card>

--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -18,6 +18,13 @@ import BildeLightbox from '@/components/ui/BildeLightbox'
 import MessengerBadge from '@/components/ui/MessengerBadge'
 import { komprimer, genererFilnavn } from '@/lib/bilde-utils'
 import { lastOppBilde, slettBilde } from '@/lib/actions/bilde-opplasting'
+import {
+  oppdaterMentionSøk as beregnMentionSøk,
+  velgMentionTekst,
+  lagMentionForslag,
+  type ChatProfil,
+} from '@/lib/mention'
+import MentionVelger from '@/components/agenda/MentionVelger'
 
 // ChatScope er sentralt definert i lib/chat-konfig.ts og re-eksportert her
 // for kall-ergonomi (eksisterende callsites importerer fra Chat.tsx).
@@ -36,12 +43,10 @@ export type ChatMelding = {
   fra_facebook?: boolean
 }
 
-export type ChatProfil = {
-  id: string
-  navn: string | null
-  bilde_url: string | null
-  rolle?: string | null
-}
+// ChatProfil-typen ligger nå i lib/mention.ts (sentralisert siden flere
+// flater bruker mention-velgeren). Re-eksporteres her for å bevare
+// eksisterende imports.
+export type { ChatProfil } from '@/lib/mention'
 
 // Antall meldinger som lastes first-batch og per "Vis eldre"-klikk
 const SIDE_STORRELSE = 30
@@ -211,42 +216,13 @@ export default function Chat({
     setBildeFeil('')
   }
 
-  // @alle er et spesialvalg som trigger varsel til alle aktive profiler.
-  // Server-siden matcher strengen «alle» direkte og sender varsler bredt.
-  const ALLE_VALG: ChatProfil = {
-    id: '__alle__',
-    navn: 'alle',
-    bilde_url: null,
-    rolle: null,
-  }
-  const mentionForslag =
-    mentionSøk !== null
-      ? [
-          ...('alle'.startsWith(mentionSøk.toLowerCase()) ? [ALLE_VALG] : []),
-          ...andreProfiler
-            .filter(p => p.navn!.toLowerCase().includes(mentionSøk.toLowerCase()))
-            .slice(0, 5),
-        ]
-      : []
-
-  function oppdaterMentionSøk(verdi: string) {
-    const sisteAt = verdi.lastIndexOf('@')
-    if (sisteAt === -1) {
-      setMentionSøk(null)
-      return
-    }
-    const etterAt = verdi.slice(sisteAt + 1)
-    if (etterAt.endsWith('  ') || etterAt.includes('\n')) {
-      setMentionSøk(null)
-      return
-    }
-    setMentionSøk(etterAt)
-  }
+  // Mention-state og -forslag styres av hjelperne i lib/mention.ts.
+  // andreProfiler-filteret over ekskluderer allerede innlogget bruker, men vi
+  // sender brukerId likevel som ekskluder for å gjøre kontrakten eksplisitt.
+  const mentionForslag = lagMentionForslag(mentionSøk, andreProfiler, brukerId)
 
   function velgMention(navn: string) {
-    const sisteAt = tekst.lastIndexOf('@')
-    if (sisteAt === -1) return
-    const nyTekst = tekst.slice(0, sisteAt) + '@' + navn + ' '
+    const nyTekst = velgMentionTekst(tekst, navn)
     setTekst(nyTekst)
     setMentionSøk(null)
     inputRef.current?.focus()
@@ -1202,48 +1178,7 @@ export default function Chat({
         }}
       >
       {/* @mention-forslag */}
-      {mentionForslag.length > 0 && (
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 10 }}>
-          {mentionForslag.map(p => {
-            const erAlle = p.id === '__alle__'
-            return (
-              <button
-                key={p.id}
-                type="button"
-                onMouseDown={e => e.preventDefault()}
-                onClick={() => velgMention(p.navn!)}
-                style={{
-                  padding: '6px 12px',
-                  borderRadius: 999,
-                  background: erAlle ? 'var(--accent-soft)' : 'var(--bg-elevated)',
-                  border: `0.5px solid ${erAlle ? 'var(--accent)' : 'var(--border)'}`,
-                  color: 'var(--accent)',
-                  fontFamily: 'var(--font-body)',
-                  fontSize: 12,
-                  fontWeight: erAlle ? 600 : 500,
-                  cursor: 'pointer',
-                }}
-              >
-                @{p.navn}
-                {erAlle && (
-                  <span
-                    style={{
-                      marginLeft: 6,
-                      fontFamily: 'var(--font-mono)',
-                      fontSize: 9,
-                      letterSpacing: '1.2px',
-                      textTransform: 'uppercase',
-                      color: 'var(--text-tertiary)',
-                    }}
-                  >
-                    varsler hele klubben
-                  </span>
-                )}
-              </button>
-            )
-          })}
-        </div>
-      )}
+      <MentionVelger forslag={mentionForslag} onVelg={velgMention} />
       {/* Bilde-forhåndsvisning over input når et bilde er valgt */}
       {bildePreview && (
         <div
@@ -1352,7 +1287,7 @@ export default function Chat({
           value={tekst}
           onChange={e => {
             setTekst(e.target.value)
-            oppdaterMentionSøk(e.target.value)
+            setMentionSøk(beregnMentionSøk(e.target.value))
           }}
           onKeyDown={e => {
             if (e.key === 'Enter' && !e.shiftKey) {

--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -19,7 +19,7 @@ import MessengerBadge from '@/components/ui/MessengerBadge'
 import { komprimer, genererFilnavn } from '@/lib/bilde-utils'
 import { lastOppBilde, slettBilde } from '@/lib/actions/bilde-opplasting'
 import {
-  oppdaterMentionSøk as beregnMentionSøk,
+  beregnMentionSøk,
   velgMentionTekst,
   lagMentionForslag,
   type ChatProfil,
@@ -43,10 +43,7 @@ export type ChatMelding = {
   fra_facebook?: boolean
 }
 
-// ChatProfil-typen ligger nå i lib/mention.ts (sentralisert siden flere
-// flater bruker mention-velgeren). Re-eksporteres her for å bevare
-// eksisterende imports.
-export type { ChatProfil } from '@/lib/mention'
+// ChatProfil-typen ligger i lib/mention.ts — importer derfra direkte.
 
 // Antall meldinger som lastes first-batch og per "Vis eldre"-klikk
 const SIDE_STORRELSE = 30

--- a/lib/mention.ts
+++ b/lib/mention.ts
@@ -1,0 +1,71 @@
+// Sentral mention-logikk for chat- og kommentar-input.
+//
+// Brukes av både `components/chat/Chat.tsx` (full chat-flate) og
+// `components/agenda/KommentarerPaaKort.tsx` (inline kommentar-felt på
+// agenda-kort). Tidligere lå logikken kun i Chat.tsx — duplisering ble
+// unngått ved å trekke den ut hit. Visningen håndteres av
+// `components/agenda/MentionVelger.tsx`.
+
+export type ChatProfil = {
+  id: string
+  navn: string | null
+  bilde_url: string | null
+  rolle?: string | null
+}
+
+// `@alle` er et spesialvalg som ikke matcher en konkret profil — server-siden
+// matcher strengen «alle» direkte og sender varsler bredt til hele klubben.
+// Vi gir den en sentinel-id (`__alle__`) slik at React-keys og klikk-håndtering
+// kan skille den fra ekte profiler uten å trenge en egen kodevei.
+export const ALLE_VALG: ChatProfil = {
+  id: '__alle__',
+  navn: 'alle',
+  bilde_url: null,
+  rolle: null,
+}
+
+/**
+ * Tolk hva brukeren har skrevet i input-feltet og returner aktivt mention-søk
+ * — strengen etter siste `@` — eller `null` hvis ingen mention er aktiv.
+ *
+ * Avbryter mention-modus dersom det er to mellomrom på rad eller en linjeskift
+ * etter `@` (typisk når brukeren har gått videre uten å velge noen).
+ */
+export function oppdaterMentionSøk(verdi: string): string | null {
+  const sisteAt = verdi.lastIndexOf('@')
+  if (sisteAt === -1) return null
+  const etterAt = verdi.slice(sisteAt + 1)
+  if (etterAt.endsWith('  ') || etterAt.includes('\n')) return null
+  return etterAt
+}
+
+/**
+ * Erstatt det aktive mention-søket (alt etter siste `@`) med valgt navn,
+ * og legg til et trailing mellomrom så brukeren kan skrive videre.
+ */
+export function velgMentionTekst(tekst: string, navn: string): string {
+  const sisteAt = tekst.lastIndexOf('@')
+  if (sisteAt === -1) return tekst
+  return tekst.slice(0, sisteAt) + '@' + navn + ' '
+}
+
+/**
+ * Bygg listen av mention-forslag for et gitt søk. `@alle` plasseres først
+ * når søket er prefiks av "alle"; deretter de første 5 profilene som matcher
+ * (case-insensitive) — uten `eksluderId` (typisk innlogget bruker, så han
+ * ikke nevner seg selv).
+ */
+export function lagMentionForslag(
+  mentionSøk: string | null,
+  profiler: ChatProfil[],
+  ekskluderId?: string,
+): ChatProfil[] {
+  if (mentionSøk === null) return []
+  const søkLower = mentionSøk.toLowerCase()
+  const inkluderAlle = 'alle'.startsWith(søkLower)
+  const treff = profiler
+    .filter(p => p.id !== ekskluderId && p.navn)
+    .filter(p => p.navn!.toLowerCase().includes(søkLower))
+    .slice(0, 5)
+  return inkluderAlle ? [ALLE_VALG, ...treff] : treff
+}

--- a/lib/mention.ts
+++ b/lib/mention.ts
@@ -31,7 +31,7 @@ export const ALLE_VALG: ChatProfil = {
  * Avbryter mention-modus dersom det er to mellomrom på rad eller en linjeskift
  * etter `@` (typisk når brukeren har gått videre uten å velge noen).
  */
-export function oppdaterMentionSøk(verdi: string): string | null {
+export function beregnMentionSøk(verdi: string): string | null {
   const sisteAt = verdi.lastIndexOf('@')
   if (sisteAt === -1) return null
   const etterAt = verdi.slice(sisteAt + 1)

--- a/lib/mention.ts
+++ b/lib/mention.ts
@@ -28,7 +28,7 @@ export const ALLE_VALG: ChatProfil = {
  * Tolk hva brukeren har skrevet i input-feltet og returner aktivt mention-søk
  * — strengen etter siste `@` — eller `null` hvis ingen mention er aktiv.
  *
- * Avbryter mention-modus dersom det er to mellomrom på rad eller en linjeskift
+ * Avbryter mention-modus dersom det er to mellomrom på rad eller et linjeskift
  * etter `@` (typisk når brukeren har gått videre uten å velge noen).
  */
 export function beregnMentionSøk(verdi: string): string | null {

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 5,
-  "versjon": "V3.0.5"
+  "nummer": 6,
+  "versjon": "V3.0.6"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 4,
-  "versjon": "V3.0.4"
+  "nummer": 5,
+  "versjon": "V3.0.5"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 6,
-  "versjon": "V3.0.6"
+  "nummer": 7,
+  "versjon": "V3.0.7"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "herreklubben",
-  "version": "2.28.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "herreklubben",
-      "version": "2.28.0",
+      "version": "3.0.0",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@supabase/ssr": "^0.10.0",

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V3.0.5'
+const CACHE_VERSION = 'V3.0.6'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V3.0.4'
+const CACHE_VERSION = 'V3.0.5'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V3.0.6'
+const CACHE_VERSION = 'V3.0.7'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Fikser #167.

## Endring
@-tagging fungerte ikke i inline-kommentar-feltet på agenda — det var aldri implementert der. Refaktor som ekstraherer mention-logikken fra `Chat.tsx` til en delt modul:

- `lib/mention.ts` — `beregnMentionSøk`, `velgMentionTekst`, `lagMentionForslag`, `ALLE_VALG`, `ChatProfil`-type
- `components/agenda/MentionVelger.tsx` — chip-rad-komponent gjenbrukt av både Chat og inline-feltet
- `KommentarerPaaKort` får nye `profiler`/`brukerId`-props og renderer `MentionVelger`
- ArrangementKort/PollKort/MeldingKort videresender props
- `app/(app)/page.tsx` henter profiler-listen og sender ned

`@alle`-valget er tilgjengelig overalt (Reidars beslutning).

## Beslutninger underveis
- **Krav-flertydighet eskalert til Reidar:** `@alle` skal være tilgjengelig også fra inline-feltet på agenda (samme oppførsel som full chat).
- **Sentralisering valgt over duplisering** — én sannhet for mention-regex/oppførsel.
- **Reviewer-funn:** stop-propagation på wrapper-div rettet, rename `oppdaterMentionSøk` → `beregnMentionSøk` rettet, re-eksport av `ChatProfil` fjernet. NIT om `chatProfiler` alltid lastes — forsvart (~17 medlemmer, trivielt payload).
- **Bonus-rydding:** `KommentarerPaaKort` brukte hardkodet `maxLength={500}` mens resten av kodebasen bruker `CHAT_MAKS_LENGDE` — byttet i samme PR.

## Test plan
- [x] Lint
- [x] Build
- [x] Mention-regex testsuite (7/7)
- [ ] Manuell: skriv `@` på inline-kommentar på agenda → velger åpnes med medlemmer + `@alle`
- [ ] Manuell: klikk på chip skal IKKE navigere til arrangement-siden (Link-wrapping)
- [ ] Manuell: full chat (`/chat`, arrangement-detalj) fortsatt uendret

🤖 Generated with [Claude Code](https://claude.com/claude-code)