### PR TITLE
Importer 75 historiske FB-bildeposter som meldinger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,12 @@ scripts/data/import-rapport.json
 /scripts/fb-reimport.mjs
 /scripts/fb-kjor.mjs
 /scripts/kjor-migrasjon.mjs
+
+# FB-bilde-import (issue #?) — store kopier av råbilder + genererte HTML-rapporter
+/scripts/fb-bilder-preview/
+/scripts/fb-bilder-r2-upload/
+/scripts/fb-bilder-kommentar-crops/
+/scripts/fb-bilder-pairing.html
+/scripts/fb-bilder-metadata.html
 .vercel
 .env*.local

--- a/__tests__/meldinger.test.ts
+++ b/__tests__/meldinger.test.ts
@@ -16,7 +16,9 @@ function lagMelding(opprettetDagerSiden: number, aktivitetDagerSiden: number): M
   return {
     id: 'm1',
     innhold: 'test',
-    bilde_url: null,
+    bilde_url: null as string | null,
+    tilleggsbilder: [] as string[],
+    fraFacebook: false,
     opprettet: new Date(naaMs - opprettetDagerSiden * DAG_MS).toISOString(),
     sist_aktivitet: new Date(naaMs - aktivitetDagerSiden * DAG_MS).toISOString(),
     forfatter: { id: 'p', navn: 'Ola', bilde_url: null, rolle: null },

--- a/app/(app)/meldinger/[id]/page.tsx
+++ b/app/(app)/meldinger/[id]/page.tsx
@@ -15,12 +15,14 @@ type MeldingRad = {
   innhold: string
   opprettet: string
   bilde_url: string | null
+  fra_facebook: boolean | null
   profil_id: string
   profiles: {
     navn: string | null
     bilde_url: string | null
     rolle: string | null
   } | null
+  melding_bilder: { bilde_url: string; rekkefoelge: number }[] | null
 }
 
 type ReaksjonRad = {
@@ -49,7 +51,7 @@ export default async function MeldingDetalj({
     supabase
       .from('meldinger')
       .select(
-        'id, innhold, opprettet, bilde_url, profil_id, profiles!meldinger_profil_id_fkey(navn, bilde_url, rolle)',
+        'id, innhold, opprettet, bilde_url, fra_facebook, profil_id, profiles!meldinger_profil_id_fkey(navn, bilde_url, rolle), melding_bilder(bilde_url, rekkefoelge)',
       )
       .eq('id', id)
       .single<MeldingRad>(),
@@ -128,6 +130,21 @@ export default async function MeldingDetalj({
                 locale: nb,
                 addSuffix: true,
               })}
+              {melding.fra_facebook && (
+                <span
+                  title="Importert fra Facebook"
+                  style={{
+                    marginLeft: 8,
+                    border: '0.5px solid var(--border)',
+                    borderRadius: 3,
+                    padding: '1px 5px',
+                    fontSize: 9,
+                    opacity: 0.7,
+                  }}
+                >
+                  Facebook
+                </span>
+              )}
             </div>
           </div>
         </div>
@@ -146,27 +163,57 @@ export default async function MeldingDetalj({
           {melding.innhold}
         </div>
 
-        {melding.bilde_url && (
-          <div
-            style={{
-              position: 'relative',
-              width: '100%',
-              aspectRatio: '4/3',
-              borderRadius: 'var(--radius-card)',
-              overflow: 'hidden',
-              marginBottom: 16,
-            }}
-          >
-            <Image
-              src={melding.bilde_url}
-              alt=""
-              fill
-              sizes="(max-width: 512px) 100vw, 512px"
-              style={{ objectFit: 'cover' }}
-              priority
-            />
-          </div>
-        )}
+        {melding.bilde_url && (() => {
+          const ekstra = [...(melding.melding_bilder ?? [])]
+            .sort((a, b) => a.rekkefoelge - b.rekkefoelge)
+            .map(b => b.bilde_url)
+          return (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginBottom: 16 }}>
+              <div
+                style={{
+                  position: 'relative',
+                  width: '100%',
+                  aspectRatio: '4/3',
+                  borderRadius: 'var(--radius-card)',
+                  overflow: 'hidden',
+                }}
+              >
+                <Image
+                  src={melding.bilde_url}
+                  alt=""
+                  fill
+                  sizes="(max-width: 512px) 100vw, 512px"
+                  style={{ objectFit: 'cover' }}
+                  priority
+                />
+              </div>
+              {ekstra.length > 0 && (
+                <div style={{ display: 'grid', gridTemplateColumns: `repeat(${ekstra.length}, 1fr)`, gap: 4 }}>
+                  {ekstra.map((url, i) => (
+                    <div
+                      key={i}
+                      style={{
+                        position: 'relative',
+                        width: '100%',
+                        aspectRatio: '1/1',
+                        borderRadius: 'var(--radius-card)',
+                        overflow: 'hidden',
+                      }}
+                    >
+                      <Image
+                        src={url}
+                        alt=""
+                        fill
+                        sizes="(max-width: 512px) 33vw, 170px"
+                        style={{ objectFit: 'cover' }}
+                      />
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )
+        })()}
 
         <MeldingReaksjoner
           meldingId={melding.id}

--- a/app/(app)/meldinger/[id]/page.tsx
+++ b/app/(app)/meldinger/[id]/page.tsx
@@ -12,7 +12,7 @@ import { nb } from 'date-fns/locale'
 
 type MeldingRad = {
   id: string
-  innhold: string
+  innhold: string | null
   opprettet: string
   bilde_url: string | null
   fra_facebook: boolean | null
@@ -74,7 +74,9 @@ export default async function MeldingDetalj({
   if (!melding) notFound()
 
   const erAdmin = kanAdministrere(profil?.rolle)
-  const kanSlette = melding.profil_id === user!.id || erAdmin
+  // FB-importerte meldinger er fryst i RLS (mig 081 speiler 067 fra klubb_chat).
+  // Skjul slette-knappen så brukeren ikke møter en kryptisk RLS-feil ved klikk.
+  const kanSlette = (melding.profil_id === user!.id || erAdmin) && !melding.fra_facebook
 
   // Aggreger reaksjoner per emoji
   const grupper = new Map<string, string[]>()

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -123,7 +123,10 @@ export default async function Forside() {
     supabase
       .from('meldinger')
       .select(
-        'id, innhold, opprettet, sist_aktivitet, bilde_url, fra_facebook, profil_id, profiles!meldinger_profil_id_fkey (navn, bilde_url, rolle), melding_bilder (bilde_url, rekkefoelge)',
+        // melding_chat(count) returnerer aggregert antall kommentarer per
+        // melding via PostgREST — billig og uavhengig av om den enkelte
+        // kommentaren faller innenfor melding_chat-limit-vinduet under.
+        'id, innhold, opprettet, sist_aktivitet, bilde_url, fra_facebook, profil_id, profiles!meldinger_profil_id_fkey (navn, bilde_url, rolle), melding_bilder (bilde_url, rekkefoelge), melding_chat (count)',
       )
       .order('sist_aktivitet', { ascending: false }),
       // Tidligere hadde vi limit(60) her, men det skvisa ut historiske
@@ -154,8 +157,8 @@ export default async function Forside() {
     // Totalt antall kommentarer per arrangement og poll — ren id-spørring
     // uten join, limit eller dato-filter. Brukes til overskriften «X kommentarer»
     // på agenda-kort så tallet er den faktiske totalen, ikke begrenset av
-    // visningsvinduet eller topp-3-uttrekket. For meldinger holder vi oss til
-    // limit(60)-uttrekket i meldingKommentarer over.
+    // visningsvinduet eller topp-3-uttrekket. For meldinger gjør vi tilsvarende
+    // via melding_chat(count)-embed direkte på meldinger-spørringen.
     supabase
       .from('arrangement_chat')
       .select('arrangement_id'),
@@ -305,9 +308,15 @@ export default async function Forside() {
   for (const r of (pollKommTotalt ?? []) as { poll_id: string }[]) {
     totaltPerPoll.set(r.poll_id, (totaltPerPoll.get(r.poll_id) ?? 0) + 1)
   }
+  // antallKommentarer per melding kommer nå fra count-aggregatet på selve
+  // meldinger-spørringen (melding_chat(count)), ikke fra meldingKommentarer
+  // (limit 60). Det fixer regresjonen som oppsto da vi fjernet limit(60) på
+  // meldinger: før hadde vi praktisk talt total dekning fordi begge limit'ene
+  // var 60, men med 75 historiske FB-meldinger holdt det ikke. count-aggregat
+  // er pålitelig uansett vindu.
   const antallKommPerMelding = new Map<string, number>()
-  for (const r of (meldingKommentarer ?? []) as unknown as RawMeldKomm[]) {
-    antallKommPerMelding.set(r.melding_id, (antallKommPerMelding.get(r.melding_id) ?? 0) + 1)
+  for (const m of (meldingerRaad ?? []) as unknown as RawMelding[]) {
+    antallKommPerMelding.set(m.id, m.melding_chat?.[0]?.count ?? 0)
   }
 
   // Aggreger reaksjoner per melding+emoji
@@ -331,6 +340,7 @@ export default async function Forside() {
     profil_id: string
     profiles: { navn: string | null; bilde_url: string | null; rolle: string | null } | null
     melding_bilder: { bilde_url: string; rekkefoelge: number }[] | null
+    melding_chat: { count: number }[] | null
   }
 
   const meldingerForAgenda: MeldingRaad[] = (meldingerRaad ?? []).map((m: RawMelding) => {

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -123,10 +123,12 @@ export default async function Forside() {
     supabase
       .from('meldinger')
       .select(
-        'id, innhold, opprettet, sist_aktivitet, bilde_url, profil_id, profiles!meldinger_profil_id_fkey (navn, bilde_url, rolle)',
+        'id, innhold, opprettet, sist_aktivitet, bilde_url, fra_facebook, profil_id, profiles!meldinger_profil_id_fkey (navn, bilde_url, rolle), melding_bilder (bilde_url, rekkefoelge)',
       )
-      .order('sist_aktivitet', { ascending: false })
-      .limit(60),
+      .order('sist_aktivitet', { ascending: false }),
+      // Tidligere hadde vi limit(60) her, men det skvisa ut historiske
+      // FB-importerte meldinger (75 stk fra 2010-2022). Issue #176 sporer
+      // sentralisert agenda-cutoff + paginering på tvers av typer.
     supabase
       .from('melding_reaksjon')
       .select('melding_id, profil_id, emoji'),
@@ -321,12 +323,14 @@ export default async function Forside() {
 
   type RawMelding = {
     id: string
-    innhold: string
+    innhold: string | null
     opprettet: string
     sist_aktivitet: string
     bilde_url: string | null
+    fra_facebook: boolean | null
     profil_id: string
     profiles: { navn: string | null; bilde_url: string | null; rolle: string | null } | null
+    melding_bilder: { bilde_url: string; rekkefoelge: number }[] | null
   }
 
   const meldingerForAgenda: MeldingRaad[] = (meldingerRaad ?? []).map((m: RawMelding) => {
@@ -335,12 +339,17 @@ export default async function Forside() {
       emoji,
       profilIder,
     }))
+    const tilleggsbilder = [...(m.melding_bilder ?? [])]
+      .sort((a, b) => a.rekkefoelge - b.rekkefoelge)
+      .map(b => b.bilde_url)
     return {
       id: m.id,
       innhold: m.innhold,
       opprettet: m.opprettet,
       sist_aktivitet: m.sist_aktivitet,
       bilde_url: m.bilde_url,
+      tilleggsbilder,
+      fraFacebook: m.fra_facebook === true,
       forfatter: {
         id: m.profil_id,
         navn: m.profiles?.navn ?? 'Ukjent',

--- a/components/agenda/MeldingKort.tsx
+++ b/components/agenda/MeldingKort.tsx
@@ -13,10 +13,14 @@ import { nb } from 'date-fns/locale'
 
 export type MeldingKortData = {
   id: string
-  innhold: string
+  innhold: string | null
   opprettet: string
   sist_aktivitet: string
   bilde_url: string | null
+  // Tilleggsbilder utover bilde_url. Når satt vises grid (cover + ekstra).
+  // Brukes av FB-importerte poster — issue #174 sporer multi-upload fra UI.
+  tilleggsbilder?: string[]
+  fraFacebook?: boolean
   forfatter: {
     id: string
     navn: string
@@ -163,6 +167,24 @@ export default function MeldingKort({ melding, brukerId, kommentarer = [], profi
               >
                 {relativTid(melding.opprettet)}
               </span>
+              {melding.fraFacebook && (
+                <span
+                  title="Importert fra Facebook"
+                  style={{
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 9,
+                    color: 'var(--text-tertiary)',
+                    letterSpacing: '0.8px',
+                    textTransform: 'uppercase',
+                    border: '0.5px solid var(--border)',
+                    borderRadius: 3,
+                    padding: '1px 5px',
+                    opacity: 0.7,
+                  }}
+                >
+                  Facebook
+                </span>
+              )}
             </div>
           </div>
 
@@ -185,28 +207,81 @@ export default function MeldingKort({ melding, brukerId, kommentarer = [], profi
             {melding.innhold}
           </div>
 
-          {/* Bilde (valgfritt) */}
-          {melding.bilde_url && (
-            <div
-              style={{
-                position: 'relative',
-                width: '100%',
-                aspectRatio: '4/3',
-                borderRadius: 'var(--radius-card)',
-                overflow: 'hidden',
-                marginBottom:
-                  !melding.tidligere && (melding.reaksjoner.length > 0 || pickerApen) ? 10 : 0,
-              }}
-            >
-              <Image
-                src={melding.bilde_url}
-                alt=""
-                fill
-                sizes="(max-width: 512px) 100vw, 512px"
-                style={{ objectFit: 'cover' }}
-              />
-            </div>
-          )}
+          {/* Bilde(r). Cover (bilde_url) først; ev. tilleggsbilder etter i grid.
+              Issue #174 vil utvide til multi-upload fra UI senere. */}
+          {melding.bilde_url && (() => {
+            const ekstra = melding.tilleggsbilder ?? []
+            const alle = [melding.bilde_url, ...ekstra]
+            const wrapperBunn =
+              !melding.tidligere && (melding.reaksjoner.length > 0 || pickerApen) ? 10 : 0
+            // Ett bilde: behold full-bredde 4:3-render. Flere bilder: vis cover
+            // i full bredde og resten i en horisontal grid under.
+            if (alle.length === 1) {
+              return (
+                <div
+                  style={{
+                    position: 'relative',
+                    width: '100%',
+                    aspectRatio: '4/3',
+                    borderRadius: 'var(--radius-card)',
+                    overflow: 'hidden',
+                    marginBottom: wrapperBunn,
+                  }}
+                >
+                  <Image
+                    src={melding.bilde_url}
+                    alt=""
+                    fill
+                    sizes="(max-width: 512px) 100vw, 512px"
+                    style={{ objectFit: 'cover' }}
+                  />
+                </div>
+              )
+            }
+            return (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginBottom: wrapperBunn }}>
+                <div
+                  style={{
+                    position: 'relative',
+                    width: '100%',
+                    aspectRatio: '4/3',
+                    borderRadius: 'var(--radius-card)',
+                    overflow: 'hidden',
+                  }}
+                >
+                  <Image
+                    src={melding.bilde_url}
+                    alt=""
+                    fill
+                    sizes="(max-width: 512px) 100vw, 512px"
+                    style={{ objectFit: 'cover' }}
+                  />
+                </div>
+                <div style={{ display: 'grid', gridTemplateColumns: `repeat(${ekstra.length}, 1fr)`, gap: 4 }}>
+                  {ekstra.map((url, i) => (
+                    <div
+                      key={i}
+                      style={{
+                        position: 'relative',
+                        width: '100%',
+                        aspectRatio: '1/1',
+                        borderRadius: 'var(--radius-card)',
+                        overflow: 'hidden',
+                      }}
+                    >
+                      <Image
+                        src={url}
+                        alt=""
+                        fill
+                        sizes="(max-width: 512px) 33vw, 170px"
+                        style={{ objectFit: 'cover' }}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )
+          })()}
 
           {/* Reaksjons-rad — vises kun hvis det finnes reaksjoner eller
               picker er åpen. Picker styres av long-press over. */}

--- a/lib/agenda-sortering.ts
+++ b/lib/agenda-sortering.ts
@@ -121,10 +121,15 @@ export type PollRaad = {
 // melding_chat eller melding_reaksjon.
 export type MeldingRaad = {
   id: string
-  innhold: string
+  innhold: string | null
   opprettet: string
   sist_aktivitet: string
   bilde_url: string | null
+  // Tilleggsbilder utover bilde_url (cover). Brukes av FB-importerte poster
+  // med flere bilder. Sortert på rekkefoelge. Utvidelse til full multi-upload
+  // fra UI er sporet i issue #174.
+  tilleggsbilder: string[]
+  fraFacebook: boolean
   forfatter: {
     id: string
     navn: string
@@ -225,6 +230,8 @@ export function tilMeldingKort(m: MeldingRaad, tidligere: boolean): MeldingKortD
     opprettet: m.opprettet,
     sist_aktivitet: m.sist_aktivitet,
     bilde_url: m.bilde_url,
+    tilleggsbilder: m.tilleggsbilder,
+    fraFacebook: m.fraFacebook,
     forfatter: m.forfatter,
     reaksjoner: m.reaksjoner,
     antallKommentarer: m.antallKommentarer,

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -468,11 +468,45 @@ export type Database = {
           },
         ]
       }
+      melding_bilder: {
+        Row: {
+          bilde_url: string
+          id: string
+          melding_id: string
+          opprettet: string
+          rekkefoelge: number
+        }
+        Insert: {
+          bilde_url: string
+          id?: string
+          melding_id: string
+          opprettet?: string
+          rekkefoelge?: number
+        }
+        Update: {
+          bilde_url?: string
+          id?: string
+          melding_id?: string
+          opprettet?: string
+          rekkefoelge?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "melding_bilder_melding_id_fkey"
+            columns: ["melding_id"]
+            isOneToOne: false
+            referencedRelation: "meldinger"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       melding_chat: {
         Row: {
           bilde_url: string | null
+          fra_facebook: boolean
           id: string
           innhold: string | null
+          kilde_ekstern_id: string | null
           melding_id: string
           opprettet: string
           profil_id: string
@@ -480,8 +514,10 @@ export type Database = {
         }
         Insert: {
           bilde_url?: string | null
+          fra_facebook?: boolean
           id?: string
           innhold?: string | null
+          kilde_ekstern_id?: string | null
           melding_id: string
           opprettet?: string
           profil_id: string
@@ -489,8 +525,10 @@ export type Database = {
         }
         Update: {
           bilde_url?: string | null
+          fra_facebook?: boolean
           id?: string
           innhold?: string | null
+          kilde_ekstern_id?: string | null
           melding_id?: string
           opprettet?: string
           profil_id?: string
@@ -552,24 +590,30 @@ export type Database = {
       meldinger: {
         Row: {
           bilde_url: string | null
+          fra_facebook: boolean
           id: string
-          innhold: string
+          innhold: string | null
+          kilde_ekstern_id: string | null
           opprettet: string
           profil_id: string
           sist_aktivitet: string
         }
         Insert: {
           bilde_url?: string | null
+          fra_facebook?: boolean
           id?: string
-          innhold: string
+          innhold?: string | null
+          kilde_ekstern_id?: string | null
           opprettet?: string
           profil_id: string
           sist_aktivitet?: string
         }
         Update: {
           bilde_url?: string | null
+          fra_facebook?: boolean
           id?: string
-          innhold?: string
+          innhold?: string | null
+          kilde_ekstern_id?: string | null
           opprettet?: string
           profil_id?: string
           sist_aktivitet?: string

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 8,
-  "versjon": "V3.0.8"
+  "nummer": 9,
+  "versjon": "V3.0.9"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V3.0.8'
+const CACHE_VERSION = 'V3.0.9'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/scripts/fb-bilder-bytt.mjs
+++ b/scripts/fb-bilder-bytt.mjs
@@ -1,0 +1,80 @@
+// Bytt bilde-tildeling mellom to par i fb-bilder-pairing.json.
+//
+// Bruk:  node scripts/fb-bilder-bytt.mjs <bilde_nr_A> <screenshot_nr_X>
+//
+// Tolkning: "bilde A skal pares med screenshot X". Skriptet finner raden
+// der bilde A ligger nå, raden der screenshot X ligger, og bytter bilde-
+// tildelingen mellom dem. Hvis screenshot X i dag har bilde B, ender bilde B
+// opp på det stedet bilde A pleide å være. (Slik holder vi alle bilder paret
+// så langt det går — ingen blir utilsiktet droppet.)
+//
+// Etterpå: kjør node scripts/fb-bilder-render.mjs for å oppdatere HTML.
+
+import { readFileSync, writeFileSync } from 'node:fs'
+
+const JSON_FIL = 'scripts/fb-bilder-pairing.json'
+
+const [, , bildeArg, screenshotArg] = process.argv
+if (!bildeArg || !screenshotArg) {
+  console.error('Bruk: node scripts/fb-bilder-bytt.mjs <bilde_nr> <screenshot_nr>')
+  process.exit(1)
+}
+const bildeNr = Number(bildeArg)
+const ssNr = Number(screenshotArg)
+
+const data = JSON.parse(readFileSync(JSON_FIL, 'utf8'))
+const par = data.par
+
+// Finn raden der bilde A ligger
+const radA = par.findIndex(p => p.bilde_nr === bildeNr)
+// Finn raden der screenshot X ligger
+const radX = par.findIndex(p => p.screenshot_nr === ssNr)
+
+if (radX === -1) {
+  console.error(`Fant ikke screenshot ${ssNr}`)
+  process.exit(1)
+}
+
+if (radA === radX) {
+  console.log(`Bilde ${bildeNr} er allerede paret med screenshot ${ssNr} — ingen endring.`)
+  process.exit(0)
+}
+
+// Hent bilde-objektet i hver rad
+const bildeAFelter = radA !== -1
+  ? { bilde_nr: par[radA].bilde_nr, bilde: par[radA].bilde, bilde_mtime: par[radA].bilde_mtime }
+  : null
+const bildeXFelter = {
+  bilde_nr: par[radX].bilde_nr,
+  bilde: par[radX].bilde,
+  bilde_mtime: par[radX].bilde_mtime,
+}
+
+// Bytt
+if (radA !== -1) {
+  Object.assign(par[radA], bildeXFelter)
+  par[radA].diff_sek = par[radA].bilde_mtime
+    ? Math.round((new Date(par[radA].screenshot_mtime) - new Date(par[radA].bilde_mtime)) / 1000)
+    : null
+}
+
+if (bildeAFelter) {
+  Object.assign(par[radX], bildeAFelter)
+} else {
+  par[radX].bilde_nr = bildeNr
+  // Filnavnet må slås opp — men skriptet kan ikke uten å kjenne mappingen.
+  // I praksis bruker vi alltid bilder som allerede ligger i par-listen.
+  console.warn(`Advarsel: bilde ${bildeNr} fantes ikke i noen rad fra før — kopierer kun bilde_nr.`)
+}
+par[radX].diff_sek = par[radX].bilde_mtime
+  ? Math.round((new Date(par[radX].screenshot_mtime) - new Date(par[radX].bilde_mtime)) / 1000)
+  : null
+
+writeFileSync(JSON_FIL, JSON.stringify(data, null, 2), 'utf8')
+
+console.log(`✓ Byttet: bilde ${bildeNr} ↔ screenshot ${ssNr}`)
+if (radA !== -1) {
+  console.log(`  Rad ${radA + 1} (screenshot ${par[radA].screenshot_nr}) har nå bilde ${par[radA].bilde_nr ?? '—'}`)
+}
+console.log(`  Rad ${radX + 1} (screenshot ${par[radX].screenshot_nr}) har nå bilde ${par[radX].bilde_nr}`)
+console.log(`\nKjør: node scripts/fb-bilder-render.mjs for å oppdatere HTML.`)

--- a/scripts/fb-bilder-crop-kommentarer.mjs
+++ b/scripts/fb-bilder-crop-kommentarer.mjs
@@ -1,0 +1,35 @@
+// Cropper kommentar-kolonnen ut av hver unike screenshot i pairing-JSON.
+// FB photo viewer har en konsistent ~380px-bred kommentar-kolonne til høyre,
+// uansett vindusstørrelse — vi cropper de siste 400 px for trygghet.
+//
+// Bruk: node scripts/fb-bilder-crop-kommentarer.mjs
+
+import sharp from 'sharp'
+import { readFileSync, mkdirSync, existsSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+
+const SCREENSHOTS_DIR = 'C:/Users/reida/Pictures/Screenshots'
+const JSON_FIL = 'scripts/fb-bilder-pairing.json'
+const CROPS_DIR = 'scripts/fb-bilder-kommentar-crops'
+const KOLONNE_BREDDE = 400
+
+const data = JSON.parse(readFileSync(JSON_FIL, 'utf8'))
+const unikeScreenshots = [...new Set(data.par.map(p => p.screenshot))]
+
+if (existsSync(CROPS_DIR)) rmSync(CROPS_DIR, { recursive: true })
+mkdirSync(CROPS_DIR, { recursive: true })
+
+let antall = 0
+for (const navn of unikeScreenshots) {
+  const inn = join(SCREENSHOTS_DIR, navn)
+  const ut = join(CROPS_DIR, navn)
+  const meta = await sharp(inn).metadata()
+  const left = Math.max(0, meta.width - KOLONNE_BREDDE)
+  await sharp(inn)
+    .extract({ left, top: 0, width: meta.width - left, height: meta.height })
+    .png()
+    .toFile(ut)
+  antall++
+}
+
+console.log(`✓ Croppet ${antall} kommentar-kolonner til ${CROPS_DIR}/`)

--- a/scripts/fb-bilder-fyll-nr.mjs
+++ b/scripts/fb-bilder-fyll-nr.mjs
@@ -1,0 +1,36 @@
+// Engangs-fix: gi bilde_nr til ikke_parede_bilder som mangler det.
+// Numrene følger samme kronologiske mtime-orden som første pairing brukte.
+
+import { readdirSync, statSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const BILDER_DIR = 'C:/Users/reida/Pictures'
+const JSON_FIL = 'scripts/fb-bilder-pairing.json'
+const EKSKLUDER = ['icon-192.png', 'icon-192n.png']
+
+const bilder = readdirSync(BILDER_DIR)
+  .filter(f => /\.(jpe?g|png)$/i.test(f) && !f.startsWith('Skjermbilde') && !f.startsWith('_crop'))
+  .filter(f => !EKSKLUDER.includes(f))
+  .map(f => ({ navn: f, mtime: statSync(join(BILDER_DIR, f)).mtime }))
+  .sort((a, b) => a.mtime - b.mtime)
+
+const nrFraNavn = new Map(bilder.map((b, i) => [b.navn, i + 1]))
+const mtimeFraNavn = new Map(bilder.map(b => [b.navn, b.mtime.toISOString()]))
+
+const data = JSON.parse(readFileSync(JSON_FIL, 'utf8'))
+
+let fikset = 0
+data.ikke_parede_bilder = data.ikke_parede_bilder.map(o => {
+  const obj = typeof o === 'string' ? { navn: o } : o
+  if (obj.bilde_nr == null) {
+    obj.bilde_nr = nrFraNavn.get(obj.navn) ?? null
+    obj.bilde_mtime = obj.bilde_mtime ?? mtimeFraNavn.get(obj.navn) ?? null
+    if (obj.bilde_nr != null) fikset++
+  }
+  return obj
+})
+
+data.ikke_parede_bilder.sort((a, b) => (a.bilde_nr ?? 999) - (b.bilde_nr ?? 999))
+
+writeFileSync(JSON_FIL, JSON.stringify(data, null, 2), 'utf8')
+console.log(`✓ Fylte inn bilde_nr på ${fikset} løse bilder`)

--- a/scripts/fb-bilder-generer-sql.mjs
+++ b/scripts/fb-bilder-generer-sql.mjs
@@ -115,11 +115,11 @@ for (const meta of [...METADATA].sort((a, b) => a.screenshot_nr - b.screenshot_n
       const url = `${R2_PUBLIC_URL}/meldinger/${p.bilde}`
       return `  ((select id from melding_id_cte), ${sql(url)}, ${i + 1}, ${sql(opprettet)})`
     }).join(',\n')
-    // ingen unique constraint på melding_bilder — vi unngår dupliseringer ved
-    // at hele transaksjonen bare opprettes en gang (meldingens kilde_ekstern_id
-    // forhindrer dobbel insert), og ekstrabildene henger på den nye meldingen.
+    // Idempotens via unique constraint (melding_id, rekkefoelge) lagt til i
+    // migrasjon 082. Re-import skipper duplikat-rader uten å feile.
     linjer.push('insert into melding_bilder (melding_id, bilde_url, rekkefoelge, opprettet) values')
-    linjer.push(ekstraInserts + ';')
+    linjer.push(ekstraInserts)
+    linjer.push('on conflict (melding_id, rekkefoelge) do nothing;')
     antallBilder += sortertePar.length - 1
   } else {
     linjer.push('select 1;')  // dummy så CTE ikke skal være "unused"

--- a/scripts/fb-bilder-generer-sql.mjs
+++ b/scripts/fb-bilder-generer-sql.mjs
@@ -1,0 +1,174 @@
+// Genererer SQL-inserts for FB-bilde-import basert på pairing + metadata + navn-mapping.
+//
+// Output:
+//   scripts/fb-bilder-import.sql — kjøres i Supabase SQL Editor etter at:
+//     1. Migrasjon 081 er kjørt
+//     2. Bilder er lastet opp til R2 under "meldinger/"
+//
+// Bruk: node scripts/fb-bilder-generer-sql.mjs
+
+import { readFileSync, writeFileSync } from 'node:fs'
+
+const PAIRING = JSON.parse(readFileSync('scripts/fb-bilder-pairing.json', 'utf8'))
+const METADATA = JSON.parse(readFileSync('scripts/fb-bilder-metadata.json', 'utf8'))
+const NAVN_MAPPING = JSON.parse(readFileSync('scripts/fb-bilder-navn-mapping.json', 'utf8'))
+
+// R2 public URL — matcher fb-import.mjs (samme bucket)
+const R2_PUBLIC_URL = 'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev'
+
+// Norske månedsnavn → tall (for å parse "2. april 2016")
+const MND = { januar:1, februar:2, mars:3, april:4, mai:5, juni:6, juli:7, august:8, september:9, oktober:10, november:11, desember:12 }
+
+function parseNorskDato(s) {
+  // Format: "DD. mnd YYYY" — eks "2. april 2016", "31. mai 2022"
+  const m = s.match(/^(\d{1,2})\.\s*([a-zæøå]+)\s+(\d{4})$/i)
+  if (!m) throw new Error(`Kan ikke parse dato: ${s}`)
+  const dag = parseInt(m[1], 10)
+  const mnd = MND[m[2].toLowerCase()]
+  if (!mnd) throw new Error(`Ukjent måned: ${m[2]}`)
+  const aar = parseInt(m[3], 10)
+  // Bruk 12:34:56 norsk lokaltid (Reidars kode for "konstruert tid")
+  // Konverter til UTC: norsk sommer UTC+2, vinter UTC+1. Vi bruker UTC+1 for
+  // enkelhet — sortering blir fortsatt riktig innen samme dag.
+  // Format: YYYY-MM-DDTHH:MM:SS+01:00
+  const dd = String(dag).padStart(2, '0')
+  const mm = String(mnd).padStart(2, '0')
+  return `${aar}-${mm}-${dd}T12:34:56+01:00`
+}
+
+function sql(s) {
+  if (s == null) return 'null'
+  return "'" + String(s).replace(/'/g, "''") + "'"
+}
+
+function sqlText(s) {
+  if (s == null) return 'null'
+  return "'" + String(s).replace(/'/g, "''") + "'"
+}
+
+// Grupper par på screenshot — én melding pr unik screenshot
+const grupper = new Map()
+for (const p of PAIRING.par) {
+  if (!grupper.has(p.screenshot_nr)) grupper.set(p.screenshot_nr, [])
+  grupper.get(p.screenshot_nr).push(p)
+}
+
+const linjer = []
+linjer.push('-- FB-bilde-import — generert av scripts/fb-bilder-generer-sql.mjs')
+linjer.push('-- Forutsetter:')
+linjer.push('--   1. Migrasjon 081_meldinger_fra_facebook.sql er kjørt')
+linjer.push('--   2. Bildene er lastet opp til R2 under "meldinger/"')
+linjer.push('--')
+linjer.push('-- Idempotent: bruker kilde_ekstern_id med ON CONFLICT DO NOTHING')
+linjer.push('')
+linjer.push('begin;')
+linjer.push('')
+
+let antallMeldinger = 0
+let antallBilder = 0
+let antallKommentarer = 0
+let advarsler = []
+
+for (const meta of [...METADATA].sort((a, b) => a.screenshot_nr - b.screenshot_nr)) {
+  const par = grupper.get(meta.screenshot_nr) ?? []
+  if (par.length === 0) continue
+
+  const profilMap = NAVN_MAPPING[meta.postet_av]
+  if (!profilMap?.profil_id) {
+    advarsler.push(`screenshot ${meta.screenshot_nr}: ukjent forfatter "${meta.postet_av}" — hopper over`)
+    continue
+  }
+
+  const opprettet = parseNorskDato(meta.postet_dato)
+  const kildeExternId = `facebook:bilde:ss${meta.screenshot_nr}`
+
+  // Sorter bilder på bilde_nr så rekkefølgen er deterministisk
+  const sortertePar = [...par].sort((a, b) => a.bilde_nr - b.bilde_nr)
+  const coverFilnavn = sortertePar[0].bilde
+  const coverUrl = `${R2_PUBLIC_URL}/meldinger/${coverFilnavn}`
+
+  linjer.push(`-- screenshot ${meta.screenshot_nr}: ${meta.postet_av}, ${meta.postet_dato} (${sortertePar.length} bilde${sortertePar.length>1?'r':''}, ${meta.kommentarer?.length ?? 0} kommentar${meta.kommentarer?.length===1?'':'er'})`)
+  linjer.push('with melding_insert as (')
+  linjer.push('  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (')
+  linjer.push(`    ${sql(profilMap.profil_id)},`)
+  linjer.push(`    ${sqlText(meta.beskrivelse)},`)
+  linjer.push(`    ${sql(coverUrl)},`)
+  linjer.push(`    ${sql(opprettet)},`)
+  linjer.push(`    ${sql(opprettet)},  -- sist_aktivitet = postdato (sortering)`)
+  linjer.push('    true,')
+  linjer.push(`    ${sql(kildeExternId)}`)
+  linjer.push('  )')
+  linjer.push('  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing')
+  linjer.push('  returning id')
+  linjer.push('),')
+  linjer.push('melding_id_cte as (')
+  linjer.push('  select id from melding_insert')
+  linjer.push('  union all')
+  linjer.push(`  select id from meldinger where kilde_ekstern_id = ${sql(kildeExternId)} and not exists (select 1 from melding_insert)`)
+  linjer.push(')')
+
+  antallMeldinger++
+
+  // Tilleggsbilder (rekkefoelge 1+) — kun hvis flere enn ett bilde
+  if (sortertePar.length > 1) {
+    const ekstraInserts = sortertePar.slice(1).map((p, i) => {
+      const url = `${R2_PUBLIC_URL}/meldinger/${p.bilde}`
+      return `  ((select id from melding_id_cte), ${sql(url)}, ${i + 1}, ${sql(opprettet)})`
+    }).join(',\n')
+    // ingen unique constraint på melding_bilder — vi unngår dupliseringer ved
+    // at hele transaksjonen bare opprettes en gang (meldingens kilde_ekstern_id
+    // forhindrer dobbel insert), og ekstrabildene henger på den nye meldingen.
+    linjer.push('insert into melding_bilder (melding_id, bilde_url, rekkefoelge, opprettet) values')
+    linjer.push(ekstraInserts + ';')
+    antallBilder += sortertePar.length - 1
+  } else {
+    linjer.push('select 1;')  // dummy så CTE ikke skal være "unused"
+  }
+
+  // Kommentarer
+  for (const [idx, k] of (meta.kommentarer ?? []).entries()) {
+    const kProfilMap = NAVN_MAPPING[k.navn]
+    if (!kProfilMap?.profil_id) {
+      advarsler.push(`screenshot ${meta.screenshot_nr} kommentar ${idx}: ukjent forfatter "${k.navn}" — hopper over kommentar`)
+      continue
+    }
+    if (k.har_bilde) {
+      // Vi har droppet bildevedlegg per Reidars beslutning, men noterer i tekst
+      const tekst = `[bildevedlegg fra Facebook] ${k.tekst.replace(/^\[bildevedlegg.*?\]\s*/i, '')}`.trim()
+      linjer.push(`insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values`)
+      linjer.push(`  ((select id from meldinger where kilde_ekstern_id = ${sql(kildeExternId)}), ${sql(kProfilMap.profil_id)}, ${sqlText(tekst)}, ${sql(opprettet)}, true, ${sql(kildeExternId + ':c' + idx)})`)
+      linjer.push(`on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;`)
+    } else {
+      linjer.push(`insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values`)
+      linjer.push(`  ((select id from meldinger where kilde_ekstern_id = ${sql(kildeExternId)}), ${sql(kProfilMap.profil_id)}, ${sqlText(k.tekst)}, ${sql(opprettet)}, true, ${sql(kildeExternId + ':c' + idx)})`)
+      linjer.push(`on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;`)
+    }
+    antallKommentarer++
+  }
+
+  linjer.push('')
+}
+
+// Etter alle inserts: re-set sist_aktivitet til postdato på alle FB-meldinger,
+// fordi insert-trigger har bumpet det til now() når kommentarer ble lagt til.
+linjer.push('-- Reset sist_aktivitet til opprettet for alle FB-meldinger')
+linjer.push('-- (triggeren oppdater_melding_sist_aktivitet bumper sist_aktivitet ved')
+linjer.push('--  hver kommentar-insert, men for historikk vil vi ha postdato)')
+linjer.push('update meldinger set sist_aktivitet = opprettet where fra_facebook = true;')
+linjer.push('')
+linjer.push('commit;')
+linjer.push('')
+linjer.push('-- Verifisering:')
+linjer.push("-- select count(*) from meldinger where fra_facebook = true;")
+linjer.push("-- select count(*) from melding_bilder mb join meldinger m on m.id = mb.melding_id where m.fra_facebook = true;")
+linjer.push("-- select count(*) from melding_chat where fra_facebook = true;")
+
+writeFileSync('scripts/fb-bilder-import.sql', linjer.join('\n'), 'utf8')
+
+console.log(`✓ ${antallMeldinger} meldinger, ${antallBilder} tilleggsbilder, ${antallKommentarer} kommentarer`)
+console.log(`✓ scripts/fb-bilder-import.sql skrevet`)
+
+if (advarsler.length) {
+  console.log(`\n⚠ ${advarsler.length} advarsler:`)
+  for (const a of advarsler) console.log('  ' + a)
+}

--- a/scripts/fb-bilder-import.sql
+++ b/scripts/fb-bilder-import.sql
@@ -1,0 +1,1767 @@
+-- FB-bilde-import — generert av scripts/fb-bilder-generer-sql.mjs
+-- Forutsetter:
+--   1. Migrasjon 081_meldinger_fra_facebook.sql er kjørt
+--   2. Bildene er lastet opp til R2 under "meldinger/"
+--
+-- Idempotent: bruker kilde_ekstern_id med ON CONFLICT DO NOTHING
+
+begin;
+
+-- screenshot 1: Michael Johansen, 31. mai 2022 (1 bilde, 2 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '82093eaa-0a43-4191-b483-669569745b33',
+    'Jon Erik Dahl og jeg skal på Rammstein konserten på Bjerke den 24.7 så om det er noen av dere andre som ikke har billetter men har veldig lyst så kan kanskje lillebroren til Reidar Haavik hjelpe til 🍺 da får dere med dere konserten og kan servere øl til Jon Erik og meg . Vinn vinn 🙂',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/513936824_10171634064405317_8149852453545435986_n.jpg',
+    '2022-05-31T12:34:56+01:00',
+    '2022-05-31T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss1'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss1' and not exists (select 1 from melding_insert)
+)
+select 1;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss1'), 'ad597350-53e3-47aa-95a5-d207f383ef39', 'Abelist jobbannonse ass', '2022-05-31T12:34:56+01:00', true, 'facebook:bilde:ss1:c0')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss1'), '4accc876-7906-4a48-b73c-a88d0f6d114b', '200per time.. kan fort dra inn tusen spenn da... 💼', '2022-05-31T12:34:56+01:00', true, 'facebook:bilde:ss1:c1')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+
+-- screenshot 2: Jon Erik Dahl, 2. april 2016 (1 bilde, 1 kommentar)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '6673601b-c7f4-4c09-929a-3dfaa4d6fdc6',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/470583759_10170510363820626_6868328802286053130_n.jpg',
+    '2016-04-02T12:34:56+01:00',
+    '2016-04-02T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss2'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss2' and not exists (select 1 from melding_insert)
+)
+select 1;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss2'), '6673601b-c7f4-4c09-929a-3dfaa4d6fdc6', 'syntes vi trengte et gruppe bilde 😜', '2016-04-02T12:34:56+01:00', true, 'facebook:bilde:ss2:c0')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+
+-- screenshot 3: André Heede, 29. juni 2021 (1 bilde, 8 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'f3d71e5a-367a-461e-ba13-a6c4de144e32',
+    'Da ble kåken solgt',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/207616084_10165715082540226_1267054822432793292_n.jpg',
+    '2021-06-29T12:34:56+01:00',
+    '2021-06-29T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss3'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss3' and not exists (select 1 from melding_insert)
+)
+select 1;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss3'), '4accc876-7906-4a48-b73c-a88d0f6d114b', 'Konge! Grattis', '2021-06-29T12:34:56+01:00', true, 'facebook:bilde:ss3:c0')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss3'), '76801c77-b2db-41cd-ba30-6f55d10729ba', 'Grattis 🥂🍾', '2021-06-29T12:34:56+01:00', true, 'facebook:bilde:ss3:c1')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss3'), 'f3d71e5a-367a-461e-ba13-a6c4de144e32', 'Ble 360" over takst. Greit det i dagens marked', '2021-06-29T12:34:56+01:00', true, 'facebook:bilde:ss3:c2')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss3'), 'b2398344-4259-460c-a1b0-53d8a44643b3', 'Gratulerer', '2021-06-29T12:34:56+01:00', true, 'facebook:bilde:ss3:c3')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss3'), 'ad597350-53e3-47aa-95a5-d207f383ef39', 'Godt over takst da ell?', '2021-06-29T12:34:56+01:00', true, 'facebook:bilde:ss3:c4')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss3'), 'ad597350-53e3-47aa-95a5-d207f383ef39', 'Herlich! Gratulerer:)', '2021-06-29T12:34:56+01:00', true, 'facebook:bilde:ss3:c5')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss3'), 'f3d71e5a-367a-461e-ba13-a6c4de144e32', 'Jepp😊 satte rekord på Brattlikollen så da er man happy', '2021-06-29T12:34:56+01:00', true, 'facebook:bilde:ss3:c6')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss3'), '8bf2a096-1807-417f-8fe0-c33ec99d7178', 'Gratulerer! Fornøyd ?', '2021-06-29T12:34:56+01:00', true, 'facebook:bilde:ss3:c7')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+
+-- screenshot 4: Michael Johansen, 11. februar 2020 (1 bilde, 1 kommentar)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '82093eaa-0a43-4191-b483-669569745b33',
+    'Hva skjer a Reidar Haavik?',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/472995892_10170480587275317_8169909547483092892_n.jpg',
+    '2020-02-11T12:34:56+01:00',
+    '2020-02-11T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss4'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss4' and not exists (select 1 from melding_insert)
+)
+select 1;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss4'), 'ad597350-53e3-47aa-95a5-d207f383ef39', 'Og stikker av med penga!', '2020-02-11T12:34:56+01:00', true, 'facebook:bilde:ss4:c0')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+
+-- screenshot 5: Kenneth Lunde, 21. desember 2019 (1 bilde, 1 kommentar)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '97f2a53f-a386-45d0-b53e-bde46a995767',
+    'God jul ʼa boys',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/472833938_10170714749640096_7825765805359401361_n.jpg',
+    '2019-12-21T12:34:56+01:00',
+    '2019-12-21T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss5'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss5' and not exists (select 1 from melding_insert)
+)
+select 1;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss5'), '4409273c-47f3-49e9-89be-9a7018ebac5c', 'God jul 😂🤤❤️', '2019-12-21T12:34:56+01:00', true, 'facebook:bilde:ss5:c0')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+
+-- screenshot 6: Jon Erik Dahl, 22. oktober 2019 (1 bilde, 2 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '6673601b-c7f4-4c09-929a-3dfaa4d6fdc6',
+    'Når ble det greit med reklame for Adolf Hitler bilder på facebook',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/75392732_10162535023635626_4447293589667446784_n.jpg',
+    '2019-10-22T12:34:56+01:00',
+    '2019-10-22T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss6'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss6' and not exists (select 1 from melding_insert)
+)
+select 1;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss6'), 'ad597350-53e3-47aa-95a5-d207f383ef39', 'Greit for meg', '2019-10-22T12:34:56+01:00', true, 'facebook:bilde:ss6:c0')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss6'), '6673601b-c7f4-4c09-929a-3dfaa4d6fdc6', 'Morsomme var, at reklamen kom etter en kveld, hvor jeg dyp dykket inn i en del norske nettsider på ytre høyre siden av politikken', '2019-10-22T12:34:56+01:00', true, 'facebook:bilde:ss6:c1')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+
+-- screenshot 7: Øyvind Verket, 25. august 2018 (1 bilde, 3 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '4accc876-7906-4a48-b73c-a88d0f6d114b',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/40133598_10160786366215113_239708481341358080_n.jpg',
+    '2018-08-25T12:34:56+01:00',
+    '2018-08-25T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss7'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss7' and not exists (select 1 from melding_insert)
+)
+select 1;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss7'), '8bf2a096-1807-417f-8fe0-c33ec99d7178', 'For å klare å se dette så må du leite etter pikk, Øyvind Verket du leiter etter pikk! Hehe 😂', '2018-08-25T12:34:56+01:00', true, 'facebook:bilde:ss7:c0')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss7'), 'b2398344-4259-460c-a1b0-53d8a44643b3', '[bildevedlegg fra Facebook]', '2018-08-25T12:34:56+01:00', true, 'facebook:bilde:ss7:c1')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss7'), '6673601b-c7f4-4c09-929a-3dfaa4d6fdc6', 'Benco har en katolsk prest på badet', '2018-08-25T12:34:56+01:00', true, 'facebook:bilde:ss7:c2')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+
+-- screenshot 8: Jon Erik Dahl, 15. mai 2018 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '6673601b-c7f4-4c09-929a-3dfaa4d6fdc6',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/472170357_10170738984755626_2351219374440861825_n.jpg',
+    '2018-05-15T12:34:56+01:00',
+    '2018-05-15T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss8'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss8' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 9: Øyvind Rekve, 12. april 2018 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '76801c77-b2db-41cd-ba30-6f55d10729ba',
+    'Dette er i kveld... too be young again 🤘',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/469614292_10169801486285696_1735001105317423278_n.jpg',
+    '2018-04-12T12:34:56+01:00',
+    '2018-04-12T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss9'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss9' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 10: Espen Sørum Hagen, 9. desember 2017 (3 bilder, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '4409273c-47f3-49e9-89be-9a7018ebac5c',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468841672_10170003415665464_4444310879893950981_n.jpg',
+    '2017-12-09T12:34:56+01:00',
+    '2017-12-09T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss10'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss10' and not exists (select 1 from melding_insert)
+)
+insert into melding_bilder (melding_id, bilde_url, rekkefoelge, opprettet) values
+  ((select id from melding_id_cte), 'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/472027737_10170527134715464_7921074026912311111_n.jpg', 1, '2017-12-09T12:34:56+01:00'),
+  ((select id from melding_id_cte), 'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468741380_10170003415625464_4945086347616410337_n.jpg', 2, '2017-12-09T12:34:56+01:00');
+
+-- screenshot 11: Øyvind Verket, 10. november 2017 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '4accc876-7906-4a48-b73c-a88d0f6d114b',
+    'Mener at voldtekt ikke er ekte, med mindre man kan bevise at kvinnen ikke mot-jokker.',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468665243_10169825823750113_5067670262409442372_n.jpg',
+    '2017-11-10T12:34:56+01:00',
+    '2017-11-10T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss11'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss11' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 12: Reidar Haavik, 10. november 2017 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'ad597350-53e3-47aa-95a5-d207f383ef39',
+    'Vedder pungen sin mot Verkern, ca 10kr mener han.',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468964054_10169845255245370_1708449074339552897_n.jpg',
+    '2017-11-10T12:34:56+01:00',
+    '2017-11-10T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss12'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss12' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 14: Reidar Haavik, 10. november 2017 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'ad597350-53e3-47aa-95a5-d207f383ef39',
+    'Vedder en pils på at elbiler om tre år ikke lenger har særbehandling i Oslos bomringer',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468963745_10169845254575370_6869727369567777523_n.jpg',
+    '2017-11-10T12:34:56+01:00',
+    '2017-11-10T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss14'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss14' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 15: Espen Waldem, 24. juni 2017 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'b2398344-4259-460c-a1b0-53d8a44643b3',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468526434_10161817010036368_8282172887727775070_n.jpg',
+    '2017-06-24T12:34:56+01:00',
+    '2017-06-24T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss15'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss15' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 16: Espen Waldem, 24. juni 2017 (3 bilder, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'b2398344-4259-460c-a1b0-53d8a44643b3',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468568689_10161817008696368_8839644318772214941_n.jpg',
+    '2017-06-24T12:34:56+01:00',
+    '2017-06-24T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss16'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss16' and not exists (select 1 from melding_insert)
+)
+insert into melding_bilder (melding_id, bilde_url, rekkefoelge, opprettet) values
+  ((select id from melding_id_cte), 'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468496612_10161817008691368_2383094503811365159_n.jpg', 1, '2017-06-24T12:34:56+01:00'),
+  ((select id from melding_id_cte), 'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468459837_10161817008656368_7271076194809599240_n.jpg', 2, '2017-06-24T12:34:56+01:00');
+
+-- screenshot 17: Øyvind Rekve, 28. mars 2017 (1 bilde, 1 kommentar)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '76801c77-b2db-41cd-ba30-6f55d10729ba',
+    'Neste år for Herreklubben?',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/473019028_10170293689990696_8627677788363977487_n.jpg',
+    '2017-03-28T12:34:56+01:00',
+    '2017-03-28T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss17'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss17' and not exists (select 1 from melding_insert)
+)
+select 1;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss17'), '76801c77-b2db-41cd-ba30-6f55d10729ba', 'Ingen som er hypp?', '2017-03-28T12:34:56+01:00', true, 'facebook:bilde:ss17:c0')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+
+-- screenshot 18: Øyvind Rekve, 20. februar 2017 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '76801c77-b2db-41cd-ba30-6f55d10729ba',
+    'Dette bildet gjør meg glad 😘',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/470207513_10169851916900696_3070902161453074898_n.jpg',
+    '2017-02-20T12:34:56+01:00',
+    '2017-02-20T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss18'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss18' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 19: Jon Erik Dahl, 9. februar 2017 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '6673601b-c7f4-4c09-929a-3dfaa4d6fdc6',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/472327830_10170716182060626_7975648651640544702_n.jpg',
+    '2017-02-09T12:34:56+01:00',
+    '2017-02-09T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss19'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss19' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 20: Øyvind Rekve, 7. februar 2017 (1 bilde, 1 kommentar)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '76801c77-b2db-41cd-ba30-6f55d10729ba',
+    'Dukka opp på fjesboka i dag... Vi ser helt like ut jo...',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/472848654_10170272300575696_8956102802779641044_n.jpg',
+    '2017-02-07T12:34:56+01:00',
+    '2017-02-07T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss20'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss20' and not exists (select 1 from melding_insert)
+)
+select 1;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss20'), 'f3d71e5a-367a-461e-ba13-a6c4de144e32', '😂', '2017-02-07T12:34:56+01:00', true, 'facebook:bilde:ss20:c0')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+
+-- screenshot 21: André Heede, 30. september 2016 (1 bilde, 2 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'f3d71e5a-367a-461e-ba13-a6c4de144e32',
+    'Guten morgen🍻 Svogerns favoritt til frokost',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468399174_10170275252275226_7190338394014570128_n.jpg',
+    '2016-09-30T12:34:56+01:00',
+    '2016-09-30T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss21'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss21' and not exists (select 1 from melding_insert)
+)
+select 1;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss21'), 'f3d71e5a-367a-461e-ba13-a6c4de144e32', 'Har det på video. Blir spilt av på storskjermen på Armbrustschützenzelt', '2016-09-30T12:34:56+01:00', true, 'facebook:bilde:ss21:c0')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss21'), '82093eaa-0a43-4191-b483-669569745b33', 'hvor er gæg beviset André Heede?', '2016-09-30T12:34:56+01:00', true, 'facebook:bilde:ss21:c1')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+
+-- screenshot 22: André Heede, 29. september 2016 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'f3d71e5a-367a-461e-ba13-a6c4de144e32',
+    'Skål a gutta',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468284967_10170274620315226_7717431427819465511_n.jpg',
+    '2016-09-29T12:34:56+01:00',
+    '2016-09-29T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss22'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss22' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 23: André Heede, 29. september 2016 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'f3d71e5a-367a-461e-ba13-a6c4de144e32',
+    'Nachspielteltet lever ennå',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468205228_10170274616800226_5387154595722121418_n.jpg',
+    '2016-09-29T12:34:56+01:00',
+    '2016-09-29T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss23'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss23' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 24: Jon Erik Dahl, 24. september 2016 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '6673601b-c7f4-4c09-929a-3dfaa4d6fdc6',
+    'Labert oppmøte',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468546912_10170023961465626_1974895974601579098_n.jpg',
+    '2016-09-24T12:34:56+01:00',
+    '2016-09-24T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss24'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss24' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 25: Jon Erik Dahl, 21. juli 2016 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '6673601b-c7f4-4c09-929a-3dfaa4d6fdc6',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468042786_10169904888265626_7424129223818364482_n.jpg',
+    '2016-07-21T12:34:56+01:00',
+    '2016-07-21T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss25'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss25' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 26: Jon Erik Dahl, 7. mars 2016 (1 bilde, 3 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '6673601b-c7f4-4c09-929a-3dfaa4d6fdc6',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/473657432_10170911564250626_3357151237299040991_n.jpg',
+    '2016-03-07T12:34:56+01:00',
+    '2016-03-07T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss26'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss26' and not exists (select 1 from melding_insert)
+)
+select 1;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss26'), '76801c77-b2db-41cd-ba30-6f55d10729ba', 'Utafor Jon', '2016-03-07T12:34:56+01:00', true, 'facebook:bilde:ss26:c0')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss26'), '6673601b-c7f4-4c09-929a-3dfaa4d6fdc6', 'Utafor humor er også humor 😜', '2016-03-07T12:34:56+01:00', true, 'facebook:bilde:ss26:c1')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss26'), '82093eaa-0a43-4191-b483-669569745b33', 'Har dette skjedd deg Jon Erik Dahl ? i så fall syntes jeg dette er moro 😀 og at du har litt nasty tendenser.', '2016-03-07T12:34:56+01:00', true, 'facebook:bilde:ss26:c2')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+
+-- screenshot 27: Reidar Haavik, 14. mars 2015 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'ad597350-53e3-47aa-95a5-d207f383ef39',
+    'Vi er samme sted som i fjor!',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468597536_10169840290925370_5685652838756870002_n.jpg',
+    '2015-03-14T12:34:56+01:00',
+    '2015-03-14T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss27'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss27' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 28: Michael Johansen, 28. mai 2014 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '82093eaa-0a43-4191-b483-669569745b33',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/472989729_10170549701280317_1398779810565515323_n.jpg',
+    '2014-05-28T12:34:56+01:00',
+    '2014-05-28T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss28'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss28' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 29: Klas Kristoffer Liland, 4. april 2014 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '4093f488-8c3c-4daf-a743-c087c74adc6d',
+    'God helg !',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/470204415_10170130107390297_9200493019667618799_n.jpg',
+    '2014-04-04T12:34:56+01:00',
+    '2014-04-04T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss29'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss29' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 30: Klas Kristoffer Liland, 10. mars 2014 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '4093f488-8c3c-4daf-a743-c087c74adc6d',
+    'Lunch Reka',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/470214464_10170106745765297_6900551415671284136_n.jpg',
+    '2014-03-10T12:34:56+01:00',
+    '2014-03-10T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss30'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss30' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 31: Michael Johansen, 21. februar 2014 (1 bilde, 2 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '82093eaa-0a43-4191-b483-669569745b33',
+    'Får satse på at du får i deg litt av denne Kristoffer Benco Arntzen, så du orker å være med 8 Mars da 🙂',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/472744758_10170498287515317_7373605628117300606_n.jpg',
+    '2014-02-21T12:34:56+01:00',
+    '2014-02-21T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss31'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss31' and not exists (select 1 from melding_insert)
+)
+select 1;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss31'), '8bf2a096-1807-417f-8fe0-c33ec99d7178', 'Hehe, den må jeg prøve!', '2014-02-21T12:34:56+01:00', true, 'facebook:bilde:ss31:c0')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss31'), '76801c77-b2db-41cd-ba30-6f55d10729ba', 'Hehe dauer', '2014-02-21T12:34:56+01:00', true, 'facebook:bilde:ss31:c1')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+
+-- screenshot 32: Klas Kristoffer Liland, 21. februar 2014 (1 bilde, 3 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '4093f488-8c3c-4daf-a743-c087c74adc6d',
+    'Spiller du fotball MJ ?',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/473165819_10170504444200297_2545909050171481490_n.jpg',
+    '2014-02-21T12:34:56+01:00',
+    '2014-02-21T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss32'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss32' and not exists (select 1 from melding_insert)
+)
+select 1;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss32'), '82093eaa-0a43-4191-b483-669569745b33', 'HAHAHA, Benco har tatt navnet mitt', '2014-02-21T12:34:56+01:00', true, 'facebook:bilde:ss32:c0')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss32'), '8bf2a096-1807-417f-8fe0-c33ec99d7178', 'Skal jeg bli dratt inn i leken deres å nå da!! 🙂', '2014-02-21T12:34:56+01:00', true, 'facebook:bilde:ss32:c1')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss32'), '82093eaa-0a43-4191-b483-669569745b33', 'Noe må man jo gjøre, for å få deg ut av kjelleren på Hellerud 🙂', '2014-02-21T12:34:56+01:00', true, 'facebook:bilde:ss32:c2')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+
+-- screenshot 33: Michael Johansen, 20. februar 2014 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '82093eaa-0a43-4191-b483-669569745b33',
+    'Ser du har jugoslaviske bonde aner også. Klas Puder 🙂',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/472913576_10170497559555317_582184138924698425_n.jpg',
+    '2014-02-20T12:34:56+01:00',
+    '2014-02-20T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss33'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss33' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 34: Michael Johansen, 20. februar 2014 (1 bilde, 1 kommentar)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '82093eaa-0a43-4191-b483-669569745b33',
+    'Visste ikke at du var så musikalsk Klas Kristoffer Liland',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/472876311_10170497623190317_6387856711755553460_n.jpg',
+    '2014-02-20T12:34:56+01:00',
+    '2014-02-20T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss34'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss34' and not exists (select 1 from melding_insert)
+)
+select 1;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss34'), '4093f488-8c3c-4daf-a743-c087c74adc6d', 'Var ikke klar over det selv 🙂', '2014-02-20T12:34:56+01:00', true, 'facebook:bilde:ss34:c0')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+
+-- screenshot 35: Klas Kristoffer Liland, 20. februar 2014 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '4093f488-8c3c-4daf-a743-c087c74adc6d',
+    'Lunch (reka)',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/469811742_10170082468525297_4498419575386491419_n.jpg',
+    '2014-02-20T12:34:56+01:00',
+    '2014-02-20T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss35'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss35' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 36: Øyvind Verket, 8. oktober 2013 (1 bilde, 1 kommentar)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '4accc876-7906-4a48-b73c-a88d0f6d114b',
+    'Deilig hjemme og..',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/472098467_10170439595315113_7842281758487874526_n.jpg',
+    '2013-10-08T12:34:56+01:00',
+    '2013-10-08T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss36'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss36' and not exists (select 1 from melding_insert)
+)
+select 1;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss36'), 'f3d71e5a-367a-461e-ba13-a6c4de144e32', 'Ser du på menn som tar sv seg buksene?', '2013-10-08T12:34:56+01:00', true, 'facebook:bilde:ss36:c0')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+
+-- screenshot 37: André Heede, 8. oktober 2013 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'f3d71e5a-367a-461e-ba13-a6c4de144e32',
+    'Savner München, eisbein&würst og mas. Detta er crap!!',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468311580_10170275955440226_7492536933205911086_n.jpg',
+    '2013-10-08T12:34:56+01:00',
+    '2013-10-08T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss37'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss37' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 38: Reidar Haavik, 8. oktober 2013 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'ad597350-53e3-47aa-95a5-d207f383ef39',
+    'Savner Munich ass, dette er crap.. — her: DNB-huset i Bjørvika.',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/469156381_10169951257645370_2240540405814531238_n.jpg',
+    '2013-10-08T12:34:56+01:00',
+    '2013-10-08T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss38'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss38' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 39: Klas Kristoffer Liland, 2. desember 2012 (1 bilde, 3 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '4093f488-8c3c-4daf-a743-c087c74adc6d',
+    'Frokost 🙂',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/474037233_10170580987495297_7964515424150398530_n.jpg',
+    '2012-12-02T12:34:56+01:00',
+    '2012-12-02T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss39'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss39' and not exists (select 1 from melding_insert)
+)
+select 1;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss39'), '8bf2a096-1807-417f-8fe0-c33ec99d7178', 'Det oser testosteron av den der frokosten!', '2012-12-02T12:34:56+01:00', true, 'facebook:bilde:ss39:c0')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss39'), '8f64ed4a-d907-424f-82ae-d6220c7fb02c', 'Sweet!', '2012-12-02T12:34:56+01:00', true, 'facebook:bilde:ss39:c1')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss39'), '4409273c-47f3-49e9-89be-9a7018ebac5c', 'med tyttebærsyltetøy 🙂', '2012-12-02T12:34:56+01:00', true, 'facebook:bilde:ss39:c2')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+
+-- screenshot 40: Espen Waldem, 19. desember 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'b2398344-4259-460c-a1b0-53d8a44643b3',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/518658037_10162919427611368_3847170441472136023_n.jpg',
+    '2010-12-19T12:34:56+01:00',
+    '2010-12-19T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss40'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss40' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 41: Espen Waldem, 19. desember 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'b2398344-4259-460c-a1b0-53d8a44643b3',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/520476255_10162919427886368_8804124244684399291_n.jpg',
+    '2010-12-19T12:34:56+01:00',
+    '2010-12-19T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss41'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss41' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 42: Espen Waldem, 19. desember 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'b2398344-4259-460c-a1b0-53d8a44643b3',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/519395762_10162919427986368_2365358503468583542_n.jpg',
+    '2010-12-19T12:34:56+01:00',
+    '2010-12-19T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss42'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss42' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 43: Espen Waldem, 19. desember 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'b2398344-4259-460c-a1b0-53d8a44643b3',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/518314111_10162919428076368_2472337784645710054_n.jpg',
+    '2010-12-19T12:34:56+01:00',
+    '2010-12-19T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss43'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss43' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 44: Espen Waldem, 19. desember 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'b2398344-4259-460c-a1b0-53d8a44643b3',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/518314818_10162919427936368_8239745519008611795_n.jpg',
+    '2010-12-19T12:34:56+01:00',
+    '2010-12-19T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss44'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss44' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 45: Espen Waldem, 19. desember 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'b2398344-4259-460c-a1b0-53d8a44643b3',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/518435350_10162919427616368_5558791084309264020_n.jpg',
+    '2010-12-19T12:34:56+01:00',
+    '2010-12-19T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss45'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss45' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 46: Espen Waldem, 19. desember 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'b2398344-4259-460c-a1b0-53d8a44643b3',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/519004626_10162919427606368_216200332465866816_n.jpg',
+    '2010-12-19T12:34:56+01:00',
+    '2010-12-19T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss46'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss46' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 47: Espen Waldem, 13. desember 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'b2398344-4259-460c-a1b0-53d8a44643b3',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/518320949_10162918875406368_5800396639740064618_n.jpg',
+    '2010-12-13T12:34:56+01:00',
+    '2010-12-13T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss47'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss47' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 48: Espen Waldem, 13. desember 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'b2398344-4259-460c-a1b0-53d8a44643b3',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/520836923_10162918874856368_485771287725791650_n.jpg',
+    '2010-12-13T12:34:56+01:00',
+    '2010-12-13T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss48'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss48' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 49: Espen Waldem, 13. desember 2010 (1 bilde, 1 kommentar)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'b2398344-4259-460c-a1b0-53d8a44643b3',
+    'rybak was here',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/519723443_10162918875146368_935026746537238667_n.jpg',
+    '2010-12-13T12:34:56+01:00',
+    '2010-12-13T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss49'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss49' and not exists (select 1 from melding_insert)
+)
+select 1;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss49'), '4accc876-7906-4a48-b73c-a88d0f6d114b', 'han er ikke den eneste..', '2010-12-13T12:34:56+01:00', true, 'facebook:bilde:ss49:c0')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+
+-- screenshot 50: Espen Waldem, 13. desember 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'b2398344-4259-460c-a1b0-53d8a44643b3',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/518578916_10162918875371368_821995706893352632_n.jpg',
+    '2010-12-13T12:34:56+01:00',
+    '2010-12-13T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss50'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss50' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 51: Espen Waldem, 13. desember 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'b2398344-4259-460c-a1b0-53d8a44643b3',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/518147005_10162918875061368_1477369775922750608_n.jpg',
+    '2010-12-13T12:34:56+01:00',
+    '2010-12-13T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss51'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss51' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 52: Espen Waldem, 13. desember 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'b2398344-4259-460c-a1b0-53d8a44643b3',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/518313093_10162918875456368_1348643235867528697_n.jpg',
+    '2010-12-13T12:34:56+01:00',
+    '2010-12-13T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss52'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss52' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 53: Espen Waldem, 13. desember 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'b2398344-4259-460c-a1b0-53d8a44643b3',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/518803319_10162918875046368_350116659518989438_n.jpg',
+    '2010-12-13T12:34:56+01:00',
+    '2010-12-13T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss53'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss53' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 54: Espen Waldem, 13. desember 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'b2398344-4259-460c-a1b0-53d8a44643b3',
+    'one happy family',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/518582873_10162918875026368_610420821859682360_n.jpg',
+    '2010-12-13T12:34:56+01:00',
+    '2010-12-13T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss54'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss54' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 55: Espen Waldem, 13. desember 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'b2398344-4259-460c-a1b0-53d8a44643b3',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/518591262_10162918875286368_156734218321498286_n.jpg',
+    '2010-12-13T12:34:56+01:00',
+    '2010-12-13T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss55'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss55' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 56: Espen Waldem, 13. desember 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    'b2398344-4259-460c-a1b0-53d8a44643b3',
+    'riga in my pocket',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/520228537_10162918875471368_8693685300745149099_n.jpg',
+    '2010-12-13T12:34:56+01:00',
+    '2010-12-13T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss56'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss56' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 57: Espen Sørum Hagen, 7. oktober 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '4409273c-47f3-49e9-89be-9a7018ebac5c',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/472179447_10170550551290464_20389259500477410_n.jpg',
+    '2010-10-07T12:34:56+01:00',
+    '2010-10-07T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss57'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss57' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 58: Espen Sørum Hagen, 7. oktober 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '4409273c-47f3-49e9-89be-9a7018ebac5c',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/472119935_10170550547600464_736685527438663604_n.jpg',
+    '2010-10-07T12:34:56+01:00',
+    '2010-10-07T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss58'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss58' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 59: Espen Sørum Hagen, 7. oktober 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '4409273c-47f3-49e9-89be-9a7018ebac5c',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468856451_10170055900330464_436059343400849049_n.jpg',
+    '2010-10-07T12:34:56+01:00',
+    '2010-10-07T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss59'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss59' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 60: Espen Sørum Hagen, 7. oktober 2010 (1 bilde, 1 kommentar)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '4409273c-47f3-49e9-89be-9a7018ebac5c',
+    '— sammen med Øyvind Rekve.',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/472224837_10170550519000464_595659400939509453_n.jpg',
+    '2010-10-07T12:34:56+01:00',
+    '2010-10-07T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss60'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss60' and not exists (select 1 from melding_insert)
+)
+select 1;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss60'), 'f3d71e5a-367a-461e-ba13-a6c4de144e32', 'kjekke gutter ❤️', '2010-10-07T12:34:56+01:00', true, 'facebook:bilde:ss60:c0')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+
+-- screenshot 61: Espen Sørum Hagen, 7. oktober 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '4409273c-47f3-49e9-89be-9a7018ebac5c',
+    null,
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/472104457_10170550549540464_7228763410115619249_n.jpg',
+    '2010-10-07T12:34:56+01:00',
+    '2010-10-07T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss61'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss61' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 62: Kenneth Lunde, 25. juni 2010 (1 bilde, 7 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '97f2a53f-a386-45d0-b53e-bde46a995767',
+    'hehehe.. — med Jon Erik Dahl og 2 andre.',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468420539_10169944412665096_2192487242058145001_n.jpg',
+    '2010-06-25T12:34:56+01:00',
+    '2010-06-25T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss62'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss62' and not exists (select 1 from melding_insert)
+)
+select 1;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss62'), 'f3d71e5a-367a-461e-ba13-a6c4de144e32', 'hahaha genialt bilde', '2010-06-25T12:34:56+01:00', true, 'facebook:bilde:ss62:c0')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss62'), 'ae1834e3-2e82-4619-8372-76e2d04b65d4', 'dritbra', '2010-06-25T12:34:56+01:00', true, 'facebook:bilde:ss62:c1')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss62'), 'ad597350-53e3-47aa-95a5-d207f383ef39', 'OMG! WTF! LOL!', '2010-06-25T12:34:56+01:00', true, 'facebook:bilde:ss62:c2')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss62'), 'ad597350-53e3-47aa-95a5-d207f383ef39', 'sånn går dagene..', '2010-06-25T12:34:56+01:00', true, 'facebook:bilde:ss62:c3')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss62'), 'ad597350-53e3-47aa-95a5-d207f383ef39', 'hehe, jeg liker å se på dette bildet litt av og til, haha, det er kunst', '2010-06-25T12:34:56+01:00', true, 'facebook:bilde:ss62:c4')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss62'), 'f3d71e5a-367a-461e-ba13-a6c4de144e32', 'true 😊', '2010-06-25T12:34:56+01:00', true, 'facebook:bilde:ss62:c5')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss62'), '97f2a53f-a386-45d0-b53e-bde46a995767', 'Jeg ler enda!', '2010-06-25T12:34:56+01:00', true, 'facebook:bilde:ss62:c6')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+
+-- screenshot 63: Kenneth Lunde, 25. juni 2010 (1 bilde, 1 kommentar)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '97f2a53f-a386-45d0-b53e-bde46a995767',
+    'Helt om natta, helt om mårran!',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468443389_10169944412690096_3869888267080914533_n.jpg',
+    '2010-06-25T12:34:56+01:00',
+    '2010-06-25T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss63'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss63' and not exists (select 1 from melding_insert)
+)
+select 1;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss63'), '4accc876-7906-4a48-b73c-a88d0f6d114b', '"Shit ass. Jeg bææsja på meg!"', '2010-06-25T12:34:56+01:00', true, 'facebook:bilde:ss63:c0')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+
+-- screenshot 64: Kenneth Lunde, 25. juni 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '97f2a53f-a386-45d0-b53e-bde46a995767',
+    '"Vi er venner vi Chris?" — med Jon Erik Dahl og 2 andre.',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468623550_10169944412680096_7274017795925705100_n.jpg',
+    '2010-06-25T12:34:56+01:00',
+    '2010-06-25T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss64'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss64' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 65: Kenneth Lunde, 25. juni 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '97f2a53f-a386-45d0-b53e-bde46a995767',
+    'Major''n — sammen med André Heede.',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468357307_10169944412695096_1344239155219180584_n.jpg',
+    '2010-06-25T12:34:56+01:00',
+    '2010-06-25T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss65'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss65' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 66: Kenneth Lunde, 25. juni 2010 (1 bilde, 1 kommentar)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '97f2a53f-a386-45d0-b53e-bde46a995767',
+    '"Haaade daa Niiiiils" — sammen med Kristoffer Benco Arntzen.',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468222418_10169944412710096_3369296609782977880_n.jpg',
+    '2010-06-25T12:34:56+01:00',
+    '2010-06-25T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss66'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss66' and not exists (select 1 from melding_insert)
+)
+select 1;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss66'), 'f3d71e5a-367a-461e-ba13-a6c4de144e32', 'haade da Niiils', '2010-06-25T12:34:56+01:00', true, 'facebook:bilde:ss66:c0')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+
+-- screenshot 67: Kenneth Lunde, 25. juni 2010 (1 bilde, 1 kommentar)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '97f2a53f-a386-45d0-b53e-bde46a995767',
+    'Bilde taler for seg selv — sammen med Øyvind Rekve.',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468358468_10169944407490096_231703184139795518_n.jpg',
+    '2010-06-25T12:34:56+01:00',
+    '2010-06-25T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss67'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss67' and not exists (select 1 from melding_insert)
+)
+select 1;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss67'), 'ae1834e3-2e82-4619-8372-76e2d04b65d4', 'Waaaaale!', '2010-06-25T12:34:56+01:00', true, 'facebook:bilde:ss67:c0')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+
+-- screenshot 68: Kenneth Lunde, 25. juni 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '97f2a53f-a386-45d0-b53e-bde46a995767',
+    'en to tre hopp — med Øyvind Rekve og 2 andre.',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468357999_10169944407495096_5943155274355686811_n.jpg',
+    '2010-06-25T12:34:56+01:00',
+    '2010-06-25T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss68'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss68' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 69: Kenneth Lunde, 25. juni 2010 (1 bilde, 4 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '97f2a53f-a386-45d0-b53e-bde46a995767',
+    'STOP! Hammoc time.. — med Jon Erik Dahl og 4 andre.',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468391613_10169944407485096_8618045998776258624_n.jpg',
+    '2010-06-25T12:34:56+01:00',
+    '2010-06-25T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss69'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss69' and not exists (select 1 from melding_insert)
+)
+select 1;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss69'), 'f3d71e5a-367a-461e-ba13-a6c4de144e32', 'sjekk chris gir reidar en elbow a', '2010-06-25T12:34:56+01:00', true, 'facebook:bilde:ss69:c0')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss69'), 'ae1834e3-2e82-4619-8372-76e2d04b65d4', 'sjekk jonna klør waldem på..', '2010-06-25T12:34:56+01:00', true, 'facebook:bilde:ss69:c1')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss69'), 'f3d71e5a-367a-461e-ba13-a6c4de144e32', 'et sted som hjernen til Espen til å starte en enorm endorfinproduksjon iallefall', '2010-06-25T12:34:56+01:00', true, 'facebook:bilde:ss69:c2')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss69'), 'ae1834e3-2e82-4619-8372-76e2d04b65d4', 'oh yea!!', '2010-06-25T12:34:56+01:00', true, 'facebook:bilde:ss69:c3')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+
+-- screenshot 70: Kenneth Lunde, 25. juni 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '97f2a53f-a386-45d0-b53e-bde46a995767',
+    'Hova — med Øyvind Rekve og 2 andre.',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468388093_10169944407470096_1212063591183753932_n.jpg',
+    '2010-06-25T12:34:56+01:00',
+    '2010-06-25T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss70'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss70' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 71: Kenneth Lunde, 25. juni 2010 (1 bilde, 1 kommentar)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '97f2a53f-a386-45d0-b53e-bde46a995767',
+    '"Ikke vær redd lille venn, den er ikke større enn som så" — med André Heede og Chris Reitan.',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468358024_10169944407475096_1520356219861115183_n.jpg',
+    '2010-06-25T12:34:56+01:00',
+    '2010-06-25T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss71'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss71' and not exists (select 1 from melding_insert)
+)
+select 1;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss71'), 'ae1834e3-2e82-4619-8372-76e2d04b65d4', 'Du måkke være redd!', '2010-06-25T12:34:56+01:00', true, 'facebook:bilde:ss71:c0')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+
+-- screenshot 72: Kenneth Lunde, 25. juni 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '97f2a53f-a386-45d0-b53e-bde46a995767',
+    '"Do the Borat dance" — med Øyvind Rekve og Chris Reitan.',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468406279_10169944402200096_8662440642849756064_n.jpg',
+    '2010-06-25T12:34:56+01:00',
+    '2010-06-25T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss72'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss72' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 73: Kenneth Lunde, 25. juni 2010 (1 bilde, 4 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '97f2a53f-a386-45d0-b53e-bde46a995767',
+    '"Hva er det du har i bæggen ''a? Nødproviant, makrell i tomat??" — sammen med Chris Reitan.',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468399892_10169944402165096_277228747751722778_n.jpg',
+    '2010-06-25T12:34:56+01:00',
+    '2010-06-25T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss73'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss73' and not exists (select 1 from melding_insert)
+)
+select 1;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss73'), 'ae1834e3-2e82-4619-8372-76e2d04b65d4', 'slo ann den!', '2010-06-25T12:34:56+01:00', true, 'facebook:bilde:ss73:c0')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss73'), 'f3d71e5a-367a-461e-ba13-a6c4de144e32', 'ser ut som du har hånde på et spesielt sted du oxo', '2010-06-25T12:34:56+01:00', true, 'facebook:bilde:ss73:c1')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss73'), 'ae1834e3-2e82-4619-8372-76e2d04b65d4', 'Ooooh yea!! Bundy grepet!', '2010-06-25T12:34:56+01:00', true, 'facebook:bilde:ss73:c2')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+insert into melding_chat (melding_id, profil_id, innhold, opprettet, fra_facebook, kilde_ekstern_id) values
+  ((select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss73'), 'f3d71e5a-367a-461e-ba13-a6c4de144e32', 'de ler an Chris, de ler an', '2010-06-25T12:34:56+01:00', true, 'facebook:bilde:ss73:c3')
+on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing;
+
+-- screenshot 74: Kenneth Lunde, 25. juni 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '97f2a53f-a386-45d0-b53e-bde46a995767',
+    'HeDidIt — sammen med André Heede.',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468480465_10169944400875096_7231026925742004139_n.jpg',
+    '2010-06-25T12:34:56+01:00',
+    '2010-06-25T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss74'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss74' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 75: Kenneth Lunde, 25. juni 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '97f2a53f-a386-45d0-b53e-bde46a995767',
+    'OMG!! LOL, Lissom jesus du?! — sammen med Reidar Haavik.',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468358032_10169944400860096_2179309298273507387_n.jpg',
+    '2010-06-25T12:34:56+01:00',
+    '2010-06-25T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss75'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss75' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- screenshot 76: Kenneth Lunde, 25. juni 2010 (1 bilde, 0 kommentarer)
+with melding_insert as (
+  insert into meldinger (profil_id, innhold, bilde_url, opprettet, sist_aktivitet, fra_facebook, kilde_ekstern_id) values (
+    '97f2a53f-a386-45d0-b53e-bde46a995767',
+    'Åå løøh! DødseReka — sammen med Øyvind Rekve.',
+    'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468332682_10169944400870096_607451437907088496_n.jpg',
+    '2010-06-25T12:34:56+01:00',
+    '2010-06-25T12:34:56+01:00',  -- sist_aktivitet = postdato (sortering)
+    true,
+    'facebook:bilde:ss76'
+  )
+  on conflict (kilde_ekstern_id) where kilde_ekstern_id is not null do nothing
+  returning id
+),
+melding_id_cte as (
+  select id from melding_insert
+  union all
+  select id from meldinger where kilde_ekstern_id = 'facebook:bilde:ss76' and not exists (select 1 from melding_insert)
+)
+select 1;
+
+-- Reset sist_aktivitet til opprettet for alle FB-meldinger
+-- (triggeren oppdater_melding_sist_aktivitet bumper sist_aktivitet ved
+--  hver kommentar-insert, men for historikk vil vi ha postdato)
+update meldinger set sist_aktivitet = opprettet where fra_facebook = true;
+
+commit;
+
+-- Verifisering:
+-- select count(*) from meldinger where fra_facebook = true;
+-- select count(*) from melding_bilder mb join meldinger m on m.id = mb.melding_id where m.fra_facebook = true;
+-- select count(*) from melding_chat where fra_facebook = true;

--- a/scripts/fb-bilder-import.sql
+++ b/scripts/fb-bilder-import.sql
@@ -271,7 +271,8 @@ melding_id_cte as (
 )
 insert into melding_bilder (melding_id, bilde_url, rekkefoelge, opprettet) values
   ((select id from melding_id_cte), 'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/472027737_10170527134715464_7921074026912311111_n.jpg', 1, '2017-12-09T12:34:56+01:00'),
-  ((select id from melding_id_cte), 'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468741380_10170003415625464_4945086347616410337_n.jpg', 2, '2017-12-09T12:34:56+01:00');
+  ((select id from melding_id_cte), 'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468741380_10170003415625464_4945086347616410337_n.jpg', 2, '2017-12-09T12:34:56+01:00')
+on conflict (melding_id, rekkefoelge) do nothing;
 
 -- screenshot 11: Øyvind Verket, 10. november 2017 (1 bilde, 0 kommentarer)
 with melding_insert as (
@@ -378,7 +379,8 @@ melding_id_cte as (
 )
 insert into melding_bilder (melding_id, bilde_url, rekkefoelge, opprettet) values
   ((select id from melding_id_cte), 'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468496612_10161817008691368_2383094503811365159_n.jpg', 1, '2017-06-24T12:34:56+01:00'),
-  ((select id from melding_id_cte), 'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468459837_10161817008656368_7271076194809599240_n.jpg', 2, '2017-06-24T12:34:56+01:00');
+  ((select id from melding_id_cte), 'https://pub-31771477f82844bfb7ecc20cdb45a5ab.r2.dev/meldinger/468459837_10161817008656368_7271076194809599240_n.jpg', 2, '2017-06-24T12:34:56+01:00')
+on conflict (melding_id, rekkefoelge) do nothing;
 
 -- screenshot 17: Øyvind Rekve, 28. mars 2017 (1 bilde, 1 kommentar)
 with melding_insert as (

--- a/scripts/fb-bilder-juster.mjs
+++ b/scripts/fb-bilder-juster.mjs
@@ -1,0 +1,128 @@
+// Justerer fb-bilder-pairing.json basert på Reidars visuelle gjennomgang.
+//
+// Datamodell etter denne runden:
+//   par[]: én rad pr (bilde, screenshot)-par. Screenshot KAN repeteres
+//          (samme FB-post kan ha flere bilder). Bilde er alltid unikt.
+//   ikke_parede_bilder[]: bilder uten screenshot
+//   ikke_parede_screenshots[]: screenshots uten noen bilder
+//
+// Kommandoer:
+//   { type: 'par', bilde_nr, screenshot_nr } — flytter bilde til rad med
+//      gitt screenshot. Ny rad opprettes; gammel bilde-rad fjernes (og
+//      hvis dens screenshot ble orphaned, går screenshot til ikke_parede).
+
+import { readdirSync, statSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const BILDER_DIR = 'C:/Users/reida/Pictures'
+const SCREENSHOTS_DIR = 'C:/Users/reida/Pictures/Screenshots'
+const JSON_FIL = 'scripts/fb-bilder-pairing.json'
+const EKSKLUDER = ['icon-192.png', 'icon-192n.png']
+
+// Endringene fra Reidar denne runden:
+const KOMMANDOER = [
+  // Nytt bilde 26 (lastet ned i ettertid) → screenshot 5
+  { type: 'par', bilde_nr: 26, screenshot_nr: 5 },
+]
+
+// Master-data fra filsystem — gir oss nr og mtime for alle bilder og screenshots
+const bilderListe = readdirSync(BILDER_DIR)
+  .filter(f => /\.(jpe?g|png)$/i.test(f) && !f.startsWith('Skjermbilde') && !f.startsWith('_crop'))
+  .filter(f => !EKSKLUDER.includes(f))
+  .map(f => ({ navn: f, mtime: statSync(join(BILDER_DIR, f)).mtime }))
+  .sort((a, b) => a.mtime - b.mtime)
+
+const screenshotsListe = readdirSync(SCREENSHOTS_DIR)
+  .filter(f => /^Skjermbilde.*\.png$/i.test(f))
+  .map(f => ({ navn: f, mtime: statSync(join(SCREENSHOTS_DIR, f)).mtime }))
+  .sort((a, b) => a.mtime - b.mtime)
+
+const bildeFraNr = new Map(bilderListe.map((b, i) => [i + 1, { navn: b.navn, bilde_nr: i + 1, bilde_mtime: b.mtime.toISOString() }]))
+const screenshotFraNr = new Map(screenshotsListe.map((s, i) => [i + 1, { navn: s.navn, screenshot_nr: i + 1, screenshot_mtime: s.mtime.toISOString() }]))
+
+// Last og normaliser
+const data = JSON.parse(readFileSync(JSON_FIL, 'utf8'))
+data.ikke_parede_screenshots = data.ikke_parede_screenshots ?? []
+data.ikke_parede_bilder = (data.ikke_parede_bilder ?? []).map(o => typeof o === 'string' ? { navn: o, bilde_nr: null, bilde_mtime: null } : o)
+
+// Hjelpere
+function diffSek(ssMtime, bildeMtime) {
+  if (!ssMtime || !bildeMtime) return null
+  return Math.round((new Date(ssMtime) - new Date(bildeMtime)) / 1000)
+}
+
+function fjernBildeFraSted(bildeNr) {
+  // Fra par
+  const idx = data.par.findIndex(p => p.bilde_nr === bildeNr)
+  if (idx !== -1) {
+    const rad = data.par.splice(idx, 1)[0]
+    // Hvis denne radens screenshot ikke finnes i andre par-rader, blir den orphan
+    const ssNr = rad.screenshot_nr
+    const fortsattBrukt = data.par.some(p => p.screenshot_nr === ssNr)
+    if (!fortsattBrukt) {
+      const ssData = screenshotFraNr.get(ssNr) ?? { screenshot_nr: ssNr, screenshot: rad.screenshot, screenshot_mtime: rad.screenshot_mtime }
+      if (!data.ikke_parede_screenshots.some(s => s.screenshot_nr === ssNr)) {
+        data.ikke_parede_screenshots.push({ screenshot_nr: ssData.screenshot_nr, screenshot: ssData.navn ?? ssData.screenshot, screenshot_mtime: ssData.screenshot_mtime })
+      }
+    }
+    return { bilde_nr: rad.bilde_nr, navn: rad.bilde, bilde_mtime: rad.bilde_mtime }
+  }
+  // Fra ikke_parede_bilder
+  const idx2 = data.ikke_parede_bilder.findIndex(o => o.bilde_nr === bildeNr)
+  if (idx2 !== -1) return data.ikke_parede_bilder.splice(idx2, 1)[0]
+  // Fra masterlista (helt nytt bilde lagt til etter forrige kjøring)
+  const fra = bildeFraNr.get(bildeNr)
+  if (fra) return { bilde_nr: fra.bilde_nr, navn: fra.navn, bilde_mtime: fra.bilde_mtime }
+  return null
+}
+
+function leggTilRad(bilde, ssNr) {
+  // Finn screenshot-data — først fra eksisterende par-rader (screenshot kan repeteres),
+  // så fra ikke_parede_screenshots, så fra masterlista.
+  let ssData = data.par.find(p => p.screenshot_nr === ssNr)
+  if (ssData) {
+    ssData = { screenshot_nr: ssData.screenshot_nr, screenshot: ssData.screenshot, screenshot_mtime: ssData.screenshot_mtime }
+  } else {
+    const idx = data.ikke_parede_screenshots.findIndex(s => s.screenshot_nr === ssNr)
+    if (idx !== -1) {
+      ssData = data.ikke_parede_screenshots.splice(idx, 1)[0]
+    } else {
+      const fra = screenshotFraNr.get(ssNr)
+      if (!fra) {
+        console.error(`  Ukjent screenshot ${ssNr}`)
+        return false
+      }
+      ssData = { screenshot_nr: fra.screenshot_nr, screenshot: fra.navn, screenshot_mtime: fra.screenshot_mtime }
+    }
+  }
+  data.par.push({
+    screenshot_nr: ssData.screenshot_nr,
+    screenshot: ssData.screenshot,
+    screenshot_mtime: ssData.screenshot_mtime,
+    bilde_nr: bilde.bilde_nr,
+    bilde: bilde.navn,
+    bilde_mtime: bilde.bilde_mtime,
+    diff_sek: diffSek(ssData.screenshot_mtime, bilde.bilde_mtime),
+  })
+  return true
+}
+
+for (const cmd of KOMMANDOER) {
+  if (cmd.type !== 'par') continue
+  const bilde = fjernBildeFraSted(cmd.bilde_nr)
+  if (!bilde) {
+    console.error(`Skipping: bilde ${cmd.bilde_nr} ikke funnet`)
+    continue
+  }
+  if (leggTilRad(bilde, cmd.screenshot_nr)) {
+    console.log(`✓ par: bilde ${cmd.bilde_nr} → screenshot ${cmd.screenshot_nr}`)
+  }
+}
+
+// Sorter par på screenshot_nr og deretter bilde_nr for stabil visning
+data.par.sort((a, b) => a.screenshot_nr - b.screenshot_nr || (a.bilde_nr ?? 0) - (b.bilde_nr ?? 0))
+data.ikke_parede_bilder.sort((a, b) => (a.bilde_nr ?? 999) - (b.bilde_nr ?? 999))
+data.ikke_parede_screenshots.sort((a, b) => a.screenshot_nr - b.screenshot_nr)
+
+writeFileSync(JSON_FIL, JSON.stringify(data, null, 2), 'utf8')
+console.log(`\n✓ par: ${data.par.length}, løse bilder: ${data.ikke_parede_bilder.length}, løse screenshots: ${data.ikke_parede_screenshots.length}`)

--- a/scripts/fb-bilder-last-opp-r2.mjs
+++ b/scripts/fb-bilder-last-opp-r2.mjs
@@ -1,0 +1,54 @@
+// Laster opp alle FB-bilder til R2 under meldinger/-prefiks.
+// Idempotent — sjekker ikke om filen finnes, men R2 PUT erstatter uansett.
+//
+// Bruk: node --env-file=.env.local scripts/fb-bilder-last-opp-r2.mjs
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { AwsClient } from 'aws4fetch'
+
+const ACCOUNT_ID = process.env.R2_ACCOUNT_ID
+const ACCESS_KEY = process.env.R2_ACCESS_KEY_ID
+const SECRET_KEY = process.env.R2_SECRET_ACCESS_KEY
+const BUCKET = process.env.R2_BUCKET
+const JURISDICTION = (process.env.R2_JURISDICTION ?? 'default').toLowerCase()
+const SEG = JURISDICTION === 'default' ? '' : `.${JURISDICTION}`
+
+if (!ACCOUNT_ID || !ACCESS_KEY || !SECRET_KEY || !BUCKET) {
+  console.error('Mangler R2 env-vars')
+  process.exit(1)
+}
+
+// EU jurisdiksjon krever 'eeur' som region for signering — 'auto' fungerer
+// i Next.js men ikke fra Node.js direkte. Sett basert på R2_JURISDICTION.
+const REGION = JURISDICTION === 'eu' ? 'eeur' : 'auto'
+const aws = new AwsClient({ accessKeyId: ACCESS_KEY, secretAccessKey: SECRET_KEY, region: REGION, service: 's3' })
+
+const data = JSON.parse(readFileSync('scripts/fb-bilder-pairing.json', 'utf8'))
+const filer = [...new Set(data.par.map(p => p.bilde))]
+
+let opp = 0, feil = 0
+for (const f of filer) {
+  const sti = `meldinger/${f}`
+  const url = `https://${ACCOUNT_ID}${SEG}.r2.cloudflarestorage.com/${BUCKET}/${sti}`
+  const buf = readFileSync(`C:/Users/reida/Pictures/${f}`)
+  const ct = f.toLowerCase().endsWith('.png') ? 'image/png' : 'image/jpeg'
+  const res = await aws.fetch(url, {
+    method: 'PUT',
+    body: buf,
+    headers: {
+      'Content-Type': ct,
+      'Content-Length': String(buf.length),
+      'Cache-Control': 'public, max-age=31536000, immutable',
+    },
+  })
+  if (res.ok) {
+    opp++
+    process.stdout.write('.')
+  } else {
+    feil++
+    console.error(`\n✗ ${f}: ${res.status} ${await res.text()}`)
+  }
+}
+
+console.log(`\n✓ ${opp} opplastet, ${feil} feil`)

--- a/scripts/fb-bilder-metadata-html.mjs
+++ b/scripts/fb-bilder-metadata-html.mjs
@@ -1,0 +1,88 @@
+// Genererer en HTML der hvert bilde-par vises ved siden av sin kommentar-crop
+// + en tredje kolonne med strukturert OCR-resultat.
+// Reidar bruker den til å verifisere at OCR-en treffer riktig.
+//
+// Bruk: node scripts/fb-bilder-metadata-html.mjs
+
+import { readFileSync, writeFileSync } from 'node:fs'
+
+const PAIRING_FIL = 'scripts/fb-bilder-pairing.json'
+const METADATA_FIL = 'scripts/fb-bilder-metadata.json'
+const HTML_OUT = 'scripts/fb-bilder-metadata.html'
+const CROPS_PUB = 'fb-bilder-kommentar-crops'
+
+const pairing = JSON.parse(readFileSync(PAIRING_FIL, 'utf8'))
+const metadata = JSON.parse(readFileSync(METADATA_FIL, 'utf8'))
+
+const metaFraNr = new Map(metadata.map(m => [m.screenshot_nr, m]))
+
+// Grupper på screenshot
+const grupper = new Map()
+for (const p of pairing.par) {
+  if (!grupper.has(p.screenshot_nr)) grupper.set(p.screenshot_nr, { screenshot: p.screenshot, screenshot_nr: p.screenshot_nr, bilder: [] })
+  grupper.get(p.screenshot_nr).bilder.push(p)
+}
+
+function escapeHtml(s) {
+  if (s == null) return ''
+  return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}
+
+const rader = [...grupper.values()]
+  .sort((a, b) => a.screenshot_nr - b.screenshot_nr)
+  .map(g => {
+    const meta = metaFraNr.get(g.screenshot_nr)
+    const bilderHtml = g.bilder.map(p => `
+      <div style="margin-bottom:8px">
+        <strong>bilde ${p.bilde_nr}</strong><br>
+        <img src="fb-bilder-preview/${p.bilde}" loading="lazy" style="max-width:240px;max-height:200px;display:block">
+      </div>`).join('')
+
+    const kommentarerHtml = (meta?.kommentarer ?? []).map(k => `
+      <div style="margin-top:6px;padding:6px 8px;background:#f0f0f0;border-radius:6px;font-size:12px">
+        <strong>${escapeHtml(k.navn)}</strong>
+        <span style="color:#888;font-size:10px">${escapeHtml(k.relativ_tid ?? '')}</span><br>
+        ${escapeHtml(k.tekst)}
+        ${k.svar_paa ? `<div style="font-size:10px;color:#999">↳ svar på ${escapeHtml(k.svar_paa)}</div>` : ''}
+        ${k.har_bilde ? `<div style="font-size:10px;color:#c70">📷 inneholder bilde</div>` : ''}
+      </div>`).join('')
+
+    const merknadHtml = meta?.merknad ? `<div style="background:#fff3cd;padding:6px;border-radius:4px;font-size:11px;margin-top:6px">⚠️ ${escapeHtml(meta.merknad)}</div>` : ''
+
+    return `<tr>
+      <td>${bilderHtml}</td>
+      <td><strong>screenshot ${g.screenshot_nr}</strong><br>
+          <img src="${CROPS_PUB}/${g.screenshot}" loading="lazy" style="max-width:340px;display:block;border:1px solid #ccc">
+      </td>
+      <td style="min-width:280px;max-width:380px">
+        <div style="font-size:13px"><strong>${escapeHtml(meta?.postet_av ?? '?')}</strong>
+        <span style="color:#888;font-size:11px">${escapeHtml(meta?.postet_dato ?? '?')}</span></div>
+        ${meta?.beskrivelse ? `<div style="margin-top:6px;font-size:13px;white-space:pre-wrap">${escapeHtml(meta.beskrivelse)}</div>` : '<div style="font-size:11px;color:#aaa;font-style:italic">(ingen beskrivelse)</div>'}
+        ${merknadHtml}
+        ${kommentarerHtml.length ? `<div style="margin-top:8px"><strong style="font-size:11px;color:#555">${(meta?.kommentarer?.length ?? 0)} kommentarer:</strong>${kommentarerHtml}</div>` : '<div style="margin-top:8px;font-size:11px;color:#aaa">(ingen kommentarer)</div>'}
+      </td>
+    </tr>`
+  }).join('')
+
+const html = `<!doctype html>
+<html lang="nb"><head><meta charset="utf-8"><title>FB-bilder metadata-verifikasjon</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 0; padding: 20px; background: #fafafa; color: #222; }
+  h1 { font-size: 18px; }
+  table { width: 100%; border-collapse: collapse; background: white; }
+  th, td { border: 1px solid #ddd; padding: 10px; vertical-align: top; text-align: left; }
+  th { background: #eee; position: sticky; top: 0; z-index: 1; }
+  .merknad { background: #fff3cd; padding: 12px; border: 1px solid #ffc107; border-radius: 4px; margin-bottom: 20px; }
+</style></head><body>
+<h1>Metadata-verifikasjon — ${grupper.size} unike screenshots, ${pairing.par.length} bilder, ${metadata.filter(m => m.kommentarer?.length).length} med kommentarer</h1>
+<div class="merknad">
+  Sammenlign kolonne 3 (OCR-resultat) med kolonne 2 (kommentar-crop). Si fra med screenshot-nr om noe er feil eller mangler.
+</div>
+<table>
+<thead><tr><th>Bilde(r)</th><th>Kommentar-crop</th><th>OCR-resultat</th></tr></thead>
+<tbody>${rader}</tbody>
+</table>
+</body></html>`
+
+writeFileSync(HTML_OUT, html, 'utf8')
+console.log(`✓ Skrev ${HTML_OUT}`)

--- a/scripts/fb-bilder-metadata-patch.mjs
+++ b/scripts/fb-bilder-metadata-patch.mjs
@@ -1,0 +1,24 @@
+// Merger inn metadata-oppdateringer for én eller flere screenshots.
+// Bruk: node scripts/fb-bilder-metadata-patch.mjs '<JSON_array>'
+//
+// Hvert objekt i array har screenshot_nr + felter som skal oppdateres.
+
+import { readFileSync, writeFileSync } from 'node:fs'
+
+const JSON_FIL = 'scripts/fb-bilder-metadata.json'
+const input = process.argv[2]
+if (!input) { console.error('Mangler JSON-argument'); process.exit(1) }
+
+const oppdateringer = JSON.parse(input)
+const data = JSON.parse(readFileSync(JSON_FIL, 'utf8'))
+
+let n = 0
+for (const u of oppdateringer) {
+  const idx = data.findIndex(d => d.screenshot_nr === u.screenshot_nr)
+  if (idx === -1) { console.error(`screenshot ${u.screenshot_nr} ikke funnet`); continue }
+  Object.assign(data[idx], u, { ocr_status: 'lest' })
+  n++
+}
+
+writeFileSync(JSON_FIL, JSON.stringify(data, null, 2))
+console.log(`✓ Oppdatert ${n} screenshots`)

--- a/scripts/fb-bilder-metadata.json
+++ b/scripts/fb-bilder-metadata.json
@@ -1,0 +1,1453 @@
+[
+  {
+    "screenshot_nr": 1,
+    "screenshot": "Skjermbilde 2026-05-14 063627.png",
+    "bilder": [
+      {
+        "bilde_nr": 1,
+        "bilde": "513936824_10171634064405317_8149852453545435986_n.jpg"
+      }
+    ],
+    "postet_av": "Michael Johansen",
+    "postet_dato": "31. mai 2022",
+    "beskrivelse": "Jon Erik Dahl og jeg skal på Rammstein konserten på Bjerke den 24.7 så om det er noen av dere andre som ikke har billetter men har veldig lyst så kan kanskje lillebroren til Reidar Haavik hjelpe til 🍺 da får dere med dere konserten og kan servere øl til Jon Erik og meg . Vinn vinn 🙂",
+    "kommentarer": [
+      {
+        "navn": "Reidar Haavik",
+        "tekst": "Abelist jobbannonse ass",
+        "relativ_tid": "3 år"
+      },
+      {
+        "navn": "Øyvind Verket",
+        "tekst": "200per time.. kan fort dra inn tusen spenn da... 💼",
+        "relativ_tid": "3 år"
+      }
+    ],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 2,
+    "screenshot": "Skjermbilde 2026-05-14 063652.png",
+    "bilder": [
+      {
+        "bilde_nr": 2,
+        "bilde": "470583759_10170510363820626_6868328802286053130_n.jpg"
+      }
+    ],
+    "postet_av": "Jon Erik Dahl",
+    "postet_dato": "2. april 2016",
+    "beskrivelse": null,
+    "kommentarer": [
+      {
+        "navn": "Jon Erik Dahl",
+        "tekst": "syntes vi trengte et gruppe bilde 😜",
+        "relativ_tid": "10 år"
+      }
+    ],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 3,
+    "screenshot": "Skjermbilde 2026-05-14 111120.png",
+    "bilder": [
+      {
+        "bilde_nr": 3,
+        "bilde": "207616084_10165715082540226_1267054822432793292_n.jpg"
+      }
+    ],
+    "postet_av": "André Heede",
+    "postet_dato": "29. juni 2021",
+    "beskrivelse": "Da ble kåken solgt",
+    "kommentarer": [
+      {
+        "navn": "Øyvind Verket",
+        "tekst": "Konge! Grattis",
+        "relativ_tid": "4 år"
+      },
+      {
+        "navn": "Øyvind Rekve",
+        "tekst": "Grattis 🥂🍾",
+        "relativ_tid": "4 år"
+      },
+      {
+        "navn": "André Heede",
+        "tekst": "Ble 360\" over takst. Greit det i dagens marked",
+        "relativ_tid": "4 år"
+      },
+      {
+        "navn": "Espen Waldem",
+        "tekst": "Gratulerer",
+        "relativ_tid": "4 år"
+      },
+      {
+        "navn": "Reidar Haavik",
+        "tekst": "Godt over takst da ell?",
+        "relativ_tid": "4 år"
+      },
+      {
+        "navn": "Reidar Haavik",
+        "tekst": "Herlich! Gratulerer:)",
+        "relativ_tid": "4 år"
+      },
+      {
+        "navn": "André Heede",
+        "tekst": "Jepp😊 satte rekord på Brattlikollen så da er man happy",
+        "relativ_tid": "4 år"
+      },
+      {
+        "navn": "Kristoffer Benco Arntzen",
+        "tekst": "Gratulerer! Fornøyd ?",
+        "relativ_tid": "4 år"
+      }
+    ],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 4,
+    "screenshot": "Skjermbilde 2026-05-14 063736.png",
+    "bilder": [
+      {
+        "bilde_nr": 4,
+        "bilde": "472995892_10170480587275317_8169909547483092892_n.jpg"
+      }
+    ],
+    "postet_av": "Michael Johansen",
+    "postet_dato": "11. februar 2020",
+    "beskrivelse": "Hva skjer a Reidar Haavik?",
+    "kommentarer": [
+      {
+        "navn": "Reidar Haavik",
+        "tekst": "Og stikker av med penga!",
+        "relativ_tid": "6 år"
+      }
+    ],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 5,
+    "screenshot": "Skjermbilde 2026-05-14 063754.png",
+    "bilder": [
+      {
+        "bilde_nr": 26,
+        "bilde": "472833938_10170714749640096_7825765805359401361_n.jpg"
+      }
+    ],
+    "postet_av": "Kenneth Lunde",
+    "postet_dato": "21. desember 2019",
+    "beskrivelse": "God jul ʼa boys",
+    "kommentarer": [
+      {
+        "navn": "Espen Sørum Hagen",
+        "tekst": "God jul 😂🤤❤️",
+        "relativ_tid": "6 år"
+      }
+    ],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 6,
+    "screenshot": "Skjermbilde 2026-05-14 063833.png",
+    "bilder": [
+      {
+        "bilde_nr": 5,
+        "bilde": "75392732_10162535023635626_4447293589667446784_n.jpg"
+      }
+    ],
+    "postet_av": "Jon Erik Dahl",
+    "postet_dato": "22. oktober 2019",
+    "beskrivelse": "Når ble det greit med reklame for Adolf Hitler bilder på facebook",
+    "kommentarer": [
+      {
+        "navn": "Reidar Haavik",
+        "tekst": "Greit for meg",
+        "relativ_tid": "6 år"
+      },
+      {
+        "navn": "Jon Erik Dahl",
+        "tekst": "Morsomme var, at reklamen kom etter en kveld, hvor jeg dyp dykket inn i en del norske nettsider på ytre høyre siden av politikken",
+        "relativ_tid": "6 år",
+        "svar_paa": "Reidar Haavik"
+      }
+    ],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 7,
+    "screenshot": "Skjermbilde 2026-05-14 063855.png",
+    "bilder": [
+      {
+        "bilde_nr": 6,
+        "bilde": "40133598_10160786366215113_239708481341358080_n.jpg"
+      }
+    ],
+    "postet_av": "Øyvind Verket",
+    "postet_dato": "25. august 2018",
+    "beskrivelse": null,
+    "kommentarer": [
+      {
+        "navn": "Kristoffer Benco Arntzen",
+        "tekst": "For å klare å se dette så må du leite etter pikk, Øyvind Verket du leiter etter pikk! Hehe 😂",
+        "relativ_tid": "7 år"
+      },
+      {
+        "navn": "Espen Waldem",
+        "tekst": "[bildevedlegg - urinal]",
+        "relativ_tid": "7 år",
+        "har_bilde": true
+      },
+      {
+        "navn": "Jon Erik Dahl",
+        "tekst": "Benco har en katolsk prest på badet",
+        "relativ_tid": "7 år"
+      }
+    ],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 8,
+    "screenshot": "Skjermbilde 2026-05-14 063908.png",
+    "bilder": [
+      {
+        "bilde_nr": 7,
+        "bilde": "472170357_10170738984755626_2351219374440861825_n.jpg"
+      }
+    ],
+    "postet_av": "Jon Erik Dahl",
+    "postet_dato": "15. mai 2018",
+    "beskrivelse": null,
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 9,
+    "screenshot": "Skjermbilde 2026-05-14 063926.png",
+    "bilder": [
+      {
+        "bilde_nr": 8,
+        "bilde": "469614292_10169801486285696_1735001105317423278_n.jpg"
+      }
+    ],
+    "postet_av": "Øyvind Rekve",
+    "postet_dato": "12. april 2018",
+    "beskrivelse": "Dette er i kveld... too be young again 🤘",
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 10,
+    "screenshot": "Skjermbilde 2026-05-14 063945.png",
+    "bilder": [
+      {
+        "bilde_nr": 9,
+        "bilde": "468841672_10170003415665464_4444310879893950981_n.jpg"
+      },
+      {
+        "bilde_nr": 10,
+        "bilde": "472027737_10170527134715464_7921074026912311111_n.jpg"
+      },
+      {
+        "bilde_nr": 11,
+        "bilde": "468741380_10170003415625464_4945086347616410337_n.jpg"
+      }
+    ],
+    "postet_av": "Espen Sørum Hagen",
+    "postet_dato": "9. desember 2017",
+    "beskrivelse": null,
+    "kommentarer": [],
+    "ocr_status": "lest",
+    "merknad": "Bildet er fra et parent-innlegg (Dette bildet er fra et innlegg) - parent-tekst er ikke synlig"
+  },
+  {
+    "screenshot_nr": 11,
+    "screenshot": "Skjermbilde 2026-05-14 064019.png",
+    "bilder": [
+      {
+        "bilde_nr": 12,
+        "bilde": "468665243_10169825823750113_5067670262409442372_n.jpg"
+      }
+    ],
+    "postet_av": "Øyvind Verket",
+    "postet_dato": "10. november 2017",
+    "beskrivelse": "Mener at voldtekt ikke er ekte, med mindre man kan bevise at kvinnen ikke mot-jokker.",
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 12,
+    "screenshot": "Skjermbilde 2026-05-14 064033.png",
+    "bilder": [
+      {
+        "bilde_nr": 13,
+        "bilde": "468964054_10169845255245370_1708449074339552897_n.jpg"
+      }
+    ],
+    "postet_av": "Reidar Haavik",
+    "postet_dato": "10. november 2017",
+    "beskrivelse": "Vedder pungen sin mot Verkern, ca 10kr mener han.",
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 14,
+    "screenshot": "Skjermbilde 2026-05-14 064054.png",
+    "bilder": [
+      {
+        "bilde_nr": 14,
+        "bilde": "468963745_10169845254575370_6869727369567777523_n.jpg"
+      }
+    ],
+    "postet_av": "Reidar Haavik",
+    "postet_dato": "10. november 2017",
+    "beskrivelse": "Vedder en pils på at elbiler om tre år ikke lenger har særbehandling i Oslos bomringer",
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 15,
+    "screenshot": "Skjermbilde 2026-05-14 064112.png",
+    "bilder": [
+      {
+        "bilde_nr": 15,
+        "bilde": "468526434_10161817010036368_8282172887727775070_n.jpg"
+      }
+    ],
+    "postet_av": "Espen Waldem",
+    "postet_dato": "24. juni 2017",
+    "beskrivelse": null,
+    "kommentarer": [],
+    "ocr_status": "lest",
+    "merknad": "Bildet er fra et parent-innlegg"
+  },
+  {
+    "screenshot_nr": 16,
+    "screenshot": "Skjermbilde 2026-05-14 064121.png",
+    "bilder": [
+      {
+        "bilde_nr": 16,
+        "bilde": "468568689_10161817008696368_8839644318772214941_n.jpg"
+      },
+      {
+        "bilde_nr": 17,
+        "bilde": "468496612_10161817008691368_2383094503811365159_n.jpg"
+      },
+      {
+        "bilde_nr": 18,
+        "bilde": "468459837_10161817008656368_7271076194809599240_n.jpg"
+      }
+    ],
+    "postet_av": "Espen Waldem",
+    "postet_dato": "24. juni 2017",
+    "beskrivelse": null,
+    "kommentarer": [],
+    "ocr_status": "lest",
+    "merknad": "Bildet er fra et parent-innlegg"
+  },
+  {
+    "screenshot_nr": 17,
+    "screenshot": "Skjermbilde 2026-05-14 064144.png",
+    "bilder": [
+      {
+        "bilde_nr": 19,
+        "bilde": "473019028_10170293689990696_8627677788363977487_n.jpg"
+      }
+    ],
+    "postet_av": "Øyvind Rekve",
+    "postet_dato": "28. mars 2017",
+    "beskrivelse": "Neste år for Herreklubben?",
+    "kommentarer": [
+      {
+        "navn": "Øyvind Rekve",
+        "tekst": "Ingen som er hypp?",
+        "relativ_tid": "9 år"
+      }
+    ],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 18,
+    "screenshot": "Skjermbilde 2026-05-14 064157.png",
+    "bilder": [
+      {
+        "bilde_nr": 20,
+        "bilde": "470207513_10169851916900696_3070902161453074898_n.jpg"
+      }
+    ],
+    "postet_av": "Øyvind Rekve",
+    "postet_dato": "20. februar 2017",
+    "beskrivelse": "Dette bildet gjør meg glad 😘",
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 19,
+    "screenshot": "Skjermbilde 2026-05-14 064212.png",
+    "bilder": [
+      {
+        "bilde_nr": 21,
+        "bilde": "472327830_10170716182060626_7975648651640544702_n.jpg"
+      }
+    ],
+    "postet_av": "Jon Erik Dahl",
+    "postet_dato": "9. februar 2017",
+    "beskrivelse": null,
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 20,
+    "screenshot": "Skjermbilde 2026-05-14 064241.png",
+    "bilder": [
+      {
+        "bilde_nr": 22,
+        "bilde": "472848654_10170272300575696_8956102802779641044_n.jpg"
+      }
+    ],
+    "postet_av": "Øyvind Rekve",
+    "postet_dato": "7. februar 2017",
+    "beskrivelse": "Dukka opp på fjesboka i dag... Vi ser helt like ut jo...",
+    "kommentarer": [
+      {
+        "navn": "André Heede",
+        "tekst": "😂",
+        "relativ_tid": "9 år"
+      }
+    ],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 21,
+    "screenshot": "Skjermbilde 2026-05-14 064305.png",
+    "bilder": [
+      {
+        "bilde_nr": 23,
+        "bilde": "468399174_10170275252275226_7190338394014570128_n.jpg"
+      }
+    ],
+    "postet_av": "André Heede",
+    "postet_dato": "30. september 2016",
+    "beskrivelse": "Guten morgen🍻 Svogerns favoritt til frokost",
+    "kommentarer": [
+      {
+        "navn": "André Heede",
+        "tekst": "Har det på video. Blir spilt av på storskjermen på Armbrustschützenzelt",
+        "relativ_tid": "9 år"
+      },
+      {
+        "navn": "Michael Johansen",
+        "tekst": "hvor er gæg beviset André Heede?",
+        "relativ_tid": "9 år"
+      }
+    ],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 22,
+    "screenshot": "Skjermbilde 2026-05-14 064351.png",
+    "bilder": [
+      {
+        "bilde_nr": 24,
+        "bilde": "468284967_10170274620315226_7717431427819465511_n.jpg"
+      }
+    ],
+    "postet_av": "André Heede",
+    "postet_dato": "29. september 2016",
+    "beskrivelse": "Skål a gutta",
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 23,
+    "screenshot": "Skjermbilde 2026-05-14 064415.png",
+    "bilder": [
+      {
+        "bilde_nr": 25,
+        "bilde": "468205228_10170274616800226_5387154595722121418_n.jpg"
+      }
+    ],
+    "postet_av": "André Heede",
+    "postet_dato": "29. september 2016",
+    "beskrivelse": "Nachspielteltet lever ennå",
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 24,
+    "screenshot": "Skjermbilde 2026-05-14 085008.png",
+    "bilder": [
+      {
+        "bilde_nr": 27,
+        "bilde": "468546912_10170023961465626_1974895974601579098_n.jpg"
+      }
+    ],
+    "postet_av": "Jon Erik Dahl",
+    "postet_dato": "24. september 2016",
+    "beskrivelse": "Labert oppmøte",
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 25,
+    "screenshot": "Skjermbilde 2026-05-14 085023.png",
+    "bilder": [
+      {
+        "bilde_nr": 28,
+        "bilde": "468042786_10169904888265626_7424129223818364482_n.jpg"
+      }
+    ],
+    "postet_av": "Jon Erik Dahl",
+    "postet_dato": "21. juli 2016",
+    "beskrivelse": null,
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 26,
+    "screenshot": "Skjermbilde 2026-05-14 085043.png",
+    "bilder": [
+      {
+        "bilde_nr": 29,
+        "bilde": "473657432_10170911564250626_3357151237299040991_n.jpg"
+      }
+    ],
+    "postet_av": "Jon Erik Dahl",
+    "postet_dato": "7. mars 2016",
+    "beskrivelse": null,
+    "kommentarer": [
+      {
+        "navn": "Øyvind Rekve",
+        "tekst": "Utafor Jon",
+        "relativ_tid": "10 år"
+      },
+      {
+        "navn": "Jon Erik Dahl",
+        "tekst": "Utafor humor er også humor 😜",
+        "relativ_tid": "10 år"
+      },
+      {
+        "navn": "Michael Johansen",
+        "tekst": "Har dette skjedd deg Jon Erik Dahl ? i så fall syntes jeg dette er moro 😀 og at du har litt nasty tendenser.",
+        "relativ_tid": "10 år"
+      }
+    ],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 27,
+    "screenshot": "Skjermbilde 2026-05-14 085059.png",
+    "bilder": [
+      {
+        "bilde_nr": 30,
+        "bilde": "468597536_10169840290925370_5685652838756870002_n.jpg"
+      }
+    ],
+    "postet_av": "Reidar Haavik",
+    "postet_dato": "14. mars 2015",
+    "beskrivelse": "Vi er samme sted som i fjor!",
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 28,
+    "screenshot": "Skjermbilde 2026-05-14 085116.png",
+    "bilder": [
+      {
+        "bilde_nr": 31,
+        "bilde": "472989729_10170549701280317_1398779810565515323_n.jpg"
+      }
+    ],
+    "postet_av": "Michael Johansen",
+    "postet_dato": "28. mai 2014",
+    "beskrivelse": null,
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 29,
+    "screenshot": "Skjermbilde 2026-05-14 085126.png",
+    "bilder": [
+      {
+        "bilde_nr": 32,
+        "bilde": "470204415_10170130107390297_9200493019667618799_n.jpg"
+      }
+    ],
+    "postet_av": "Klas Kristoffer Liland",
+    "postet_dato": "4. april 2014",
+    "beskrivelse": "God helg !",
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 30,
+    "screenshot": "Skjermbilde 2026-05-14 085154.png",
+    "bilder": [
+      {
+        "bilde_nr": 33,
+        "bilde": "470214464_10170106745765297_6900551415671284136_n.jpg"
+      }
+    ],
+    "postet_av": "Klas Kristoffer Liland",
+    "postet_dato": "10. mars 2014",
+    "beskrivelse": "Lunch Reka",
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 31,
+    "screenshot": "Skjermbilde 2026-05-14 085203.png",
+    "bilder": [
+      {
+        "bilde_nr": 34,
+        "bilde": "472744758_10170498287515317_7373605628117300606_n.jpg"
+      }
+    ],
+    "postet_av": "Michael Johansen",
+    "postet_dato": "21. februar 2014",
+    "beskrivelse": "Får satse på at du får i deg litt av denne Kristoffer Benco Arntzen, så du orker å være med 8 Mars da 🙂",
+    "kommentarer": [
+      {
+        "navn": "Kristoffer Benco Arntzen",
+        "tekst": "Hehe, den må jeg prøve!",
+        "relativ_tid": "12 år"
+      },
+      {
+        "navn": "Øyvind Rekve",
+        "tekst": "Hehe dauer",
+        "relativ_tid": "12 år"
+      }
+    ],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 32,
+    "screenshot": "Skjermbilde 2026-05-14 085215.png",
+    "bilder": [
+      {
+        "bilde_nr": 35,
+        "bilde": "473165819_10170504444200297_2545909050171481490_n.jpg"
+      }
+    ],
+    "postet_av": "Klas Kristoffer Liland",
+    "postet_dato": "21. februar 2014",
+    "beskrivelse": "Spiller du fotball MJ ?",
+    "kommentarer": [
+      {
+        "navn": "Michael Johansen",
+        "tekst": "HAHAHA, Benco har tatt navnet mitt",
+        "relativ_tid": "12 år"
+      },
+      {
+        "navn": "Kristoffer Benco Arntzen",
+        "tekst": "Skal jeg bli dratt inn i leken deres å nå da!! 🙂",
+        "relativ_tid": "12 år"
+      },
+      {
+        "navn": "Michael Johansen",
+        "tekst": "Noe må man jo gjøre, for å få deg ut av kjelleren på Hellerud 🙂",
+        "relativ_tid": "12 år"
+      }
+    ],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 33,
+    "screenshot": "Skjermbilde 2026-05-14 085231.png",
+    "bilder": [
+      {
+        "bilde_nr": 36,
+        "bilde": "472913576_10170497559555317_582184138924698425_n.jpg"
+      }
+    ],
+    "postet_av": "Michael Johansen",
+    "postet_dato": "20. februar 2014",
+    "beskrivelse": "Ser du har jugoslaviske bonde aner også. Klas Puder 🙂",
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 34,
+    "screenshot": "Skjermbilde 2026-05-14 085241.png",
+    "bilder": [
+      {
+        "bilde_nr": 37,
+        "bilde": "472876311_10170497623190317_6387856711755553460_n.jpg"
+      }
+    ],
+    "postet_av": "Michael Johansen",
+    "postet_dato": "20. februar 2014",
+    "beskrivelse": "Visste ikke at du var så musikalsk Klas Kristoffer Liland",
+    "kommentarer": [
+      {
+        "navn": "Klas Kristoffer Liland",
+        "tekst": "Var ikke klar over det selv 🙂",
+        "relativ_tid": "12 år"
+      }
+    ],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 35,
+    "screenshot": "Skjermbilde 2026-05-14 085303.png",
+    "bilder": [
+      {
+        "bilde_nr": 38,
+        "bilde": "469811742_10170082468525297_4498419575386491419_n.jpg"
+      }
+    ],
+    "postet_av": "Klas Kristoffer Liland",
+    "postet_dato": "20. februar 2014",
+    "beskrivelse": "Lunch (reka)",
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 36,
+    "screenshot": "Skjermbilde 2026-05-14 085317.png",
+    "bilder": [
+      {
+        "bilde_nr": 39,
+        "bilde": "472098467_10170439595315113_7842281758487874526_n.jpg"
+      }
+    ],
+    "postet_av": "Øyvind Verket",
+    "postet_dato": "8. oktober 2013",
+    "beskrivelse": "Deilig hjemme og..",
+    "kommentarer": [
+      {
+        "navn": "André Heede",
+        "tekst": "Ser du på menn som tar sv seg buksene?",
+        "relativ_tid": "12 år"
+      }
+    ],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 37,
+    "screenshot": "Skjermbilde 2026-05-14 085331.png",
+    "bilder": [
+      {
+        "bilde_nr": 40,
+        "bilde": "468311580_10170275955440226_7492536933205911086_n.jpg"
+      }
+    ],
+    "postet_av": "André Heede",
+    "postet_dato": "8. oktober 2013",
+    "beskrivelse": "Savner München, eisbein&würst og mas. Detta er crap!!",
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 38,
+    "screenshot": "Skjermbilde 2026-05-14 085350.png",
+    "bilder": [
+      {
+        "bilde_nr": 41,
+        "bilde": "469156381_10169951257645370_2240540405814531238_n.jpg"
+      }
+    ],
+    "postet_av": "Reidar Haavik",
+    "postet_dato": "8. oktober 2013",
+    "beskrivelse": "Savner Munich ass, dette er crap.. — her: DNB-huset i Bjørvika.",
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 39,
+    "screenshot": "Skjermbilde 2026-05-14 085401.png",
+    "bilder": [
+      {
+        "bilde_nr": 42,
+        "bilde": "474037233_10170580987495297_7964515424150398530_n.jpg"
+      }
+    ],
+    "postet_av": "Klas Kristoffer Liland",
+    "postet_dato": "2. desember 2012",
+    "beskrivelse": "Frokost 🙂",
+    "kommentarer": [
+      {
+        "navn": "Kristoffer Benco Arntzen",
+        "tekst": "Det oser testosteron av den der frokosten!",
+        "relativ_tid": "13 år"
+      },
+      {
+        "navn": "Alexander Svensen",
+        "tekst": "Sweet!",
+        "relativ_tid": "13 år"
+      },
+      {
+        "navn": "Espen Sørum Hagen",
+        "tekst": "med tyttebærsyltetøy 🙂",
+        "relativ_tid": "13 år"
+      }
+    ],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 40,
+    "screenshot": "Skjermbilde 2026-05-14 085422.png",
+    "bilder": [
+      {
+        "bilde_nr": 43,
+        "bilde": "518658037_10162919427611368_3847170441472136023_n.jpg"
+      }
+    ],
+    "postet_av": "Espen Waldem",
+    "postet_dato": "19. desember 2010",
+    "beskrivelse": null,
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 41,
+    "screenshot": "Skjermbilde 2026-05-14 085436.png",
+    "bilder": [
+      {
+        "bilde_nr": 44,
+        "bilde": "520476255_10162919427886368_8804124244684399291_n.jpg"
+      }
+    ],
+    "postet_av": "Espen Waldem",
+    "postet_dato": "19. desember 2010",
+    "beskrivelse": null,
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 42,
+    "screenshot": "Skjermbilde 2026-05-14 085447.png",
+    "bilder": [
+      {
+        "bilde_nr": 45,
+        "bilde": "519395762_10162919427986368_2365358503468583542_n.jpg"
+      }
+    ],
+    "postet_av": "Espen Waldem",
+    "postet_dato": "19. desember 2010",
+    "beskrivelse": null,
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 43,
+    "screenshot": "Skjermbilde 2026-05-14 085458.png",
+    "bilder": [
+      {
+        "bilde_nr": 46,
+        "bilde": "518314111_10162919428076368_2472337784645710054_n.jpg"
+      }
+    ],
+    "postet_av": "Espen Waldem",
+    "postet_dato": "19. desember 2010",
+    "beskrivelse": null,
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 44,
+    "screenshot": "Skjermbilde 2026-05-14 085508.png",
+    "bilder": [
+      {
+        "bilde_nr": 47,
+        "bilde": "518314818_10162919427936368_8239745519008611795_n.jpg"
+      }
+    ],
+    "postet_av": "Espen Waldem",
+    "postet_dato": "19. desember 2010",
+    "beskrivelse": null,
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 45,
+    "screenshot": "Skjermbilde 2026-05-14 085518.png",
+    "bilder": [
+      {
+        "bilde_nr": 48,
+        "bilde": "518435350_10162919427616368_5558791084309264020_n.jpg"
+      }
+    ],
+    "postet_av": "Espen Waldem",
+    "postet_dato": "19. desember 2010",
+    "beskrivelse": null,
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 46,
+    "screenshot": "Skjermbilde 2026-05-14 085528.png",
+    "bilder": [
+      {
+        "bilde_nr": 49,
+        "bilde": "519004626_10162919427606368_216200332465866816_n.jpg"
+      }
+    ],
+    "postet_av": "Espen Waldem",
+    "postet_dato": "19. desember 2010",
+    "beskrivelse": null,
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 47,
+    "screenshot": "Skjermbilde 2026-05-14 085541.png",
+    "bilder": [
+      {
+        "bilde_nr": 50,
+        "bilde": "518320949_10162918875406368_5800396639740064618_n.jpg"
+      }
+    ],
+    "postet_av": "Espen Waldem",
+    "postet_dato": "13. desember 2010",
+    "beskrivelse": null,
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 48,
+    "screenshot": "Skjermbilde 2026-05-14 085551.png",
+    "bilder": [
+      {
+        "bilde_nr": 51,
+        "bilde": "520836923_10162918874856368_485771287725791650_n.jpg"
+      }
+    ],
+    "postet_av": "Espen Waldem",
+    "postet_dato": "13. desember 2010",
+    "beskrivelse": null,
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 49,
+    "screenshot": "Skjermbilde 2026-05-14 085603.png",
+    "bilder": [
+      {
+        "bilde_nr": 52,
+        "bilde": "519723443_10162918875146368_935026746537238667_n.jpg"
+      }
+    ],
+    "postet_av": "Espen Waldem",
+    "postet_dato": "13. desember 2010",
+    "beskrivelse": "rybak was here",
+    "kommentarer": [
+      {
+        "navn": "Øyvind Verket",
+        "tekst": "han er ikke den eneste..",
+        "relativ_tid": "15 år"
+      }
+    ],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 50,
+    "screenshot": "Skjermbilde 2026-05-14 085613.png",
+    "bilder": [
+      {
+        "bilde_nr": 53,
+        "bilde": "518578916_10162918875371368_821995706893352632_n.jpg"
+      }
+    ],
+    "postet_av": "Espen Waldem",
+    "postet_dato": "13. desember 2010",
+    "beskrivelse": null,
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 51,
+    "screenshot": "Skjermbilde 2026-05-14 085622.png",
+    "bilder": [
+      {
+        "bilde_nr": 54,
+        "bilde": "518147005_10162918875061368_1477369775922750608_n.jpg"
+      }
+    ],
+    "postet_av": "Espen Waldem",
+    "postet_dato": "13. desember 2010",
+    "beskrivelse": null,
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 52,
+    "screenshot": "Skjermbilde 2026-05-14 085631.png",
+    "bilder": [
+      {
+        "bilde_nr": 55,
+        "bilde": "518313093_10162918875456368_1348643235867528697_n.jpg"
+      }
+    ],
+    "postet_av": "Espen Waldem",
+    "postet_dato": "13. desember 2010",
+    "beskrivelse": null,
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 53,
+    "screenshot": "Skjermbilde 2026-05-14 085642.png",
+    "bilder": [
+      {
+        "bilde_nr": 56,
+        "bilde": "518803319_10162918875046368_350116659518989438_n.jpg"
+      }
+    ],
+    "postet_av": "Espen Waldem",
+    "postet_dato": "13. desember 2010",
+    "beskrivelse": null,
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 54,
+    "screenshot": "Skjermbilde 2026-05-14 085656.png",
+    "bilder": [
+      {
+        "bilde_nr": 57,
+        "bilde": "518582873_10162918875026368_610420821859682360_n.jpg"
+      }
+    ],
+    "postet_av": "Espen Waldem",
+    "postet_dato": "13. desember 2010",
+    "beskrivelse": "one happy family",
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 55,
+    "screenshot": "Skjermbilde 2026-05-14 085707.png",
+    "bilder": [
+      {
+        "bilde_nr": 58,
+        "bilde": "518591262_10162918875286368_156734218321498286_n.jpg"
+      }
+    ],
+    "postet_av": "Espen Waldem",
+    "postet_dato": "13. desember 2010",
+    "beskrivelse": null,
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 56,
+    "screenshot": "Skjermbilde 2026-05-14 085716.png",
+    "bilder": [
+      {
+        "bilde_nr": 59,
+        "bilde": "520228537_10162918875471368_8693685300745149099_n.jpg"
+      }
+    ],
+    "postet_av": "Espen Waldem",
+    "postet_dato": "13. desember 2010",
+    "beskrivelse": "riga in my pocket",
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 57,
+    "screenshot": "Skjermbilde 2026-05-14 085726.png",
+    "bilder": [
+      {
+        "bilde_nr": 60,
+        "bilde": "472179447_10170550551290464_20389259500477410_n.jpg"
+      }
+    ],
+    "postet_av": "Espen Sørum Hagen",
+    "postet_dato": "7. oktober 2010",
+    "beskrivelse": null,
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 58,
+    "screenshot": "Skjermbilde 2026-05-14 085735.png",
+    "bilder": [
+      {
+        "bilde_nr": 61,
+        "bilde": "472119935_10170550547600464_736685527438663604_n.jpg"
+      }
+    ],
+    "postet_av": "Espen Sørum Hagen",
+    "postet_dato": "7. oktober 2010",
+    "beskrivelse": null,
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 59,
+    "screenshot": "Skjermbilde 2026-05-14 085750.png",
+    "bilder": [
+      {
+        "bilde_nr": 62,
+        "bilde": "468856451_10170055900330464_436059343400849049_n.jpg"
+      }
+    ],
+    "postet_av": "Espen Sørum Hagen",
+    "postet_dato": "7. oktober 2010",
+    "beskrivelse": null,
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 60,
+    "screenshot": "Skjermbilde 2026-05-14 085759.png",
+    "bilder": [
+      {
+        "bilde_nr": 63,
+        "bilde": "472224837_10170550519000464_595659400939509453_n.jpg"
+      }
+    ],
+    "postet_av": "Espen Sørum Hagen",
+    "postet_dato": "7. oktober 2010",
+    "beskrivelse": "— sammen med Øyvind Rekve.",
+    "kommentarer": [
+      {
+        "navn": "André Heede",
+        "tekst": "kjekke gutter ❤️",
+        "relativ_tid": "15 år"
+      }
+    ],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 61,
+    "screenshot": "Skjermbilde 2026-05-14 085809.png",
+    "bilder": [
+      {
+        "bilde_nr": 64,
+        "bilde": "472104457_10170550549540464_7228763410115619249_n.jpg"
+      }
+    ],
+    "postet_av": "Espen Sørum Hagen",
+    "postet_dato": "7. oktober 2010",
+    "beskrivelse": null,
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 62,
+    "screenshot": "Skjermbilde 2026-05-14 111252.png",
+    "bilder": [
+      {
+        "bilde_nr": 65,
+        "bilde": "468420539_10169944412665096_2192487242058145001_n.jpg"
+      }
+    ],
+    "postet_av": "Kenneth Lunde",
+    "postet_dato": "25. juni 2010",
+    "beskrivelse": "hehehe.. — med Jon Erik Dahl og 2 andre.",
+    "kommentarer": [
+      {
+        "navn": "André Heede",
+        "tekst": "hahaha genialt bilde",
+        "relativ_tid": "15 år"
+      },
+      {
+        "navn": "Chris Reitan",
+        "tekst": "dritbra",
+        "relativ_tid": "15 år"
+      },
+      {
+        "navn": "Reidar Haavik",
+        "tekst": "OMG! WTF! LOL!",
+        "relativ_tid": "15 år"
+      },
+      {
+        "navn": "Reidar Haavik",
+        "tekst": "sånn går dagene..",
+        "relativ_tid": "15 år"
+      },
+      {
+        "navn": "Reidar Haavik",
+        "tekst": "hehe, jeg liker å se på dette bildet litt av og til, haha, det er kunst",
+        "relativ_tid": "15 år"
+      },
+      {
+        "navn": "André Heede",
+        "tekst": "true 😊",
+        "relativ_tid": "15 år"
+      },
+      {
+        "navn": "Kenneth Lunde",
+        "tekst": "Jeg ler enda!",
+        "relativ_tid": "10 år"
+      }
+    ],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 63,
+    "screenshot": "Skjermbilde 2026-05-14 085834.png",
+    "bilder": [
+      {
+        "bilde_nr": 66,
+        "bilde": "468443389_10169944412690096_3869888267080914533_n.jpg"
+      }
+    ],
+    "postet_av": "Kenneth Lunde",
+    "postet_dato": "25. juni 2010",
+    "beskrivelse": "Helt om natta, helt om mårran!",
+    "kommentarer": [
+      {
+        "navn": "Øyvind Verket",
+        "tekst": "\"Shit ass. Jeg bææsja på meg!\"",
+        "relativ_tid": "15 år"
+      }
+    ],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 64,
+    "screenshot": "Skjermbilde 2026-05-14 085847.png",
+    "bilder": [
+      {
+        "bilde_nr": 67,
+        "bilde": "468623550_10169944412680096_7274017795925705100_n.jpg"
+      }
+    ],
+    "postet_av": "Kenneth Lunde",
+    "postet_dato": "25. juni 2010",
+    "beskrivelse": "\"Vi er venner vi Chris?\" — med Jon Erik Dahl og 2 andre.",
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 65,
+    "screenshot": "Skjermbilde 2026-05-14 085857.png",
+    "bilder": [
+      {
+        "bilde_nr": 68,
+        "bilde": "468357307_10169944412695096_1344239155219180584_n.jpg"
+      }
+    ],
+    "postet_av": "Kenneth Lunde",
+    "postet_dato": "25. juni 2010",
+    "beskrivelse": "Major'n — sammen med André Heede.",
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 66,
+    "screenshot": "Skjermbilde 2026-05-14 085907.png",
+    "bilder": [
+      {
+        "bilde_nr": 69,
+        "bilde": "468222418_10169944412710096_3369296609782977880_n.jpg"
+      }
+    ],
+    "postet_av": "Kenneth Lunde",
+    "postet_dato": "25. juni 2010",
+    "beskrivelse": "\"Haaade daa Niiiiils\" — sammen med Kristoffer Benco Arntzen.",
+    "kommentarer": [
+      {
+        "navn": "André Heede",
+        "tekst": "haade da Niiils",
+        "relativ_tid": "15 år"
+      }
+    ],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 67,
+    "screenshot": "Skjermbilde 2026-05-14 085916.png",
+    "bilder": [
+      {
+        "bilde_nr": 70,
+        "bilde": "468358468_10169944407490096_231703184139795518_n.jpg"
+      }
+    ],
+    "postet_av": "Kenneth Lunde",
+    "postet_dato": "25. juni 2010",
+    "beskrivelse": "Bilde taler for seg selv — sammen med Øyvind Rekve.",
+    "kommentarer": [
+      {
+        "navn": "Chris Reitan",
+        "tekst": "Waaaaale!",
+        "relativ_tid": "15 år"
+      }
+    ],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 68,
+    "screenshot": "Skjermbilde 2026-05-14 085933.png",
+    "bilder": [
+      {
+        "bilde_nr": 71,
+        "bilde": "468357999_10169944407495096_5943155274355686811_n.jpg"
+      }
+    ],
+    "postet_av": "Kenneth Lunde",
+    "postet_dato": "25. juni 2010",
+    "beskrivelse": "en to tre hopp — med Øyvind Rekve og 2 andre.",
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 69,
+    "screenshot": "Skjermbilde 2026-05-14 085941.png",
+    "bilder": [
+      {
+        "bilde_nr": 72,
+        "bilde": "468391613_10169944407485096_8618045998776258624_n.jpg"
+      }
+    ],
+    "postet_av": "Kenneth Lunde",
+    "postet_dato": "25. juni 2010",
+    "beskrivelse": "STOP! Hammoc time.. — med Jon Erik Dahl og 4 andre.",
+    "kommentarer": [
+      {
+        "navn": "André Heede",
+        "tekst": "sjekk chris gir reidar en elbow a",
+        "relativ_tid": "15 år"
+      },
+      {
+        "navn": "Chris Reitan",
+        "tekst": "sjekk jonna klør waldem på..",
+        "relativ_tid": "15 år"
+      },
+      {
+        "navn": "André Heede",
+        "tekst": "et sted som hjernen til Espen til å starte en enorm endorfinproduksjon iallefall",
+        "relativ_tid": "15 år"
+      },
+      {
+        "navn": "Chris Reitan",
+        "tekst": "oh yea!!",
+        "relativ_tid": "15 år"
+      }
+    ],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 70,
+    "screenshot": "Skjermbilde 2026-05-14 085956.png",
+    "bilder": [
+      {
+        "bilde_nr": 73,
+        "bilde": "468388093_10169944407470096_1212063591183753932_n.jpg"
+      }
+    ],
+    "postet_av": "Kenneth Lunde",
+    "postet_dato": "25. juni 2010",
+    "beskrivelse": "Hova — med Øyvind Rekve og 2 andre.",
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 71,
+    "screenshot": "Skjermbilde 2026-05-14 090005.png",
+    "bilder": [
+      {
+        "bilde_nr": 74,
+        "bilde": "468358024_10169944407475096_1520356219861115183_n.jpg"
+      }
+    ],
+    "postet_av": "Kenneth Lunde",
+    "postet_dato": "25. juni 2010",
+    "beskrivelse": "\"Ikke vær redd lille venn, den er ikke større enn som så\" — med André Heede og Chris Reitan.",
+    "kommentarer": [
+      {
+        "navn": "Chris Reitan",
+        "tekst": "Du måkke være redd!",
+        "relativ_tid": "15 år"
+      }
+    ],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 72,
+    "screenshot": "Skjermbilde 2026-05-14 090017.png",
+    "bilder": [
+      {
+        "bilde_nr": 75,
+        "bilde": "468406279_10169944402200096_8662440642849756064_n.jpg"
+      }
+    ],
+    "postet_av": "Kenneth Lunde",
+    "postet_dato": "25. juni 2010",
+    "beskrivelse": "\"Do the Borat dance\" — med Øyvind Rekve og Chris Reitan.",
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 73,
+    "screenshot": "Skjermbilde 2026-05-14 090032.png",
+    "bilder": [
+      {
+        "bilde_nr": 76,
+        "bilde": "468399892_10169944402165096_277228747751722778_n.jpg"
+      }
+    ],
+    "postet_av": "Kenneth Lunde",
+    "postet_dato": "25. juni 2010",
+    "beskrivelse": "\"Hva er det du har i bæggen 'a? Nødproviant, makrell i tomat??\" — sammen med Chris Reitan.",
+    "kommentarer": [
+      {
+        "navn": "Chris Reitan",
+        "tekst": "slo ann den!",
+        "relativ_tid": "15 år"
+      },
+      {
+        "navn": "André Heede",
+        "tekst": "ser ut som du har hånde på et spesielt sted du oxo",
+        "relativ_tid": "15 år"
+      },
+      {
+        "navn": "Chris Reitan",
+        "tekst": "Ooooh yea!! Bundy grepet!",
+        "relativ_tid": "15 år"
+      },
+      {
+        "navn": "André Heede",
+        "tekst": "de ler an Chris, de ler an",
+        "relativ_tid": "15 år"
+      }
+    ],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 74,
+    "screenshot": "Skjermbilde 2026-05-14 090041.png",
+    "bilder": [
+      {
+        "bilde_nr": 77,
+        "bilde": "468480465_10169944400875096_7231026925742004139_n.jpg"
+      }
+    ],
+    "postet_av": "Kenneth Lunde",
+    "postet_dato": "25. juni 2010",
+    "beskrivelse": "HeDidIt — sammen med André Heede.",
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 75,
+    "screenshot": "Skjermbilde 2026-05-14 090052.png",
+    "bilder": [
+      {
+        "bilde_nr": 78,
+        "bilde": "468358032_10169944400860096_2179309298273507387_n.jpg"
+      }
+    ],
+    "postet_av": "Kenneth Lunde",
+    "postet_dato": "25. juni 2010",
+    "beskrivelse": "OMG!! LOL, Lissom jesus du?! — sammen med Reidar Haavik.",
+    "kommentarer": [],
+    "ocr_status": "lest"
+  },
+  {
+    "screenshot_nr": 76,
+    "screenshot": "Skjermbilde 2026-05-14 090100.png",
+    "bilder": [
+      {
+        "bilde_nr": 79,
+        "bilde": "468332682_10169944400870096_607451437907088496_n.jpg"
+      }
+    ],
+    "postet_av": "Kenneth Lunde",
+    "postet_dato": "25. juni 2010",
+    "beskrivelse": "Åå løøh! DødseReka — sammen med Øyvind Rekve.",
+    "kommentarer": [],
+    "ocr_status": "lest"
+  }
+]

--- a/scripts/fb-bilder-navn-mapping.json
+++ b/scripts/fb-bilder-navn-mapping.json
@@ -1,0 +1,80 @@
+{
+  "Alexander Svensen": {
+    "profil_id": "8f64ed4a-d907-424f-82ae-d6220c7fb02c",
+    "profil_navn": "Alexander Svensen",
+    "aktiv": true,
+    "match": "auto"
+  },
+  "André Heede": {
+    "profil_id": "f3d71e5a-367a-461e-ba13-a6c4de144e32",
+    "profil_navn": "André Heede",
+    "aktiv": true,
+    "match": "auto"
+  },
+  "Chris Reitan": {
+    "profil_id": "ae1834e3-2e82-4619-8372-76e2d04b65d4",
+    "profil_navn": "Christopher Reitan",
+    "aktiv": true,
+    "match": "auto"
+  },
+  "Espen Sørum Hagen": {
+    "profil_id": "4409273c-47f3-49e9-89be-9a7018ebac5c",
+    "profil_navn": "Espen Hagen",
+    "aktiv": true,
+    "match": "manuelt"
+  },
+  "Espen Waldem": {
+    "profil_id": "b2398344-4259-460c-a1b0-53d8a44643b3",
+    "profil_navn": "Espen Waldem",
+    "aktiv": true,
+    "match": "auto"
+  },
+  "Jon Erik Dahl": {
+    "profil_id": "6673601b-c7f4-4c09-929a-3dfaa4d6fdc6",
+    "profil_navn": "Jon Erik Dahl",
+    "aktiv": true,
+    "match": "auto"
+  },
+  "Kenneth Lunde": {
+    "profil_id": "97f2a53f-a386-45d0-b53e-bde46a995767",
+    "profil_navn": "Kenneth Lunde",
+    "aktiv": true,
+    "match": "auto"
+  },
+  "Klas Kristoffer Liland": {
+    "profil_id": "4093f488-8c3c-4daf-a743-c087c74adc6d",
+    "profil_navn": "Klas Kristoffer Liland",
+    "aktiv": true,
+    "match": "auto"
+  },
+  "Kristoffer Benco Arntzen": {
+    "profil_id": "8bf2a096-1807-417f-8fe0-c33ec99d7178",
+    "profil_navn": "Kristoffer Benco Arntzen",
+    "aktiv": true,
+    "match": "auto"
+  },
+  "Michael Johansen": {
+    "profil_id": "82093eaa-0a43-4191-b483-669569745b33",
+    "profil_navn": "Michael Johansen",
+    "aktiv": true,
+    "match": "auto"
+  },
+  "Reidar Haavik": {
+    "profil_id": "ad597350-53e3-47aa-95a5-d207f383ef39",
+    "profil_navn": "Reidar Eik Haavik",
+    "aktiv": true,
+    "match": "auto"
+  },
+  "Øyvind Rekve": {
+    "profil_id": "76801c77-b2db-41cd-ba30-6f55d10729ba",
+    "profil_navn": "Øyvind Rekve",
+    "aktiv": true,
+    "match": "auto"
+  },
+  "Øyvind Verket": {
+    "profil_id": "4accc876-7906-4a48-b73c-a88d0f6d114b",
+    "profil_navn": "Øyvind Verket",
+    "aktiv": true,
+    "match": "auto"
+  }
+}

--- a/scripts/fb-bilder-navn-mapping.mjs
+++ b/scripts/fb-bilder-navn-mapping.mjs
@@ -1,0 +1,56 @@
+// Henter profiles fra Supabase og auto-matcher mot FB-navn fra metadata.
+// Produserer scripts/fb-bilder-navn-mapping.json som Reidar verifiserer/retter.
+//
+// Bruk: node --env-file=.env.local scripts/fb-bilder-navn-mapping.mjs
+
+import { createClient } from '@supabase/supabase-js'
+import { readFileSync, writeFileSync } from 'node:fs'
+
+const URL = process.env.NEXT_PUBLIC_SUPABASE_URL
+const KEY = process.env.SUPABASE_SERVICE_ROLE_KEY
+if (!URL || !KEY) { console.error('Mangler env-vars'); process.exit(1) }
+
+const supabase = createClient(URL, KEY)
+
+const metadata = JSON.parse(readFileSync('scripts/fb-bilder-metadata.json', 'utf8'))
+const navn = new Set()
+for (const m of metadata) {
+  if (m.postet_av) navn.add(m.postet_av)
+  for (const k of (m.kommentarer ?? [])) if (k.navn) navn.add(k.navn)
+}
+
+const { data: profiler, error } = await supabase
+  .from('profiles')
+  .select('id, navn, aktiv')
+  .order('navn')
+
+if (error) { console.error(error); process.exit(1) }
+
+function normaliser(s) {
+  return s.toLowerCase().replace(/\s+/g, ' ').trim()
+}
+
+const mapping = {}
+for (const fbNavn of [...navn].sort()) {
+  const norm = normaliser(fbNavn)
+  // 1) Eksakt match
+  let traff = profiler.find(p => normaliser(p.navn ?? '') === norm)
+  // 2) Inneholder begge fornavn + etternavn
+  if (!traff) {
+    const deler = norm.split(' ')
+    traff = profiler.find(p => {
+      const pn = normaliser(p.navn ?? '')
+      return deler.every(d => pn.includes(d))
+    })
+  }
+  mapping[fbNavn] = traff
+    ? { profil_id: traff.id, profil_navn: traff.navn, aktiv: traff.aktiv, match: 'auto' }
+    : { profil_id: null, profil_navn: null, match: 'INGEN — fyll inn manuelt' }
+}
+
+writeFileSync('scripts/fb-bilder-navn-mapping.json', JSON.stringify(mapping, null, 2))
+console.log(`✓ Skrev scripts/fb-bilder-navn-mapping.json`)
+console.log(`\nMapping (${Object.keys(mapping).length} navn):`)
+for (const [fb, m] of Object.entries(mapping)) {
+  console.log(`  ${fb.padEnd(28)} → ${m.profil_navn ?? '???'}  ${m.profil_id ? '✓' : '✗'}`)
+}

--- a/scripts/fb-bilder-pairing.json
+++ b/scripts/fb-bilder-pairing.json
@@ -1,0 +1,723 @@
+{
+  "par": [
+    {
+      "screenshot_nr": 1,
+      "screenshot": "Skjermbilde 2026-05-14 063627.png",
+      "screenshot_mtime": "2026-05-14T04:36:27.988Z",
+      "bilde_nr": 1,
+      "bilde": "513936824_10171634064405317_8149852453545435986_n.jpg",
+      "bilde_mtime": "2026-05-14T04:35:07.204Z",
+      "diff_sek": 81
+    },
+    {
+      "screenshot_nr": 2,
+      "screenshot": "Skjermbilde 2026-05-14 063652.png",
+      "screenshot_mtime": "2026-05-14T04:36:52.534Z",
+      "bilde_nr": 2,
+      "bilde": "470583759_10170510363820626_6868328802286053130_n.jpg",
+      "bilde_mtime": "2026-05-14T04:35:16.499Z",
+      "diff_sek": 96
+    },
+    {
+      "screenshot_nr": 3,
+      "screenshot": "Skjermbilde 2026-05-14 111120.png",
+      "screenshot_mtime": "2026-05-14T09:11:20.350Z",
+      "bilde_nr": 3,
+      "bilde": "207616084_10165715082540226_1267054822432793292_n.jpg",
+      "bilde_mtime": "2026-05-14T04:37:05.800Z",
+      "diff_sek": 12
+    },
+    {
+      "screenshot_nr": 4,
+      "screenshot": "Skjermbilde 2026-05-14 063736.png",
+      "screenshot_mtime": "2026-05-14T04:37:36.840Z",
+      "bilde_nr": 4,
+      "bilde": "472995892_10170480587275317_8169909547483092892_n.jpg",
+      "bilde_mtime": "2026-05-14T04:37:25.289Z",
+      "diff_sek": 12
+    },
+    {
+      "screenshot_nr": 5,
+      "screenshot": "Skjermbilde 2026-05-14 063754.png",
+      "screenshot_mtime": "2026-05-14T04:37:55.034Z",
+      "bilde_nr": 26,
+      "bilde": "472833938_10170714749640096_7825765805359401361_n.jpg",
+      "bilde_mtime": "2026-05-14T06:37:38.304Z",
+      "diff_sek": -7183
+    },
+    {
+      "screenshot_nr": 6,
+      "screenshot": "Skjermbilde 2026-05-14 063833.png",
+      "screenshot_mtime": "2026-05-14T04:38:33.570Z",
+      "bilde_nr": 5,
+      "bilde": "75392732_10162535023635626_4447293589667446784_n.jpg",
+      "bilde_mtime": "2026-05-14T04:38:20.965Z",
+      "diff_sek": 13
+    },
+    {
+      "screenshot_nr": 7,
+      "screenshot": "Skjermbilde 2026-05-14 063855.png",
+      "screenshot_mtime": "2026-05-14T04:38:55.371Z",
+      "bilde_nr": 6,
+      "bilde": "40133598_10160786366215113_239708481341358080_n.jpg",
+      "bilde_mtime": "2026-05-14T04:38:43.126Z",
+      "diff_sek": 12
+    },
+    {
+      "screenshot_nr": 8,
+      "screenshot": "Skjermbilde 2026-05-14 063908.png",
+      "screenshot_mtime": "2026-05-14T04:39:09.001Z",
+      "bilde_nr": 7,
+      "bilde": "472170357_10170738984755626_2351219374440861825_n.jpg",
+      "bilde_mtime": "2026-05-14T04:39:12.943Z",
+      "diff_sek": -4
+    },
+    {
+      "screenshot_nr": 9,
+      "screenshot": "Skjermbilde 2026-05-14 063926.png",
+      "screenshot_mtime": "2026-05-14T04:39:26.333Z",
+      "bilde_nr": 8,
+      "bilde": "469614292_10169801486285696_1735001105317423278_n.jpg",
+      "bilde_mtime": "2026-05-14T04:39:22.282Z",
+      "diff_sek": 4
+    },
+    {
+      "screenshot_nr": 10,
+      "screenshot": "Skjermbilde 2026-05-14 063945.png",
+      "screenshot_mtime": "2026-05-14T04:39:45.924Z",
+      "bilde_nr": 9,
+      "bilde": "468841672_10170003415665464_4444310879893950981_n.jpg",
+      "bilde_mtime": "2026-05-14T04:39:35.344Z",
+      "diff_sek": 11
+    },
+    {
+      "screenshot_nr": 10,
+      "screenshot": "Skjermbilde 2026-05-14 063945.png",
+      "screenshot_mtime": "2026-05-14T04:39:45.924Z",
+      "bilde_nr": 10,
+      "bilde": "472027737_10170527134715464_7921074026912311111_n.jpg",
+      "bilde_mtime": "2026-05-14T04:39:58.060Z",
+      "diff_sek": -12
+    },
+    {
+      "screenshot_nr": 10,
+      "screenshot": "Skjermbilde 2026-05-14 063945.png",
+      "screenshot_mtime": "2026-05-14T04:39:45.924Z",
+      "bilde_nr": 11,
+      "bilde": "468741380_10170003415625464_4945086347616410337_n.jpg",
+      "bilde_mtime": "2026-05-14T04:40:03.305Z",
+      "diff_sek": -17
+    },
+    {
+      "screenshot_nr": 11,
+      "screenshot": "Skjermbilde 2026-05-14 064019.png",
+      "screenshot_mtime": "2026-05-14T04:40:19.822Z",
+      "bilde_nr": 12,
+      "bilde": "468665243_10169825823750113_5067670262409442372_n.jpg",
+      "bilde_mtime": "2026-05-14T04:40:12.033Z",
+      "diff_sek": 8
+    },
+    {
+      "screenshot_nr": 12,
+      "screenshot": "Skjermbilde 2026-05-14 064033.png",
+      "screenshot_mtime": "2026-05-14T04:40:33.269Z",
+      "bilde_nr": 13,
+      "bilde": "468964054_10169845255245370_1708449074339552897_n.jpg",
+      "bilde_mtime": "2026-05-14T04:40:27.031Z",
+      "diff_sek": 6
+    },
+    {
+      "screenshot_nr": 14,
+      "screenshot": "Skjermbilde 2026-05-14 064054.png",
+      "screenshot_mtime": "2026-05-14T04:40:54.931Z",
+      "bilde_nr": 14,
+      "bilde": "468963745_10169845254575370_6869727369567777523_n.jpg",
+      "bilde_mtime": "2026-05-14T04:40:43.267Z",
+      "diff_sek": 12
+    },
+    {
+      "screenshot_nr": 15,
+      "screenshot": "Skjermbilde 2026-05-14 064112.png",
+      "screenshot_mtime": "2026-05-14T04:41:12.218Z",
+      "bilde_nr": 15,
+      "bilde": "468526434_10161817010036368_8282172887727775070_n.jpg",
+      "bilde_mtime": "2026-05-14T04:41:02.698Z",
+      "diff_sek": 10
+    },
+    {
+      "screenshot_nr": 16,
+      "screenshot": "Skjermbilde 2026-05-14 064121.png",
+      "screenshot_mtime": "2026-05-14T04:41:22.090Z",
+      "bilde_nr": 16,
+      "bilde": "468568689_10161817008696368_8839644318772214941_n.jpg",
+      "bilde_mtime": "2026-05-14T04:41:17.447Z",
+      "diff_sek": 5
+    },
+    {
+      "screenshot_nr": 16,
+      "screenshot": "Skjermbilde 2026-05-14 064121.png",
+      "screenshot_mtime": "2026-05-14T04:41:22.090Z",
+      "bilde_nr": 17,
+      "bilde": "468496612_10161817008691368_2383094503811365159_n.jpg",
+      "bilde_mtime": "2026-05-14T04:41:27.812Z",
+      "diff_sek": -6
+    },
+    {
+      "screenshot_nr": 16,
+      "screenshot": "Skjermbilde 2026-05-14 064121.png",
+      "screenshot_mtime": "2026-05-14T04:41:22.090Z",
+      "bilde_nr": 18,
+      "bilde": "468459837_10161817008656368_7271076194809599240_n.jpg",
+      "bilde_mtime": "2026-05-14T04:41:31.998Z",
+      "diff_sek": -10
+    },
+    {
+      "screenshot_nr": 17,
+      "screenshot": "Skjermbilde 2026-05-14 064144.png",
+      "screenshot_mtime": "2026-05-14T04:41:44.558Z",
+      "bilde_nr": 19,
+      "bilde": "473019028_10170293689990696_8627677788363977487_n.jpg",
+      "bilde_mtime": "2026-05-14T04:41:47.780Z",
+      "diff_sek": -3
+    },
+    {
+      "screenshot_nr": 18,
+      "screenshot": "Skjermbilde 2026-05-14 064157.png",
+      "screenshot_mtime": "2026-05-14T04:41:58.076Z",
+      "bilde_nr": 20,
+      "bilde": "470207513_10169851916900696_3070902161453074898_n.jpg",
+      "bilde_mtime": "2026-05-14T04:41:54.679Z",
+      "diff_sek": 3
+    },
+    {
+      "screenshot_nr": 19,
+      "screenshot": "Skjermbilde 2026-05-14 064212.png",
+      "screenshot_mtime": "2026-05-14T04:42:12.434Z",
+      "bilde_nr": 21,
+      "bilde": "472327830_10170716182060626_7975648651640544702_n.jpg",
+      "bilde_mtime": "2026-05-14T04:42:04.878Z",
+      "diff_sek": 8
+    },
+    {
+      "screenshot_nr": 20,
+      "screenshot": "Skjermbilde 2026-05-14 064241.png",
+      "screenshot_mtime": "2026-05-14T04:42:41.935Z",
+      "bilde_nr": 22,
+      "bilde": "472848654_10170272300575696_8956102802779641044_n.jpg",
+      "bilde_mtime": "2026-05-14T04:42:36.161Z",
+      "diff_sek": 6
+    },
+    {
+      "screenshot_nr": 21,
+      "screenshot": "Skjermbilde 2026-05-14 064305.png",
+      "screenshot_mtime": "2026-05-14T04:43:05.437Z",
+      "bilde_nr": 23,
+      "bilde": "468399174_10170275252275226_7190338394014570128_n.jpg",
+      "bilde_mtime": "2026-05-14T04:42:58.094Z",
+      "diff_sek": 7
+    },
+    {
+      "screenshot_nr": 22,
+      "screenshot": "Skjermbilde 2026-05-14 064351.png",
+      "screenshot_mtime": "2026-05-14T04:43:51.439Z",
+      "bilde_nr": 24,
+      "bilde": "468284967_10170274620315226_7717431427819465511_n.jpg",
+      "bilde_mtime": "2026-05-14T04:43:43.954Z",
+      "diff_sek": 7
+    },
+    {
+      "screenshot_nr": 23,
+      "screenshot": "Skjermbilde 2026-05-14 064415.png",
+      "screenshot_mtime": "2026-05-14T04:44:15.290Z",
+      "bilde_nr": 25,
+      "bilde": "468205228_10170274616800226_5387154595722121418_n.jpg",
+      "bilde_mtime": "2026-05-14T04:43:59.374Z",
+      "diff_sek": 16
+    },
+    {
+      "screenshot_nr": 24,
+      "screenshot": "Skjermbilde 2026-05-14 085008.png",
+      "screenshot_mtime": "2026-05-14T06:50:08.374Z",
+      "bilde_nr": 27,
+      "bilde": "468546912_10170023961465626_1974895974601579098_n.jpg",
+      "bilde_mtime": "2026-05-14T06:49:59.008Z",
+      "diff_sek": 9
+    },
+    {
+      "screenshot_nr": 25,
+      "screenshot": "Skjermbilde 2026-05-14 085023.png",
+      "screenshot_mtime": "2026-05-14T06:50:23.617Z",
+      "bilde_nr": 28,
+      "bilde": "468042786_10169904888265626_7424129223818364482_n.jpg",
+      "bilde_mtime": "2026-05-14T06:50:14.971Z",
+      "diff_sek": 9
+    },
+    {
+      "screenshot_nr": 26,
+      "screenshot": "Skjermbilde 2026-05-14 085043.png",
+      "screenshot_mtime": "2026-05-14T06:50:43.855Z",
+      "bilde_nr": 29,
+      "bilde": "473657432_10170911564250626_3357151237299040991_n.jpg",
+      "bilde_mtime": "2026-05-14T06:50:36.739Z",
+      "diff_sek": 7
+    },
+    {
+      "screenshot_nr": 27,
+      "screenshot": "Skjermbilde 2026-05-14 085059.png",
+      "screenshot_mtime": "2026-05-14T06:51:00.013Z",
+      "bilde_nr": 30,
+      "bilde": "468597536_10169840290925370_5685652838756870002_n.jpg",
+      "bilde_mtime": "2026-05-14T06:50:52.831Z",
+      "diff_sek": 7
+    },
+    {
+      "screenshot_nr": 28,
+      "screenshot": "Skjermbilde 2026-05-14 085116.png",
+      "screenshot_mtime": "2026-05-14T06:51:16.470Z",
+      "bilde_nr": 31,
+      "bilde": "472989729_10170549701280317_1398779810565515323_n.jpg",
+      "bilde_mtime": "2026-05-14T06:51:11.107Z",
+      "diff_sek": 5
+    },
+    {
+      "screenshot_nr": 29,
+      "screenshot": "Skjermbilde 2026-05-14 085126.png",
+      "screenshot_mtime": "2026-05-14T06:51:26.497Z",
+      "bilde_nr": 32,
+      "bilde": "470204415_10170130107390297_9200493019667618799_n.jpg",
+      "bilde_mtime": "2026-05-14T06:51:20.393Z",
+      "diff_sek": 6
+    },
+    {
+      "screenshot_nr": 30,
+      "screenshot": "Skjermbilde 2026-05-14 085154.png",
+      "screenshot_mtime": "2026-05-14T06:51:54.828Z",
+      "bilde_nr": 33,
+      "bilde": "470214464_10170106745765297_6900551415671284136_n.jpg",
+      "bilde_mtime": "2026-05-14T06:51:47.923Z",
+      "diff_sek": 7
+    },
+    {
+      "screenshot_nr": 31,
+      "screenshot": "Skjermbilde 2026-05-14 085203.png",
+      "screenshot_mtime": "2026-05-14T06:52:03.906Z",
+      "bilde_nr": 34,
+      "bilde": "472744758_10170498287515317_7373605628117300606_n.jpg",
+      "bilde_mtime": "2026-05-14T06:51:59.588Z",
+      "diff_sek": 4
+    },
+    {
+      "screenshot_nr": 32,
+      "screenshot": "Skjermbilde 2026-05-14 085215.png",
+      "screenshot_mtime": "2026-05-14T06:52:15.871Z",
+      "bilde_nr": 35,
+      "bilde": "473165819_10170504444200297_2545909050171481490_n.jpg",
+      "bilde_mtime": "2026-05-14T06:52:09.005Z",
+      "diff_sek": 7
+    },
+    {
+      "screenshot_nr": 33,
+      "screenshot": "Skjermbilde 2026-05-14 085231.png",
+      "screenshot_mtime": "2026-05-14T06:52:31.162Z",
+      "bilde_nr": 36,
+      "bilde": "472913576_10170497559555317_582184138924698425_n.jpg",
+      "bilde_mtime": "2026-05-14T06:52:24.738Z",
+      "diff_sek": 6
+    },
+    {
+      "screenshot_nr": 34,
+      "screenshot": "Skjermbilde 2026-05-14 085241.png",
+      "screenshot_mtime": "2026-05-14T06:52:41.443Z",
+      "bilde_nr": 37,
+      "bilde": "472876311_10170497623190317_6387856711755553460_n.jpg",
+      "bilde_mtime": "2026-05-14T06:52:35.977Z",
+      "diff_sek": 5
+    },
+    {
+      "screenshot_nr": 35,
+      "screenshot": "Skjermbilde 2026-05-14 085303.png",
+      "screenshot_mtime": "2026-05-14T06:53:03.688Z",
+      "bilde_nr": 38,
+      "bilde": "469811742_10170082468525297_4498419575386491419_n.jpg",
+      "bilde_mtime": "2026-05-14T06:52:55.587Z",
+      "diff_sek": 8
+    },
+    {
+      "screenshot_nr": 36,
+      "screenshot": "Skjermbilde 2026-05-14 085317.png",
+      "screenshot_mtime": "2026-05-14T06:53:17.527Z",
+      "bilde_nr": 39,
+      "bilde": "472098467_10170439595315113_7842281758487874526_n.jpg",
+      "bilde_mtime": "2026-05-14T06:53:08.848Z",
+      "diff_sek": 9
+    },
+    {
+      "screenshot_nr": 37,
+      "screenshot": "Skjermbilde 2026-05-14 085331.png",
+      "screenshot_mtime": "2026-05-14T06:53:31.582Z",
+      "bilde_nr": 40,
+      "bilde": "468311580_10170275955440226_7492536933205911086_n.jpg",
+      "bilde_mtime": "2026-05-14T06:53:22.898Z",
+      "diff_sek": 9
+    },
+    {
+      "screenshot_nr": 38,
+      "screenshot": "Skjermbilde 2026-05-14 085350.png",
+      "screenshot_mtime": "2026-05-14T06:53:50.239Z",
+      "bilde_nr": 41,
+      "bilde": "469156381_10169951257645370_2240540405814531238_n.jpg",
+      "bilde_mtime": "2026-05-14T06:53:42.762Z",
+      "diff_sek": 7
+    },
+    {
+      "screenshot_nr": 39,
+      "screenshot": "Skjermbilde 2026-05-14 085401.png",
+      "screenshot_mtime": "2026-05-14T06:54:01.616Z",
+      "bilde_nr": 42,
+      "bilde": "474037233_10170580987495297_7964515424150398530_n.jpg",
+      "bilde_mtime": "2026-05-14T06:53:55.716Z",
+      "diff_sek": 6
+    },
+    {
+      "screenshot_nr": 40,
+      "screenshot": "Skjermbilde 2026-05-14 085422.png",
+      "screenshot_mtime": "2026-05-14T06:54:22.738Z",
+      "bilde_nr": 43,
+      "bilde": "518658037_10162919427611368_3847170441472136023_n.jpg",
+      "bilde_mtime": "2026-05-14T06:54:13.422Z",
+      "diff_sek": 9
+    },
+    {
+      "screenshot_nr": 41,
+      "screenshot": "Skjermbilde 2026-05-14 085436.png",
+      "screenshot_mtime": "2026-05-14T06:54:36.930Z",
+      "bilde_nr": 44,
+      "bilde": "520476255_10162919427886368_8804124244684399291_n.jpg",
+      "bilde_mtime": "2026-05-14T06:54:28.629Z",
+      "diff_sek": 8
+    },
+    {
+      "screenshot_nr": 42,
+      "screenshot": "Skjermbilde 2026-05-14 085447.png",
+      "screenshot_mtime": "2026-05-14T06:54:47.890Z",
+      "bilde_nr": 45,
+      "bilde": "519395762_10162919427986368_2365358503468583542_n.jpg",
+      "bilde_mtime": "2026-05-14T06:54:41.997Z",
+      "diff_sek": 6
+    },
+    {
+      "screenshot_nr": 43,
+      "screenshot": "Skjermbilde 2026-05-14 085458.png",
+      "screenshot_mtime": "2026-05-14T06:54:58.750Z",
+      "bilde_nr": 46,
+      "bilde": "518314111_10162919428076368_2472337784645710054_n.jpg",
+      "bilde_mtime": "2026-05-14T06:54:52.368Z",
+      "diff_sek": 6
+    },
+    {
+      "screenshot_nr": 44,
+      "screenshot": "Skjermbilde 2026-05-14 085508.png",
+      "screenshot_mtime": "2026-05-14T06:55:08.262Z",
+      "bilde_nr": 47,
+      "bilde": "518314818_10162919427936368_8239745519008611795_n.jpg",
+      "bilde_mtime": "2026-05-14T06:55:03.200Z",
+      "diff_sek": 5
+    },
+    {
+      "screenshot_nr": 45,
+      "screenshot": "Skjermbilde 2026-05-14 085518.png",
+      "screenshot_mtime": "2026-05-14T06:55:19.135Z",
+      "bilde_nr": 48,
+      "bilde": "518435350_10162919427616368_5558791084309264020_n.jpg",
+      "bilde_mtime": "2026-05-14T06:55:13.258Z",
+      "diff_sek": 6
+    },
+    {
+      "screenshot_nr": 46,
+      "screenshot": "Skjermbilde 2026-05-14 085528.png",
+      "screenshot_mtime": "2026-05-14T06:55:29.116Z",
+      "bilde_nr": 49,
+      "bilde": "519004626_10162919427606368_216200332465866816_n.jpg",
+      "bilde_mtime": "2026-05-14T06:55:23.854Z",
+      "diff_sek": 5
+    },
+    {
+      "screenshot_nr": 47,
+      "screenshot": "Skjermbilde 2026-05-14 085541.png",
+      "screenshot_mtime": "2026-05-14T06:55:41.776Z",
+      "bilde_nr": 50,
+      "bilde": "518320949_10162918875406368_5800396639740064618_n.jpg",
+      "bilde_mtime": "2026-05-14T06:55:36.829Z",
+      "diff_sek": 5
+    },
+    {
+      "screenshot_nr": 48,
+      "screenshot": "Skjermbilde 2026-05-14 085551.png",
+      "screenshot_mtime": "2026-05-14T06:55:51.968Z",
+      "bilde_nr": 51,
+      "bilde": "520836923_10162918874856368_485771287725791650_n.jpg",
+      "bilde_mtime": "2026-05-14T06:55:46.499Z",
+      "diff_sek": 5
+    },
+    {
+      "screenshot_nr": 49,
+      "screenshot": "Skjermbilde 2026-05-14 085603.png",
+      "screenshot_mtime": "2026-05-14T06:56:03.756Z",
+      "bilde_nr": 52,
+      "bilde": "519723443_10162918875146368_935026746537238667_n.jpg",
+      "bilde_mtime": "2026-05-14T06:55:58.051Z",
+      "diff_sek": 6
+    },
+    {
+      "screenshot_nr": 50,
+      "screenshot": "Skjermbilde 2026-05-14 085613.png",
+      "screenshot_mtime": "2026-05-14T06:56:13.563Z",
+      "bilde_nr": 53,
+      "bilde": "518578916_10162918875371368_821995706893352632_n.jpg",
+      "bilde_mtime": "2026-05-14T06:56:08.606Z",
+      "diff_sek": 5
+    },
+    {
+      "screenshot_nr": 51,
+      "screenshot": "Skjermbilde 2026-05-14 085622.png",
+      "screenshot_mtime": "2026-05-14T06:56:23.185Z",
+      "bilde_nr": 54,
+      "bilde": "518147005_10162918875061368_1477369775922750608_n.jpg",
+      "bilde_mtime": "2026-05-14T06:56:18.321Z",
+      "diff_sek": 5
+    },
+    {
+      "screenshot_nr": 52,
+      "screenshot": "Skjermbilde 2026-05-14 085631.png",
+      "screenshot_mtime": "2026-05-14T06:56:32.152Z",
+      "bilde_nr": 55,
+      "bilde": "518313093_10162918875456368_1348643235867528697_n.jpg",
+      "bilde_mtime": "2026-05-14T06:56:27.551Z",
+      "diff_sek": 5
+    },
+    {
+      "screenshot_nr": 53,
+      "screenshot": "Skjermbilde 2026-05-14 085642.png",
+      "screenshot_mtime": "2026-05-14T06:56:42.727Z",
+      "bilde_nr": 56,
+      "bilde": "518803319_10162918875046368_350116659518989438_n.jpg",
+      "bilde_mtime": "2026-05-14T06:56:36.558Z",
+      "diff_sek": 6
+    },
+    {
+      "screenshot_nr": 54,
+      "screenshot": "Skjermbilde 2026-05-14 085656.png",
+      "screenshot_mtime": "2026-05-14T06:56:57.105Z",
+      "bilde_nr": 57,
+      "bilde": "518582873_10162918875026368_610420821859682360_n.jpg",
+      "bilde_mtime": "2026-05-14T06:56:51.428Z",
+      "diff_sek": 6
+    },
+    {
+      "screenshot_nr": 55,
+      "screenshot": "Skjermbilde 2026-05-14 085707.png",
+      "screenshot_mtime": "2026-05-14T06:57:07.545Z",
+      "bilde_nr": 58,
+      "bilde": "518591262_10162918875286368_156734218321498286_n.jpg",
+      "bilde_mtime": "2026-05-14T06:57:02.115Z",
+      "diff_sek": 5
+    },
+    {
+      "screenshot_nr": 56,
+      "screenshot": "Skjermbilde 2026-05-14 085716.png",
+      "screenshot_mtime": "2026-05-14T06:57:16.745Z",
+      "bilde_nr": 59,
+      "bilde": "520228537_10162918875471368_8693685300745149099_n.jpg",
+      "bilde_mtime": "2026-05-14T06:57:11.986Z",
+      "diff_sek": 5
+    },
+    {
+      "screenshot_nr": 57,
+      "screenshot": "Skjermbilde 2026-05-14 085726.png",
+      "screenshot_mtime": "2026-05-14T06:57:26.876Z",
+      "bilde_nr": 60,
+      "bilde": "472179447_10170550551290464_20389259500477410_n.jpg",
+      "bilde_mtime": "2026-05-14T06:57:22.557Z",
+      "diff_sek": 4
+    },
+    {
+      "screenshot_nr": 58,
+      "screenshot": "Skjermbilde 2026-05-14 085735.png",
+      "screenshot_mtime": "2026-05-14T06:57:35.969Z",
+      "bilde_nr": 61,
+      "bilde": "472119935_10170550547600464_736685527438663604_n.jpg",
+      "bilde_mtime": "2026-05-14T06:57:31.245Z",
+      "diff_sek": 5
+    },
+    {
+      "screenshot_nr": 59,
+      "screenshot": "Skjermbilde 2026-05-14 085750.png",
+      "screenshot_mtime": "2026-05-14T06:57:50.366Z",
+      "bilde_nr": 62,
+      "bilde": "468856451_10170055900330464_436059343400849049_n.jpg",
+      "bilde_mtime": "2026-05-14T06:57:43.199Z",
+      "diff_sek": 7
+    },
+    {
+      "screenshot_nr": 60,
+      "screenshot": "Skjermbilde 2026-05-14 085759.png",
+      "screenshot_mtime": "2026-05-14T06:58:00.100Z",
+      "bilde_nr": 63,
+      "bilde": "472224837_10170550519000464_595659400939509453_n.jpg",
+      "bilde_mtime": "2026-05-14T06:57:56.007Z",
+      "diff_sek": 4
+    },
+    {
+      "screenshot_nr": 61,
+      "screenshot": "Skjermbilde 2026-05-14 085809.png",
+      "screenshot_mtime": "2026-05-14T06:58:10.061Z",
+      "bilde_nr": 64,
+      "bilde": "472104457_10170550549540464_7228763410115619249_n.jpg",
+      "bilde_mtime": "2026-05-14T06:58:04.921Z",
+      "diff_sek": 5
+    },
+    {
+      "screenshot_nr": 62,
+      "screenshot": "Skjermbilde 2026-05-14 111252.png",
+      "screenshot_mtime": "2026-05-14T09:12:52.379Z",
+      "bilde_nr": 65,
+      "bilde": "468420539_10169944412665096_2192487242058145001_n.jpg",
+      "bilde_mtime": "2026-05-14T06:58:16.922Z",
+      "diff_sek": 7
+    },
+    {
+      "screenshot_nr": 63,
+      "screenshot": "Skjermbilde 2026-05-14 085834.png",
+      "screenshot_mtime": "2026-05-14T06:58:34.277Z",
+      "bilde_nr": 66,
+      "bilde": "468443389_10169944412690096_3869888267080914533_n.jpg",
+      "bilde_mtime": "2026-05-14T06:58:28.771Z",
+      "diff_sek": 6
+    },
+    {
+      "screenshot_nr": 64,
+      "screenshot": "Skjermbilde 2026-05-14 085847.png",
+      "screenshot_mtime": "2026-05-14T06:58:47.868Z",
+      "bilde_nr": 67,
+      "bilde": "468623550_10169944412680096_7274017795925705100_n.jpg",
+      "bilde_mtime": "2026-05-14T06:58:41.645Z",
+      "diff_sek": 6
+    },
+    {
+      "screenshot_nr": 65,
+      "screenshot": "Skjermbilde 2026-05-14 085857.png",
+      "screenshot_mtime": "2026-05-14T06:58:58.081Z",
+      "bilde_nr": 68,
+      "bilde": "468357307_10169944412695096_1344239155219180584_n.jpg",
+      "bilde_mtime": "2026-05-14T06:58:52.132Z",
+      "diff_sek": 6
+    },
+    {
+      "screenshot_nr": 66,
+      "screenshot": "Skjermbilde 2026-05-14 085907.png",
+      "screenshot_mtime": "2026-05-14T06:59:07.719Z",
+      "bilde_nr": 69,
+      "bilde": "468222418_10169944412710096_3369296609782977880_n.jpg",
+      "bilde_mtime": "2026-05-14T06:59:02.208Z",
+      "diff_sek": 6
+    },
+    {
+      "screenshot_nr": 67,
+      "screenshot": "Skjermbilde 2026-05-14 085916.png",
+      "screenshot_mtime": "2026-05-14T06:59:16.907Z",
+      "bilde_nr": 70,
+      "bilde": "468358468_10169944407490096_231703184139795518_n.jpg",
+      "bilde_mtime": "2026-05-14T06:59:12.143Z",
+      "diff_sek": 5
+    },
+    {
+      "screenshot_nr": 68,
+      "screenshot": "Skjermbilde 2026-05-14 085933.png",
+      "screenshot_mtime": "2026-05-14T06:59:33.192Z",
+      "bilde_nr": 71,
+      "bilde": "468357999_10169944407495096_5943155274355686811_n.jpg",
+      "bilde_mtime": "2026-05-14T06:59:28.065Z",
+      "diff_sek": 5
+    },
+    {
+      "screenshot_nr": 69,
+      "screenshot": "Skjermbilde 2026-05-14 085941.png",
+      "screenshot_mtime": "2026-05-14T06:59:41.890Z",
+      "bilde_nr": 72,
+      "bilde": "468391613_10169944407485096_8618045998776258624_n.jpg",
+      "bilde_mtime": "2026-05-14T06:59:37.994Z",
+      "diff_sek": 4
+    },
+    {
+      "screenshot_nr": 70,
+      "screenshot": "Skjermbilde 2026-05-14 085956.png",
+      "screenshot_mtime": "2026-05-14T06:59:56.757Z",
+      "bilde_nr": 73,
+      "bilde": "468388093_10169944407470096_1212063591183753932_n.jpg",
+      "bilde_mtime": "2026-05-14T06:59:47.841Z",
+      "diff_sek": 9
+    },
+    {
+      "screenshot_nr": 71,
+      "screenshot": "Skjermbilde 2026-05-14 090005.png",
+      "screenshot_mtime": "2026-05-14T07:00:06.102Z",
+      "bilde_nr": 74,
+      "bilde": "468358024_10169944407475096_1520356219861115183_n.jpg",
+      "bilde_mtime": "2026-05-14T07:00:02.180Z",
+      "diff_sek": 4
+    },
+    {
+      "screenshot_nr": 72,
+      "screenshot": "Skjermbilde 2026-05-14 090017.png",
+      "screenshot_mtime": "2026-05-14T07:00:17.298Z",
+      "bilde_nr": 75,
+      "bilde": "468406279_10169944402200096_8662440642849756064_n.jpg",
+      "bilde_mtime": "2026-05-14T07:00:11.687Z",
+      "diff_sek": 6
+    },
+    {
+      "screenshot_nr": 73,
+      "screenshot": "Skjermbilde 2026-05-14 090032.png",
+      "screenshot_mtime": "2026-05-14T07:00:32.342Z",
+      "bilde_nr": 76,
+      "bilde": "468399892_10169944402165096_277228747751722778_n.jpg",
+      "bilde_mtime": "2026-05-14T07:00:22.464Z",
+      "diff_sek": 10
+    },
+    {
+      "screenshot_nr": 74,
+      "screenshot": "Skjermbilde 2026-05-14 090041.png",
+      "screenshot_mtime": "2026-05-14T07:00:42.110Z",
+      "bilde_nr": 77,
+      "bilde": "468480465_10169944400875096_7231026925742004139_n.jpg",
+      "bilde_mtime": "2026-05-14T07:00:37.815Z",
+      "diff_sek": 4
+    },
+    {
+      "screenshot_nr": 75,
+      "screenshot": "Skjermbilde 2026-05-14 090052.png",
+      "screenshot_mtime": "2026-05-14T07:00:52.291Z",
+      "bilde_nr": 78,
+      "bilde": "468358032_10169944400860096_2179309298273507387_n.jpg",
+      "bilde_mtime": "2026-05-14T07:00:47.588Z",
+      "diff_sek": 5
+    },
+    {
+      "screenshot_nr": 76,
+      "screenshot": "Skjermbilde 2026-05-14 090100.png",
+      "screenshot_mtime": "2026-05-14T07:01:00.637Z",
+      "bilde_nr": 79,
+      "bilde": "468332682_10169944400870096_607451437907088496_n.jpg",
+      "bilde_mtime": "2026-05-14T07:00:56.389Z",
+      "diff_sek": 4
+    }
+  ],
+  "ikke_parede_bilder": [],
+  "ikke_parede_screenshots": [
+    {
+      "screenshot_nr": 13,
+      "screenshot": "Skjermbilde 2026-05-14 064046.png",
+      "screenshot_mtime": "2026-05-14T04:40:46.124Z"
+    }
+  ]
+}

--- a/scripts/fb-bilder-pairing.mjs
+++ b/scripts/fb-bilder-pairing.mjs
@@ -1,0 +1,135 @@
+// Pairing-HTML for FB-bilder + screenshots.
+//
+// Strategi: bildet lastes ned ~10 sek FØR screenshotten tas. For hver
+// screenshot finner vi den nærmeste foregående bilde-filen som ikke alt
+// er paret. Genererer en HTML der Reidar visuelt kan verifisere parene
+// + en JSON som kan redigeres manuelt.
+//
+// Bruk:  node scripts/fb-bilder-pairing.mjs
+
+import { readdirSync, statSync, writeFileSync, copyFileSync, mkdirSync, existsSync, rmSync } from 'node:fs'
+import { join, basename, extname } from 'node:path'
+
+const BILDER_DIR = 'C:/Users/reida/Pictures'
+const SCREENSHOTS_DIR = 'C:/Users/reida/Pictures/Screenshots'
+const PREVIEW_DIR = 'scripts/fb-bilder-preview'
+const HTML_OUT = 'scripts/fb-bilder-pairing.html'
+const JSON_OUT = 'scripts/fb-bilder-pairing.json'
+
+// Filnavn å ekskludere — app-ikoner, ikke FB-innhold
+const EKSKLUDER = ['icon-192.png', 'icon-192n.png']
+
+function listFiler(dir, predicate) {
+  return readdirSync(dir)
+    .filter(f => predicate(f))
+    .filter(f => !EKSKLUDER.includes(f))
+    .map(f => {
+      const full = join(dir, f)
+      return { navn: f, full, mtime: statSync(full).mtime }
+    })
+    .sort((a, b) => a.mtime - b.mtime)
+}
+
+const bilder = listFiler(BILDER_DIR, f => /\.(jpe?g|png)$/i.test(f) && !f.startsWith('Skjermbilde') && !f.startsWith('_crop'))
+const screenshots = listFiler(SCREENSHOTS_DIR, f => /^Skjermbilde.*\.png$/i.test(f))
+
+// Algoritme: for hver screenshot, ta nyeste ikke-parede bilde med mtime < screenshot.mtime
+// Tildel løpenumre i kronologisk rekkefølge (samme rekkefølge som listene
+// allerede er sortert i — eldst først). Reidar bruker disse numrene når
+// han retter parringen: "bilde 2 skal pares med screenshot 3".
+const bildeNr = new Map(bilder.map((b, i) => [b.navn, i + 1]))
+const screenshotNr = new Map(screenshots.map((s, i) => [s.navn, i + 1]))
+
+const usedBilder = new Set()
+const par = []
+for (const ss of screenshots) {
+  const kandidater = bilder
+    .filter(b => !usedBilder.has(b.navn) && b.mtime < ss.mtime)
+    .sort((a, b) => b.mtime - a.mtime)
+  const valgt = kandidater[0] ?? null
+  if (valgt) usedBilder.add(valgt.navn)
+  par.push({
+    screenshot_nr: screenshotNr.get(ss.navn),
+    screenshot: ss.navn,
+    screenshot_mtime: ss.mtime.toISOString(),
+    bilde_nr: valgt ? bildeNr.get(valgt.navn) : null,
+    bilde: valgt?.navn ?? null,
+    bilde_mtime: valgt?.mtime.toISOString() ?? null,
+    diff_sek: valgt ? Math.round((ss.mtime - valgt.mtime) / 1000) : null,
+  })
+}
+
+const ikkeParede = bilder.filter(b => !usedBilder.has(b.navn))
+
+// Kopier til preview-mappe (relative paths i HTML)
+if (existsSync(PREVIEW_DIR)) rmSync(PREVIEW_DIR, { recursive: true })
+mkdirSync(PREVIEW_DIR, { recursive: true })
+for (const b of bilder) copyFileSync(b.full, join(PREVIEW_DIR, b.navn))
+for (const s of screenshots) copyFileSync(s.full, join(PREVIEW_DIR, s.navn))
+
+// JSON-output
+writeFileSync(JSON_OUT, JSON.stringify({ par, ikke_parede_bilder: ikkeParede.map(b => b.navn) }, null, 2), 'utf8')
+
+// HTML-output
+const rader = par.map(p => `
+<tr>
+  <td>${p.bilde_nr != null ? `<strong style="font-size:22px">bilde ${p.bilde_nr}</strong>` : '—'}<br>
+      ${p.bilde ? `<img src="fb-bilder-preview/${p.bilde}" loading="lazy"><br><code>${p.bilde}</code>` : '<em style="color:red">INGEN BILDE FUNNET</em>'}</td>
+  <td><strong style="font-size:22px">screenshot ${p.screenshot_nr}</strong><br>
+      <img src="fb-bilder-preview/${p.screenshot}" loading="lazy"><br><code>${p.screenshot}</code></td>
+  <td><small>diff: ${p.diff_sek ?? '?'} sek<br>ss: ${p.screenshot_mtime}<br>b: ${p.bilde_mtime ?? '-'}</small></td>
+</tr>`).join('')
+
+const ikkeParedeRader = ikkeParede.map(b => `
+<tr>
+  <td><strong style="font-size:22px">bilde ${bildeNr.get(b.navn)}</strong><br>
+      <img src="fb-bilder-preview/${b.navn}" loading="lazy"><br><code>${b.navn}</code></td>
+  <td><small>${b.mtime.toISOString()}</small></td>
+</tr>`).join('')
+
+const html = `<!doctype html>
+<html lang="nb">
+<head>
+<meta charset="utf-8">
+<title>FB-bilder pairing — visuell verifikasjon</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 0; padding: 20px; background: #fafafa; color: #222; }
+  h1 { font-size: 18px; }
+  table { width: 100%; border-collapse: collapse; background: white; }
+  th, td { border: 1px solid #ddd; padding: 8px; vertical-align: top; text-align: left; }
+  th { background: #eee; position: sticky; top: 0; }
+  img { max-width: 380px; max-height: 280px; display: block; }
+  code { font-size: 11px; color: #555; word-break: break-all; }
+  small { font-size: 10px; color: #666; }
+  .merknad { background: #fff3cd; padding: 12px; border: 1px solid #ffc107; border-radius: 4px; margin-bottom: 20px; }
+</style>
+</head>
+<body>
+<h1>FB-bilder pairing — ${par.length} par, ${ikkeParede.length} ikke-parede bilder</h1>
+
+<div class="merknad">
+  <strong>Slik:</strong> Scroll gjennom og verifiser at hvert bilde matcher screenshoten ved siden av (samme motiv synlig i screenshot-en).
+  Hvis et par er feil — si f.eks. «bilde 7 skal pares med screenshot 9». Ikke-parede bilder vises nederst.
+</div>
+
+<table>
+<thead><tr><th>Bilde (FB-original)</th><th>Screenshot (med kommentarer)</th><th>Tidspunkter</th></tr></thead>
+<tbody>${rader}</tbody>
+</table>
+
+${ikkeParede.length ? `
+<h2 style="margin-top:30px">Ikke-parede bilder (${ikkeParede.length})</h2>
+<table>
+<thead><tr><th>Bilde</th><th>Tidspunkt</th></tr></thead>
+<tbody>${ikkeParedeRader}</tbody>
+</table>` : ''}
+
+</body></html>`
+
+writeFileSync(HTML_OUT, html, 'utf8')
+
+console.log(`✓ ${par.length} par foreslått`)
+console.log(`✓ ${ikkeParede.length} ikke-parede bilder`)
+console.log(`✓ HTML: ${HTML_OUT}`)
+console.log(`✓ JSON: ${JSON_OUT}`)
+console.log(`\nÅpne ${HTML_OUT} i nettleser for visuell verifikasjon.`)

--- a/scripts/fb-bilder-render.mjs
+++ b/scripts/fb-bilder-render.mjs
@@ -1,0 +1,82 @@
+// Renderer fb-bilder-pairing.html fra fb-bilder-pairing.json.
+// Kjør etter manuelle bytter med fb-bilder-bytt.mjs.
+//
+// Bruk:  node scripts/fb-bilder-render.mjs
+
+import { readFileSync, writeFileSync } from 'node:fs'
+
+const JSON_FIL = 'scripts/fb-bilder-pairing.json'
+const HTML_OUT = 'scripts/fb-bilder-pairing.html'
+
+const data = JSON.parse(readFileSync(JSON_FIL, 'utf8'))
+const par = data.par
+const ikkeParedeBilder = data.ikke_parede_bilder ?? []
+const ikkeParedeScreenshots = data.ikke_parede_screenshots ?? []
+
+// Grupper par på screenshot_nr — flere bilder pr screenshot er lov
+const grupper = new Map()
+for (const p of par) {
+  if (!grupper.has(p.screenshot_nr)) grupper.set(p.screenshot_nr, { screenshot: p, bilder: [] })
+  grupper.get(p.screenshot_nr).bilder.push(p)
+}
+
+const rader = [...grupper.values()].map(g => {
+  const bilderHtml = g.bilder.map(p => `
+    <div style="margin-bottom:8px">
+      <strong style="font-size:20px">bilde ${p.bilde_nr}</strong>
+      <small style="color:#888"> (diff ${p.diff_sek ?? '?'}s)</small><br>
+      <img src="fb-bilder-preview/${p.bilde}" loading="lazy"><br>
+      <code>${p.bilde}</code>
+    </div>`).join('')
+  return `<tr>
+  <td>${bilderHtml}</td>
+  <td><strong style="font-size:22px">screenshot ${g.screenshot.screenshot_nr}</strong><br>
+      <img src="fb-bilder-preview/${g.screenshot.screenshot}" loading="lazy"><br><code>${g.screenshot.screenshot}</code></td>
+  <td><small>ss: ${g.screenshot.screenshot_mtime}<br>antall bilder: ${g.bilder.length}</small></td>
+</tr>`
+}).join('')
+
+const ikkeParedeBilderRader = ikkeParedeBilder.map(o => {
+  const navn = typeof o === 'string' ? o : o.navn
+  const nr = typeof o === 'string' ? null : o.bilde_nr
+  return `<tr>
+  <td>${nr != null ? `<strong style="font-size:18px">bilde ${nr}</strong><br>` : ''}
+      <img src="fb-bilder-preview/${navn}" loading="lazy"><br><code>${navn}</code></td>
+</tr>`
+}).join('')
+
+const ikkeParedeScreenshotsRader = ikkeParedeScreenshots.map(o => `
+<tr>
+  <td><strong style="font-size:18px">screenshot ${o.screenshot_nr}</strong><br>
+      <img src="fb-bilder-preview/${o.screenshot}" loading="lazy"><br><code>${o.screenshot}</code></td>
+</tr>`).join('')
+
+const html = `<!doctype html>
+<html lang="nb"><head><meta charset="utf-8"><title>FB-bilder pairing</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 0; padding: 20px; background: #fafafa; color: #222; }
+  h1 { font-size: 18px; }
+  table { width: 100%; border-collapse: collapse; background: white; }
+  th, td { border: 1px solid #ddd; padding: 8px; vertical-align: top; text-align: left; }
+  th { background: #eee; position: sticky; top: 0; }
+  img { max-width: 380px; max-height: 280px; display: block; }
+  code { font-size: 11px; color: #555; word-break: break-all; }
+  small { font-size: 10px; color: #666; }
+  .merknad { background: #fff3cd; padding: 12px; border: 1px solid #ffc107; border-radius: 4px; margin-bottom: 20px; }
+</style></head><body>
+<h1>FB-bilder pairing — ${par.length} par, ${ikkeParedeBilder.length} løse bilder, ${ikkeParedeScreenshots.length} løse screenshots</h1>
+<div class="merknad">
+  Si f.eks. «bilde 5 skal pares med screenshot 7». Jeg kjører <code>scripts/fb-bilder-bytt.mjs 5 7</code> + <code>render</code> og du laster denne siden på nytt.
+</div>
+<table>
+<thead><tr><th>Bilde (FB-original)</th><th>Screenshot (med kommentarer)</th><th>Tidspunkter</th></tr></thead>
+<tbody>${rader}</tbody>
+</table>
+${ikkeParedeBilder.length ? `<h2 style="margin-top:30px">Løse bilder uten screenshot (${ikkeParedeBilder.length})</h2>
+<table><thead><tr><th>Bilde</th></tr></thead><tbody>${ikkeParedeBilderRader}</tbody></table>` : ''}
+${ikkeParedeScreenshots.length ? `<h2 style="margin-top:30px">Løse screenshots uten bilde (${ikkeParedeScreenshots.length})</h2>
+<table><thead><tr><th>Screenshot</th></tr></thead><tbody>${ikkeParedeScreenshotsRader}</tbody></table>` : ''}
+</body></html>`
+
+writeFileSync(HTML_OUT, html, 'utf8')
+console.log(`✓ Rendret ${HTML_OUT}`)

--- a/scripts/fb-bilder-sync.mjs
+++ b/scripts/fb-bilder-sync.mjs
@@ -1,0 +1,120 @@
+// Synker nye bilder og screenshots inn i preview-mappa, og legger nye filer
+// (som ikke er paret enda) inn i ikke_parede-listene med korrekt nr.
+// Kjør etter at du har lastet ned flere bilder/screenshots.
+//
+// Bruk: node scripts/fb-bilder-sync.mjs
+
+import { readdirSync, statSync, copyFileSync, readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+const BILDER_DIR = 'C:/Users/reida/Pictures'
+const SCREENSHOTS_DIR = 'C:/Users/reida/Pictures/Screenshots'
+const PREVIEW_DIR = 'scripts/fb-bilder-preview'
+const JSON_FIL = 'scripts/fb-bilder-pairing.json'
+const EKSKLUDER = ['icon-192.png', 'icon-192n.png']
+
+if (!existsSync(PREVIEW_DIR)) mkdirSync(PREVIEW_DIR, { recursive: true })
+
+const bilder = readdirSync(BILDER_DIR)
+  .filter(f => /\.(jpe?g|png)$/i.test(f) && !f.startsWith('Skjermbilde') && !f.startsWith('_crop'))
+  .filter(f => !EKSKLUDER.includes(f))
+  .map(f => ({ navn: f, mtime: statSync(join(BILDER_DIR, f)).mtime }))
+  .sort((a, b) => a.mtime - b.mtime)
+
+const screenshots = readdirSync(SCREENSHOTS_DIR)
+  .filter(f => /^Skjermbilde.*\.png$/i.test(f))
+  .map(f => ({ navn: f, mtime: statSync(join(SCREENSHOTS_DIR, f)).mtime }))
+  .sort((a, b) => a.mtime - b.mtime)
+
+let kopiert = 0
+for (const b of bilder) {
+  const dst = join(PREVIEW_DIR, b.navn)
+  if (!existsSync(dst)) { copyFileSync(join(BILDER_DIR, b.navn), dst); kopiert++ }
+}
+for (const s of screenshots) {
+  const dst = join(PREVIEW_DIR, s.navn)
+  if (!existsSync(dst)) { copyFileSync(join(SCREENSHOTS_DIR, s.navn), dst); kopiert++ }
+}
+
+const data = JSON.parse(readFileSync(JSON_FIL, 'utf8'))
+data.ikke_parede_bilder = (data.ikke_parede_bilder ?? []).map(o => typeof o === 'string' ? { navn: o, bilde_nr: null, bilde_mtime: null } : o)
+data.ikke_parede_screenshots = data.ikke_parede_screenshots ?? []
+
+// Sett av kjente filnavn
+const bilderIData = new Set([
+  ...data.par.filter(p => p.bilde).map(p => p.bilde),
+  ...data.ikke_parede_bilder.map(o => o.navn),
+])
+const screenshotsIData = new Set([
+  ...data.par.map(p => p.screenshot),
+  ...data.ikke_parede_screenshots.map(o => o.screenshot),
+])
+
+// Tildel nye nr basert på mtime-rekkefølge på master-lista
+const bildeNrFraNavn = new Map(bilder.map((b, i) => [b.navn, i + 1]))
+const screenshotNrFraNavn = new Map(screenshots.map((s, i) => [s.navn, i + 1]))
+
+// Re-tildel nr på alle eksisterende rader så numrene reflekterer dagens master-rekkefølge.
+// (Eldre filer får uendret nr siden mtime-rekkefølgen ikke endret seg — nye havner på slutten.)
+for (const p of data.par) {
+  if (p.bilde) p.bilde_nr = bildeNrFraNavn.get(p.bilde) ?? p.bilde_nr
+  p.screenshot_nr = screenshotNrFraNavn.get(p.screenshot) ?? p.screenshot_nr
+}
+for (const o of data.ikke_parede_bilder) o.bilde_nr = bildeNrFraNavn.get(o.navn) ?? o.bilde_nr
+for (const o of data.ikke_parede_screenshots) o.screenshot_nr = screenshotNrFraNavn.get(o.screenshot) ?? o.screenshot_nr
+
+let nyeBilder = 0
+for (const b of bilder) {
+  if (bilderIData.has(b.navn)) continue
+  data.ikke_parede_bilder.push({ navn: b.navn, bilde_nr: bildeNrFraNavn.get(b.navn), bilde_mtime: b.mtime.toISOString() })
+  nyeBilder++
+}
+let nyeScreenshots = 0
+for (const s of screenshots) {
+  if (screenshotsIData.has(s.navn)) continue
+  data.ikke_parede_screenshots.push({ screenshot_nr: screenshotNrFraNavn.get(s.navn), screenshot: s.navn, screenshot_mtime: s.mtime.toISOString() })
+  nyeScreenshots++
+}
+
+data.ikke_parede_bilder.sort((a, b) => (a.bilde_nr ?? 999) - (b.bilde_nr ?? 999))
+data.ikke_parede_screenshots.sort((a, b) => a.screenshot_nr - b.screenshot_nr)
+
+// Auto-par nye bilder/screenshots med nærhets-algoritmen.
+// For hver løs screenshot, ta nyeste løse bilde med mtime < screenshot.mtime
+// (innen rimelig vindu, f.eks. <300 sek). Reidar retter bytter/uparede manuelt.
+const VINDU_SEK = 300
+let autoParet = 0
+const screenshotsToProcess = [...data.ikke_parede_screenshots].sort((a, b) => new Date(a.screenshot_mtime) - new Date(b.screenshot_mtime))
+for (const ss of screenshotsToProcess) {
+  const ssTid = new Date(ss.screenshot_mtime)
+  const kandidater = data.ikke_parede_bilder
+    .filter(b => b.bilde_mtime && new Date(b.bilde_mtime) < ssTid && (ssTid - new Date(b.bilde_mtime)) / 1000 <= VINDU_SEK)
+    .sort((a, b) => new Date(b.bilde_mtime) - new Date(a.bilde_mtime))
+  const valgt = kandidater[0]
+  if (!valgt) continue
+  // Flytt valgt fra ikke_parede_bilder til ny rad i par
+  const bIdx = data.ikke_parede_bilder.findIndex(o => o.navn === valgt.navn)
+  data.ikke_parede_bilder.splice(bIdx, 1)
+  const sIdx = data.ikke_parede_screenshots.findIndex(o => o.screenshot_nr === ss.screenshot_nr)
+  data.ikke_parede_screenshots.splice(sIdx, 1)
+  data.par.push({
+    screenshot_nr: ss.screenshot_nr,
+    screenshot: ss.screenshot,
+    screenshot_mtime: ss.screenshot_mtime,
+    bilde_nr: valgt.bilde_nr,
+    bilde: valgt.navn,
+    bilde_mtime: valgt.bilde_mtime,
+    diff_sek: Math.round((ssTid - new Date(valgt.bilde_mtime)) / 1000),
+  })
+  autoParet++
+}
+
+data.par.sort((a, b) => a.screenshot_nr - b.screenshot_nr || (a.bilde_nr ?? 0) - (b.bilde_nr ?? 0))
+
+writeFileSync(JSON_FIL, JSON.stringify(data, null, 2), 'utf8')
+
+console.log(`✓ Kopiert ${kopiert} nye filer til preview`)
+console.log(`✓ Lagt til ${nyeBilder} nye bilder, ${nyeScreenshots} nye screenshots`)
+console.log(`✓ Auto-paret ${autoParet} nye par (vindu ${VINDU_SEK} sek)`)
+console.log(`  Total: ${bilder.length} bilder, ${screenshots.length} screenshots på filsystem`)
+console.log(`  par: ${data.par.length}, løse bilder: ${data.ikke_parede_bilder.length}, løse screenshots: ${data.ikke_parede_screenshots.length}`)

--- a/supabase/migrations/081_meldinger_fra_facebook.sql
+++ b/supabase/migrations/081_meldinger_fra_facebook.sql
@@ -1,0 +1,127 @@
+-- FB-import for meldinger (#?). Tre endringer:
+--   1. Ny tabell melding_bilder for tilleggsbilder utover meldinger.bilde_url.
+--      For poster med ett bilde brukes fortsatt bilde_url (cover). For poster
+--      med flere bilder ligger 2. og videre i melding_bilder.
+--   2. fra_facebook + kilde_ekstern_id på meldinger og melding_chat for
+--      idempotent re-import + frys-policy (samme mønster som 062, 066, 067).
+--   3. meldinger.innhold blir nullable så meldinger kan ha bare bilde uten tekst
+--      (bilde-uten-tekst-flyt — ble forespurt av brukeren generelt, ikke bare
+--      for FB-import).
+
+-- === 1. melding_bilder ==========================================
+create table public.melding_bilder (
+  id          uuid primary key default gen_random_uuid(),
+  melding_id  uuid not null references meldinger(id) on delete cascade,
+  bilde_url   text not null,
+  rekkefoelge int  not null default 0,
+  opprettet   timestamptz not null default now()
+);
+
+create index melding_bilder_melding_id_rekkefoelge_idx
+  on melding_bilder(melding_id, rekkefoelge);
+
+alter table public.melding_bilder enable row level security;
+
+-- Data API-tilgang (kreves fra 2026-10-30)
+grant select                         on public.melding_bilder to anon;
+grant select, insert, update, delete on public.melding_bilder to authenticated;
+grant select, insert, update, delete on public.melding_bilder to service_role;
+
+create policy "Aktive kan lese melding_bilder" on melding_bilder
+  for select using (exists (
+    select 1 from profiles where id = auth.uid() and aktiv = true
+  ));
+
+create policy "Forfatter kan legge til melding_bilder" on melding_bilder
+  for insert with check (
+    exists (select 1 from meldinger where id = melding_id and profil_id = auth.uid())
+  );
+
+create policy "Forfatter eller admin kan slette melding_bilder" on melding_bilder
+  for delete using (
+    exists (select 1 from meldinger where id = melding_id and profil_id = auth.uid())
+    or er_admin()
+  );
+
+alter publication supabase_realtime add table melding_bilder;
+
+-- === 2. meldinger.innhold blir nullable ===========================
+-- For dette trengs det å droppe den eksisterende check (1..2000) og legge på
+-- en check som tillater null. Vi lar app-laget håndheve at minst en av
+-- (innhold, bilde_url, melding_bilder-rad) er satt — kompliserte cross-table
+-- constraints med trigger er ikke verdt det her.
+alter table meldinger alter column innhold drop not null;
+alter table meldinger drop constraint if exists meldinger_innhold_check;
+alter table meldinger add constraint meldinger_innhold_check
+  check (innhold is null or char_length(innhold) between 1 and 2000);
+
+-- === 3. fra_facebook + kilde_ekstern_id på meldinger ==============
+alter table meldinger
+  add column if not exists fra_facebook boolean not null default false;
+
+alter table meldinger
+  add column if not exists kilde_ekstern_id text;
+
+-- Idempotens for re-import — samme mønster som 066 (klubb_chat)
+create unique index if not exists meldinger_kilde_ekstern_id_unique
+  on meldinger(kilde_ekstern_id)
+  where kilde_ekstern_id is not null;
+
+create index if not exists meldinger_fra_facebook_idx
+  on meldinger(fra_facebook)
+  where fra_facebook = true;
+
+-- === 4. fra_facebook + kilde_ekstern_id på melding_chat ===========
+alter table melding_chat
+  add column if not exists fra_facebook boolean not null default false;
+
+alter table melding_chat
+  add column if not exists kilde_ekstern_id text;
+
+create unique index if not exists melding_chat_kilde_ekstern_id_unique
+  on melding_chat(kilde_ekstern_id)
+  where kilde_ekstern_id is not null;
+
+create index if not exists melding_chat_fra_facebook_idx
+  on melding_chat(fra_facebook)
+  where fra_facebook = true;
+
+-- === 5. Frys-policy: FB-rader kan ikke endres/slettes =============
+-- Speiler 067 (klubb_chat). Hverken UPDATE eller DELETE skal være tillatt
+-- for fra_facebook = true, uavhengig av rolle.
+
+drop policy if exists "Slette egne melding eller admin" on meldinger;
+create policy "Slette egne melding eller admin (ikke FB)" on meldinger
+  for delete using (
+    (fra_facebook is null or fra_facebook = false)
+    and (profil_id = auth.uid() or er_admin())
+  );
+
+drop policy if exists "Oppdatere egne melding eller admin" on meldinger;
+create policy "Oppdatere egne melding (ikke FB)" on meldinger
+  for update using (
+    (fra_facebook is null or fra_facebook = false)
+    and (profil_id = auth.uid() or er_admin())
+  )
+  with check (
+    (fra_facebook is null or fra_facebook = false)
+    and (profil_id = auth.uid() or er_admin())
+  );
+
+drop policy if exists "Slette egne melding_chat eller admin" on melding_chat;
+create policy "Slette egne melding_chat eller admin (ikke FB)" on melding_chat
+  for delete using (
+    (fra_facebook is null or fra_facebook = false)
+    and (profil_id = auth.uid() or er_admin())
+  );
+
+drop policy if exists "Oppdatere egne melding_chat" on melding_chat;
+create policy "Oppdatere egne melding_chat (ikke FB)" on melding_chat
+  for update using (
+    (fra_facebook is null or fra_facebook = false)
+    and profil_id = auth.uid()
+  )
+  with check (
+    (fra_facebook is null or fra_facebook = false)
+    and profil_id = auth.uid()
+  );

--- a/supabase/migrations/082_melding_bilder_idempotens.sql
+++ b/supabase/migrations/082_melding_bilder_idempotens.sql
@@ -1,0 +1,16 @@
+-- Oppfølging av migrasjon 081 etter Copilot-review på PR #177:
+--   - Unique constraint på (melding_id, rekkefoelge) gjør melding_bilder
+--     idempotent. Re-import av samme FB-post legger ikke til duplikat-rader.
+--   - UPDATE-grant uten matching RLS-policy ble flagget som forvirrende —
+--     enten gi policy eller fjerne grant. Vi fjerner grant: bilder skal
+--     normalt ikke endres in-place, kun slettes og re-opprettes (cascade
+--     fjerner via meldingen). Hvis vi senere trenger reorder, legges
+--     UPDATE-policy inn samtidig.
+
+alter table public.melding_bilder
+  add constraint melding_bilder_melding_rekkefoelge_unique
+  unique (melding_id, rekkefoelge);
+
+-- Fjerner UPDATE fra authenticated. service_role beholder full tilgang
+-- (bypasses RLS uansett, men trenger eksplisitt grant for PostgREST).
+revoke update on public.melding_bilder from authenticated;


### PR DESCRIPTION
## Summary

- Importerer 75 historiske bildeposter fra Facebook (2010-2022) som `meldinger` med 56 kommentarer og 4 tilleggsbilder
- Migrasjon 081: ny `melding_bilder`-tabell, nullable `meldinger.innhold`, `fra_facebook` + `kilde_ekstern_id` på meldinger og melding_chat med frys-policy
- UI: MeldingKort + MeldingDetalj viser flere bilder som grid, Facebook-merkelapp ved siden av dato
- Fjernet `limit(60)` på meldinger-query (issue #176 sporer sentralisert cutoff)

## Pipeline (engangsskript)

Hele importflyten ligger dokumentert i `scripts/fb-bilder-*.mjs`:
1. `pairing.mjs` + `juster.mjs` + `bytt.mjs`: par bilder med kommentar-screenshots
2. `crop-kommentarer.mjs`: crop kommentar-kolonnen ut av FB-screenshots
3. `metadata-html.mjs`: HTML-rapport for visuell verifikasjon av OCR
4. `navn-mapping.mjs`: matche FB-navn mot profiles
5. `generer-sql.mjs`: produsere idempotente INSERT-er via `kilde_ekstern_id`
6. `last-opp-r2.mjs`: laste opp bilder til Cloudflare R2 under `meldinger/`

R2-opplasting ble gjort manuelt (drag-and-drop) fordi tokenen i `.env.local` ble avvist.

## Oppfølgings-issues

- #174: Fullt multi-bilde-refactor (multi-upload fra UI, droppe `meldinger.bilde_url`)
- #176: Sentralisere agenda-cutoff og legge til paginering/«se alle tidligere»-side

## Test plan

- [x] Migrasjon 081 kjørt mot prod-DB
- [x] Bilder lastet opp til R2 (verifisert med curl)
- [x] Import-SQL kjørt (75 meldinger, 56 kommentarer, 4 tilleggsbilder)
- [x] `npx tsc --noEmit` passerer
- [x] `npx vitest run` (106 tests passerer)
- [x] `npm run build` passerer
- [x] Visuell verifikasjon av agenda-side på localhost (Reidar bekreftet)
- [ ] Visuell verifikasjon i prod etter deploy: FB-meldinger med Facebook-merkelapp og grid for poster med flere bilder

🤖 Generated with [Claude Code](https://claude.com/claude-code)