### PR TITLE
Legg til MapPinIcon foran Søndre Nordstrand på klubbinfo

### DIFF
--- a/app/(app)/klubbinfo/page.tsx
+++ b/app/(app)/klubbinfo/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { MapPinIcon } from '@heroicons/react/24/outline'
 import { createServerClient } from '@/lib/supabase/server'
 import { getProfil } from '@/lib/auth-cache'
 import { norskAar } from '@/lib/dato'
@@ -100,7 +101,10 @@ export default async function Klubbinfo() {
           <span style={{ width: 18, height: '0.5px', background: 'var(--border-strong)' }} />
           Stiftet 24. november {KLUBBEN_START_AAR}
           <span aria-hidden="true" style={{ opacity: 0.4 }}>·</span>
-          Søndre Nordstrand
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+            <MapPinIcon aria-hidden="true" style={{ width: 11, height: 11 }} />
+            Søndre Nordstrand
+          </span>
         </div>
         <h2
           style={{

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 20,
-  "versjon": "V3.0.20"
+  "nummer": 21,
+  "versjon": "V3.0.21"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.0.20'
+const CACHE_VERSION = 'V3.0.21'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
## Summary

Lokasjons-ikon (MapPinIcon fra @heroicons) plassert rett foran «Søndre Nordstrand» i meta-stripen på `/klubbinfo`. Visuelt signal om at det er en geografisk plassering.

Lukker #186.

## Test plan

- [x] `npm run build` grønt
- [ ] Manuell: åpne `/klubbinfo` → ikon vises foran by-navn, vertikalt sentrert med teksten

🤖 Generated with [Claude Code](https://claude.com/claude-code)