### PR TITLE
FB-tekst om gruppen + lokasjon Søndre Nordstrand på klubbinfo

### DIFF
--- a/app/(app)/klubbinfo/page.tsx
+++ b/app/(app)/klubbinfo/page.tsx
@@ -99,6 +99,8 @@ export default async function Klubbinfo() {
         >
           <span style={{ width: 18, height: '0.5px', background: 'var(--border-strong)' }} />
           Stiftet 24. november {KLUBBEN_START_AAR}
+          <span style={{ opacity: 0.4 }}>·</span>
+          Søndre Nordstrand
         </div>
         <h2
           style={{
@@ -162,6 +164,60 @@ export default async function Klubbinfo() {
             </div>
           ))}
         </div>
+      </div>
+
+      {/* Om klubben */}
+      <div style={{ marginBottom: 32 }}>
+        <div
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 10,
+            color: 'var(--text-tertiary)',
+            letterSpacing: '2px',
+            textTransform: 'uppercase',
+            marginBottom: 14,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            fontWeight: 600,
+          }}
+        >
+          Om klubben
+          <span style={{ flex: 1, height: '0.5px', background: 'var(--border-subtle)' }} />
+        </div>
+        <p
+          style={{
+            fontFamily: 'var(--font-body)',
+            fontSize: 15,
+            color: 'var(--text-secondary)',
+            lineHeight: 1.55,
+            margin: '0 0 10px',
+          }}
+        >
+          Vi blir gamle og grå, så en syklubb må vi få.
+        </p>
+        <p
+          style={{
+            fontFamily: 'var(--font-body)',
+            fontSize: 15,
+            color: 'var(--text-secondary)',
+            lineHeight: 1.55,
+            margin: '0 0 10px',
+          }}
+        >
+          Her skal verdensproblemer løses og diskuteres av de største besserwisserne fra Mortensrud.
+        </p>
+        <p
+          style={{
+            fontFamily: 'var(--font-body)',
+            fontSize: 15,
+            color: 'var(--text-secondary)',
+            lineHeight: 1.55,
+            margin: 0,
+          }}
+        >
+          Så vel møtt finansakrobater og rikssynsere til månedlige sammenkomster.
+        </p>
       </div>
 
       {/* Seksjons-label */}

--- a/app/(app)/klubbinfo/page.tsx
+++ b/app/(app)/klubbinfo/page.tsx
@@ -99,7 +99,7 @@ export default async function Klubbinfo() {
         >
           <span style={{ width: 18, height: '0.5px', background: 'var(--border-strong)' }} />
           Stiftet 24. november {KLUBBEN_START_AAR}
-          <span style={{ opacity: 0.4 }}>·</span>
+          <span aria-hidden="true" style={{ opacity: 0.4 }}>·</span>
           Søndre Nordstrand
         </div>
         <h2

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 12,
-  "versjon": "V3.0.12"
+  "nummer": 13,
+  "versjon": "V3.0.13"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 13,
-  "versjon": "V3.0.13"
+  "nummer": 14,
+  "versjon": "V3.0.14"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V3.0.12'
+const CACHE_VERSION = 'V3.0.13'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V3.0.13'
+const CACHE_VERSION = 'V3.0.14'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
## Summary

- Legger inn FB-teksten «om gruppen» ordrett som ny «Om klubben»-seksjon på `/klubbinfo`, plassert mellom hero-blokken og «Innhold»-TOC.
- «Søndre Nordstrand» lagt inn som lokasjon i meta-stripen øverst, etter stiftelses-datoen.

Lukker #175.

## Beslutninger underveis

- Plassering: «Om klubben»-seksjon over Innhold-TOC for å speile eksisterende editorial-tone.
- Reviewer foreslo `aria-hidden` på dekorativ midt-prikk — tatt med (gratis tilgjengelighet-fix).
- Inline-stil-duplikasjon på de tre `<p>`-elementene flagget som NIT, men konsistent med resten av siden — beholdt.

## Test plan

- [x] `npm run build` grønt
- [ ] Manuell: åpne `/klubbinfo` → bekreft tekst ordrett, Søndre Nordstrand i topp, styling glir naturlig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)