### PR TITLE
Fjern Sammenkomster-telling på klubb-siden

### DIFF
--- a/app/(app)/klubbinfo/page.tsx
+++ b/app/(app)/klubbinfo/page.tsx
@@ -12,13 +12,10 @@ export default async function Klubbinfo() {
   const [supabase, profil] = await Promise.all([createServerClient(), getProfil()])
   const erAdmin = kanAdministrere(profil?.rolle)
 
-  const [{ count: antallMedlemmer }, { count: totaltArr }] = await Promise.all([
-    supabase
-      .from('profiles')
-      .select('id', { count: 'exact', head: true })
-      .eq('aktiv', true),
-    supabase.from('arrangementer').select('id', { count: 'exact', head: true }),
-  ])
+  const { count: antallMedlemmer } = await supabase
+    .from('profiles')
+    .select('id', { count: 'exact', head: true })
+    .eq('aktiv', true)
 
   const antallAar = norskAar() - KLUBBEN_START_AAR + 1
 
@@ -150,7 +147,6 @@ export default async function Klubbinfo() {
           {[
             { val: antallMedlemmer ?? 0, lbl: 'Medlemmer' },
             { val: antallAar, lbl: 'Årganger' },
-            { val: totaltArr ?? 0, lbl: 'Sammenkomster' },
           ].map(s => (
             <div key={s.lbl}>
               <div

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 21,
-  "versjon": "V3.0.21"
+  "nummer": 22,
+  "versjon": "V3.0.22"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.0.21'
+const CACHE_VERSION = 'V3.0.22'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
## Summary

Fjernet «Sammenkomster»-statistikk fra topp-stripen på `/klubbinfo`. Også droppet underliggende `count`-spørring mot `arrangementer`-tabellen siden tallet ikke lenger vises.

Lukker #185.

## Test plan

- [x] `npm run build` grønt
- [ ] Manuell: åpne `/klubbinfo` → kun «Medlemmer» og «Årganger» vises i statistikk-stripen

🤖 Generated with [Claude Code](https://claude.com/claude-code)