### PR TITLE
Topp-tabs: soft pill, header 60px, font 17 (#190)

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -7,7 +7,6 @@ import DeployInfo from '@/components/DeployInfo'
 import InstallVeiledning from '@/components/InstallVeiledning'
 import { getInnloggetBruker, getProfil } from '@/lib/auth-cache'
 import { redirect } from 'next/navigation'
-import versjon from '@/lib/versjon.json'
 
 async function HeaderMedProfil() {
   const profil = await getProfil()
@@ -16,7 +15,6 @@ async function HeaderMedProfil() {
       brukerNavn={profil?.navn}
       bildeUrl={profil?.bilde_url ?? null}
       rolle={profil?.rolle ?? null}
-      versjon={versjon.versjon}
     />
   )
 }
@@ -37,7 +35,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
       <ServiceWorkerRegistrering />
       <DraNedForOppdater />
       <InstallVeiledning />
-      <Suspense fallback={<TopHeader versjon={versjon.versjon} />}>
+      <Suspense fallback={<TopHeader />}>
         <HeaderMedProfil />
       </Suspense>
       <main className="flex-1 relative z-10">

--- a/app/globals.css
+++ b/app/globals.css
@@ -47,7 +47,7 @@
   /* Layout — sticky topp-header-høyde (uten safe-area). Eksponert som
    * CSS-variabel så andre sticky-elementer (f.eks. VinnerBanner) kan
    * stikke seg riktig under headeren i stedet for å havne bak. */
-  --top-header-h: 56px;
+  --top-header-h: 60px;
 
   /* Form */
   --radius: 18px;

--- a/components/TopHeader.tsx
+++ b/components/TopHeader.tsx
@@ -84,7 +84,6 @@ export default function TopHeader({ brukerNavn, bildeUrl, rolle }: Props) {
           {TABS.map(tab => {
             const aktiv = erAktiv(tab, pathname)
             const tabStil: CSSProperties = {
-              position: 'relative',
               padding: '8px 14px',
               borderRadius: 999,
               fontFamily: 'var(--font-body)',

--- a/components/TopHeader.tsx
+++ b/components/TopHeader.tsx
@@ -31,12 +31,11 @@ type Props = {
   brukerNavn?: string | null
   bildeUrl?: string | null
   rolle?: string | null
-  versjon?: string
 }
 
 /**
  * Sticky topp-header med tre alltid-synlige tabs (Agenda / Chat / Klubb) og
- * profil-snarvei høyre. Aktiv tab markert med gull underline. Path-prefikser
+ * profil-snarvei høyre. Aktiv tab markert med soft pill-bakgrunn. Path-prefikser
  * styrer hvilken tab som er aktiv på undersider (f.eks. `/arrangementer/123`
  * → Agenda aktiv).
  *
@@ -44,7 +43,7 @@ type Props = {
  * #151, #153 hvor iOS-tastatur kolliderte med fixed bottom-elementer. Se
  * Policy: Navigasjon i CLAUDE.md.
  */
-export default function TopHeader({ brukerNavn, bildeUrl, rolle, versjon }: Props) {
+export default function TopHeader({ brukerNavn, bildeUrl, rolle }: Props) {
   const pathname = usePathname()
 
   const headerStyle: CSSProperties = {
@@ -63,11 +62,11 @@ export default function TopHeader({ brukerNavn, bildeUrl, rolle, versjon }: Prop
   const innerStyle: CSSProperties = {
     // Høyden speiles av --top-header-h i globals.css så andre sticky-elementer
     // (f.eks. VinnerBanner) kan stikke seg under headeren.
-    height: 'var(--top-header-h, 56px)',
+    height: 'var(--top-header-h, 60px)',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
-    padding: '0 14px',
+    padding: '0 16px',
     gap: 8,
   }
 
@@ -81,19 +80,23 @@ export default function TopHeader({ brukerNavn, bildeUrl, rolle, versjon }: Prop
     <nav style={headerStyle} aria-label="Hovednavigasjon">
       <div style={innerStyle}>
         {/* Tabs */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
           {TABS.map(tab => {
             const aktiv = erAktiv(tab, pathname)
             const tabStil: CSSProperties = {
               position: 'relative',
-              padding: '8px 10px',
-              fontFamily: 'var(--font-display)',
-              fontSize: 15,
-              fontWeight: 500,
+              padding: '8px 14px',
+              borderRadius: 999,
+              fontFamily: 'var(--font-body)',
+              fontSize: 17,
+              fontWeight: aktiv ? 600 : 400,
               color: aktiv ? 'var(--accent)' : 'var(--text-tertiary)',
+              opacity: aktiv ? 1 : 0.6,
+              background: aktiv ? 'var(--accent-soft)' : 'transparent',
               textDecoration: 'none',
-              transition: 'color 180ms ease',
-              letterSpacing: '-0.2px',
+              letterSpacing: '-0.3px',
+              lineHeight: 1,
+              transition: 'color 180ms ease, background-color 180ms ease, opacity 180ms ease',
             }
             return (
               <Link
@@ -104,41 +107,10 @@ export default function TopHeader({ brukerNavn, bildeUrl, rolle, versjon }: Prop
                 prefetch
               >
                 {tab.label}
-                {aktiv && (
-                  <span
-                    aria-hidden="true"
-                    style={{
-                      position: 'absolute',
-                      left: 10,
-                      right: 10,
-                      bottom: 2,
-                      height: 1.5,
-                      background: 'var(--accent)',
-                      borderRadius: 1,
-                    }}
-                  />
-                )}
               </Link>
             )
           })}
         </div>
-
-        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-          {versjon && (
-            <span
-              aria-hidden="true"
-              style={{
-                fontFamily: 'var(--font-mono)',
-                fontSize: 9.5,
-                color: 'var(--text-tertiary)',
-                opacity: 0.55,
-                letterSpacing: '0.5px',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {versjon}
-            </span>
-          )}
 
         {/* Profil-snarvei */}
         <Link
@@ -157,10 +129,9 @@ export default function TopHeader({ brukerNavn, bildeUrl, rolle, versjon }: Prop
             name={brukerNavn ?? 'Herreklubben'}
             src={bildeUrl ?? null}
             rolle={rolle ?? null}
-            size={36}
+            size={38}
           />
         </Link>
-        </div>
       </div>
     </nav>
   )

--- a/components/poll/VinnerBanner.tsx
+++ b/components/poll/VinnerBanner.tsx
@@ -15,7 +15,7 @@ export default function VinnerBanner({ navn, bildeUrl, rolle, variant, undertitt
       style={{
         position: 'sticky',
         // Stikk under sticky TopHeader (z-30) — uten dette havner banneret bak headeren.
-        top: 'calc(var(--top-header-h, 56px) + env(safe-area-inset-top))',
+        top: 'calc(var(--top-header-h, 60px) + env(safe-area-inset-top))',
         zIndex: 5,
         margin: '0 -20px 24px',
         padding: '18px 20px',

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 0,
-  "versjon": "V3.1.0"
+  "nummer": 1,
+  "versjon": "V3.1.1"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 23,
-  "versjon": "V3.0.23"
+  "nummer": 0,
+  "versjon": "V3.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "herreklubben",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.0.23'
+const CACHE_VERSION = 'V3.1.0'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.0'
+const CACHE_VERSION = 'V3.1.1'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Lukker #190.

## Endringer

- `components/TopHeader.tsx`: aktiv tab har soft kremgul pill-bakgrunn (`--accent-soft`) istedenfor 1.5px underline. Font 17 i `var(--font-body)` med vekt 400/600 og opacity 0.6/1. Underline-`<span>` fjernet fra DOM. Avatar 36 → 38. Versjon-prop og versjon-spannen helt fjernet (kan flyttes til footer i oppfølgende issue). `position: relative` på `tabStil` ryddet vekk (ankret ikke noe lenger).
- `app/globals.css`: `--top-header-h` 56 → 60.
- `app/(app)/layout.tsx`: fjernet `versjon`-propen begge kallsteder + ubrukt import.
- `components/poll/VinnerBanner.tsx`: fallback i `calc()` 56 → 60.
- Versjon: bump til **V3.1.0** (deretter V3.1.1 via stamp).

## Beslutninger underveis

- Reviewer fant én NIT (overflødig `position: relative` etter at underline-spannet ble fjernet) — rettet.
- Reviewer foreslo selv å la `60px`-fallback stå duplisert (eksisterende mønster, ikke regresjon) — avvist for å unngå over-abstraksjon ved kun to bruksteder.

## Verifisering

- `npm run lint` rent
- `npm run build` rent
- `npm test` — 122 tester grønt
- Visuell verifikasjon mot `.github/issue-assets/topp-tabs-m5/preview.png` anbefalt før merge (PWA-quirks må fortsatt sjekkes manuelt på iPhone per Policy: Visuell verifikasjon).
