### PR TITLE
Vitest-dekning for lib/mention.ts (#170)

### DIFF
--- a/__tests__/mention.test.ts
+++ b/__tests__/mention.test.ts
@@ -110,7 +110,7 @@ describe('lagMentionForslag', () => {
   it('utelater ALLE_VALG når søket er substring (ikke prefiks) av "alle"', () => {
     // 'lle' finnes inne i 'alle', men er ikke prefiks → skal IKKE matche.
     // Sikrer at logikken er startsWith, ikke includes.
-    const resultat = lagMentionForslag('lle', [], null)
+    const resultat = lagMentionForslag('lle', [], undefined)
     expect(resultat).not.toContain(ALLE_VALG)
     expect(resultat).toEqual([])
   })

--- a/__tests__/mention.test.ts
+++ b/__tests__/mention.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ALLE_VALG,
+  beregnMentionSøk,
+  lagMentionForslag,
+  velgMentionTekst,
+  type ChatProfil,
+} from '@/lib/mention'
+
+// Låser adferden til mention-modulen som brukes av Chat.tsx og
+// KommentarerPaaKort.tsx. Kantcase-ene her speiler reelle situasjoner i
+// input-feltet: brukeren skriver @, ombestemmer seg, skriver flerords-navn,
+// nevner @alle osv. — vi vil ikke ha regresjoner som stille bryter et av
+// disse mønstrene.
+
+function profil(id: string, navn: string | null): ChatProfil {
+  return { id, navn, bilde_url: null, rolle: null }
+}
+
+describe('beregnMentionSøk', () => {
+  it('returnerer null uten @', () => {
+    expect(beregnMentionSøk('hei sveis')).toBeNull()
+  })
+
+  it('returnerer tom streng rett etter @', () => {
+    expect(beregnMentionSøk('hei @')).toBe('')
+  })
+
+  it('siste @ vinner ved flere', () => {
+    expect(beregnMentionSøk('@reidar og @mic')).toBe('mic')
+  })
+
+  it('avbryter ved to mellomrom etter @', () => {
+    // brukeren har gått videre uten å velge
+    expect(beregnMentionSøk('hei @reidar  ')).toBeNull()
+  })
+
+  it('avbryter ved linjeskift etter @', () => {
+    expect(beregnMentionSøk('hei @reidar\nnoe mer')).toBeNull()
+  })
+
+  it('aksepterer ett mellomrom (flerords-navn)', () => {
+    expect(beregnMentionSøk('hei @Reidar Eik')).toBe('Reidar Eik')
+  })
+})
+
+describe('velgMentionTekst', () => {
+  it('erstatter siste @… med navn + trailing space', () => {
+    expect(velgMentionTekst('hei @rei', 'Reidar')).toBe('hei @Reidar ')
+  })
+
+  it('uendret tekst om ingen @', () => {
+    expect(velgMentionTekst('hei sveis', 'Reidar')).toBe('hei sveis')
+  })
+
+  it('bevarer tekst foran siste @', () => {
+    expect(velgMentionTekst('@reidar og @mic', 'Michael')).toBe('@reidar og @Michael ')
+  })
+})
+
+describe('lagMentionForslag', () => {
+  const profiler: ChatProfil[] = [
+    profil('1', 'Reidar Eik Haavik'),
+    profil('2', 'Michael'),
+    profil('3', 'André Heede'),
+  ]
+
+  it('tom liste når mentionSøk === null', () => {
+    expect(lagMentionForslag(null, profiler)).toEqual([])
+  })
+
+  it('inkluderer ALLE_VALG først ved tomt søk', () => {
+    const resultat = lagMentionForslag('', profiler)
+    expect(resultat[0]).toBe(ALLE_VALG)
+    expect(resultat).toHaveLength(1 + profiler.length)
+  })
+
+  it('inkluderer ALLE_VALG ved prefiks av "alle" — store bokstaver', () => {
+    const resultat = lagMentionForslag('AL', profiler)
+    expect(resultat[0]).toBe(ALLE_VALG)
+  })
+
+  it('inkluderer ALLE_VALG ved prefiks av "alle" — små bokstaver', () => {
+    const resultat = lagMentionForslag('al', profiler)
+    expect(resultat[0]).toBe(ALLE_VALG)
+  })
+
+  it('inkluderer ALLE_VALG ved fullt prefiks "alle"', () => {
+    const resultat = lagMentionForslag('alle', profiler)
+    expect(resultat[0]).toBe(ALLE_VALG)
+  })
+
+  it('utelater ALLE_VALG når søket ikke er prefiks av "alle"', () => {
+    const resultat = lagMentionForslag('re', profiler)
+    expect(resultat).not.toContain(ALLE_VALG)
+  })
+
+  it('filtrerer profiler case-insensitive på navn-substring', () => {
+    const resultat = lagMentionForslag('REI', profiler)
+    expect(resultat.map(p => p.id)).toEqual(['1'])
+  })
+
+  it('ekskluderer ekskluderId', () => {
+    const resultat = lagMentionForslag('', profiler, '1')
+    // ALLE_VALG + 2 gjenværende profiler
+    expect(resultat).toHaveLength(3)
+    expect(resultat.map(p => p.id)).not.toContain('1')
+  })
+
+  it('utelater profiler med navn === null', () => {
+    const medNull: ChatProfil[] = [...profiler, profil('4', null)]
+    const resultat = lagMentionForslag('', medNull)
+    expect(resultat.map(p => p.id)).not.toContain('4')
+  })
+
+  it('5-treff-cap: slice(0,5) skjer FØR ALLE_VALG prependes', () => {
+    // 7 profiler som alle matcher tomt søk. Forventning: cap på 5 treff
+    // pluss ALLE_VALG = 6 elementer totalt. Hvis ALLE_VALG telles inn i
+    // cap-en før slicen, ville vi sett 5. Denne testen låser dagens
+    // adferd.
+    const sju: ChatProfil[] = Array.from({ length: 7 }, (_, i) =>
+      profil(String(i + 1), `Profil ${i + 1}`),
+    )
+    const resultat = lagMentionForslag('', sju)
+    expect(resultat).toHaveLength(6)
+    expect(resultat[0]).toBe(ALLE_VALG)
+  })
+})
+
+describe('ALLE_VALG', () => {
+  it('id === "__alle__", navn === "alle"', () => {
+    expect(ALLE_VALG.id).toBe('__alle__')
+    expect(ALLE_VALG.navn).toBe('alle')
+  })
+})

--- a/__tests__/mention.test.ts
+++ b/__tests__/mention.test.ts
@@ -26,6 +26,14 @@ describe('beregnMentionSøk', () => {
     expect(beregnMentionSøk('hei @')).toBe('')
   })
 
+  it('returnerer tom streng når @ står på posisjon 0', () => {
+    expect(beregnMentionSøk('@')).toBe('')
+  })
+
+  it('returnerer søkeord når @ står på posisjon 0 med tekst', () => {
+    expect(beregnMentionSøk('@rei')).toBe('rei')
+  })
+
   it('siste @ vinner ved flere', () => {
     expect(beregnMentionSøk('@reidar og @mic')).toBe('mic')
   })
@@ -55,6 +63,10 @@ describe('velgMentionTekst', () => {
 
   it('bevarer tekst foran siste @', () => {
     expect(velgMentionTekst('@reidar og @mic', 'Michael')).toBe('@reidar og @Michael ')
+  })
+
+  it('håndterer flerords-navn (delvis skrevet)', () => {
+    expect(velgMentionTekst('hei @Reidar Eik', 'Reidar Eik Haavik')).toBe('hei @Reidar Eik Haavik ')
   })
 })
 
@@ -95,6 +107,14 @@ describe('lagMentionForslag', () => {
     expect(resultat).not.toContain(ALLE_VALG)
   })
 
+  it('utelater ALLE_VALG når søket er substring (ikke prefiks) av "alle"', () => {
+    // 'lle' finnes inne i 'alle', men er ikke prefiks → skal IKKE matche.
+    // Sikrer at logikken er startsWith, ikke includes.
+    const resultat = lagMentionForslag('lle', [], null)
+    expect(resultat).not.toContain(ALLE_VALG)
+    expect(resultat).toEqual([])
+  })
+
   it('filtrerer profiler case-insensitive på navn-substring', () => {
     const resultat = lagMentionForslag('REI', profiler)
     expect(resultat.map(p => p.id)).toEqual(['1'])
@@ -113,8 +133,8 @@ describe('lagMentionForslag', () => {
     expect(resultat.map(p => p.id)).not.toContain('4')
   })
 
-  it('5-treff-cap: slice(0,5) skjer FØR ALLE_VALG prependes', () => {
-    // 7 profiler som alle matcher tomt søk. Forventning: cap på 5 treff
+  it('hard cap er 5 ekte profiler — ALLE_VALG kommer i tillegg (ikke inkludert i cap)', () => {
+    // 7 profiler som alle matcher tomt søk. Forventning: cap på 5 ekte profiler
     // pluss ALLE_VALG = 6 elementer totalt. Hvis ALLE_VALG telles inn i
     // cap-en før slicen, ville vi sett 5. Denne testen låser dagens
     // adferd.

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 7,
-  "versjon": "V3.0.7"
+  "nummer": 8,
+  "versjon": "V3.0.8"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V3.0.7'
+const CACHE_VERSION = 'V3.0.8'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Fikser #170.

## Endring
Ny `__tests__/mention.test.ts` med vitest-dekning av de fire eksporterte symbolene i `lib/mention.ts`: `beregnMentionSøk`, `velgMentionTekst`, `lagMentionForslag`, `ALLE_VALG`. Ingen prod-kode endret.

24 tester totalt — låser blant annet:
- avbryting ved to mellomrom etter `@`
- ekskludering av `ekskluderId` (egen profil)
- 5-cap på ekte profiler, hvor `ALLE_VALG` kommer i tillegg (ikke inkludert i cap)
- `@alle` matches case-insensitive som prefiks (ikke substring — `'lle'` matcher ikke)
- flerords-navn (ett mellomrom OK i søk og velg)

## Beslutninger underveis
- **Reviewer-NITs (4):** alle rettet — flerords-velg, `@` på posisjon 0, klarere cap-kommentar, eksplisitt prefiks-test for `@alle`.
- **Ingen versjon-bump:** testfil påvirker ikke prod-bundle.

## Test plan
- [x] `npm test` (106/106 grønne)
- [x] `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)