### PR TITLE
Begrens meldinger-henting på forsiden til 20 (#180)

### DIFF
--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -122,7 +122,11 @@ export default async function Forside() {
         'id, innhold, opprettet, sist_aktivitet, fra_facebook, profil_id, profiles!meldinger_profil_id_fkey (navn, bilde_url, rolle), melding_bilder (bilde_url, rekkefoelge), melding_chat (count)',
       )
       .gte('sist_aktivitet', cutoffIso)
-      .order('sist_aktivitet', { ascending: false }),
+      .order('sist_aktivitet', { ascending: false })
+      // Begrens til 20 — se #180. Etter FB-import (#177) og multi-bilde-grid (#181)
+      // kan hvert resultat hente opptil 4 thumbnails; uten limit slår dette hardt
+      // på cold load. Full historikk er tilgjengelig via /tidligere.
+      .limit(20),
     supabase
       .from('melding_reaksjon')
       .select('melding_id, profil_id, emoji'),

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 17,
-  "versjon": "V3.0.17"
+  "nummer": 18,
+  "versjon": "V3.0.18"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // CACHE_VERSION speiler app-versjonen fra lib/versjon.json og oppdateres
 // automatisk av scripts/stamp-versjon.mjs ved hver deploy. Slik invalideres
 // gammel cache uten manuell bumping.
-const CACHE_VERSION = 'V3.0.17'
+const CACHE_VERSION = 'V3.0.18'
 const STATIC_CACHE = `herreklubben-static-${CACHE_VERSION}`
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
## Summary

- Restaurerer `.limit(20)` på meldinger-spørringen i `app/(app)/page.tsx`. PR #178 fjernet det opprinnelige `limit(60)` da agenda-cutoff ble sentralisert til 12 mnd.
- Kombinasjonen 75 FB-importerte meldinger (#177) + multi-bilde 2×2-grid (#181, opp til 4 `<Image fill>` per melding) gjorde cold-load på forsiden treig.

Lukker #180.

## Diagnose

| PR | Effekt |
|----|--------|
| #177 | 75 FB-meldinger importert, mange innenfor 12-mnd-cutoff |
| #178 | `limit(60)` fjernet, alle meldinger siste 12 mnd hentes |
| #181 | Hver melding kan rendre opp til 4 `<Image fill>` (multi-bilde-grid) |

Resultat: N meldinger × opptil 4 thumbs = mange hundre next/image-optimaliseringer ved cold-load.

## Fix

Én linje:
```ts
.limit(20)
```

Full historikk er allerede tilgjengelig via `/tidligere`. «Nytt fra gutta» (≤3.5 dager) får plass i topp-20; resten er kort Tidligere-teaser før «Se hele historikken →»-lenken.

## Test plan

- [x] `npm run build` grønt
- [ ] Cold-load `/` i inkognito → bekreft TTFB tilbake på tidligere nivå
- [ ] «Nytt fra gutta» viser fortsatt alle levende meldinger
- [ ] «Se hele historikken →» fungerer

🤖 Generated with [Claude Code](https://claude.com/claude-code)