### PR TITLE
Agenda-overskrift: vis dagens dato (oppfølging av #190)

### DIFF
--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -43,7 +43,6 @@ export default async function Forside() {
 
   const [
     { data: arrangementer },
-    { count: aktiveMedlemmer },
     { data: profilerMedBursdag },
     { data: ansvar },
     { data: pollerRaad },
@@ -66,7 +65,6 @@ export default async function Forside() {
       )
       .gte('start_tidspunkt', cutoffIso)
       .order('start_tidspunkt', { ascending: true }),
-    supabase.from('profiles').select('id', { count: 'exact', head: true }).eq('aktiv', true),
     supabase
       .from('profiles')
       .select('id, visningsnavn, fodselsdato, bilde_url, rolle')
@@ -408,8 +406,13 @@ export default async function Forside() {
     aar,
   })
 
-  const antallGutta = aktiveMedlemmer ?? 0
   const chatProfiler = aktiveProfiler ?? []
+
+  // Header viser dagens norske dato: ukedag (eyebrow), dato (h1), "I dag" (label).
+  // Følger M5-referansen fra #190.
+  const naaIso = new Date().toISOString()
+  const ukedag = formaterDato(naaIso, 'EEEE')
+  const idagDato = formaterDato(naaIso, 'd. MMMM')
 
   return (
     <div style={{ padding: '0 20px 20px' }}>
@@ -430,26 +433,40 @@ export default async function Forside() {
               fontSize: 10,
               fontWeight: 600,
               color: 'var(--text-tertiary)',
-              letterSpacing: '1.6px',
+              letterSpacing: '2.5px',
               textTransform: 'uppercase',
               marginBottom: 6,
             }}
           >
-            Siden 2007 · {antallGutta} herrer
+            {ukedag}
           </div>
           <h1
             style={{
               fontFamily: 'var(--font-display)',
-              fontSize: 38,
-              fontWeight: 500,
-              letterSpacing: '-0.5px',
+              fontStyle: 'italic',
+              fontSize: 44,
+              fontWeight: 400,
+              letterSpacing: '-1px',
               lineHeight: 1,
               margin: 0,
               color: 'var(--text-primary)',
             }}
           >
-            Agenda
+            {idagDato}
           </h1>
+          <div
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 9.5,
+              fontWeight: 600,
+              color: 'rgba(255,255,255,0.4)',
+              letterSpacing: '2px',
+              textTransform: 'uppercase',
+              marginTop: 10,
+            }}
+          >
+            I dag
+          </div>
         </div>
 
         <NyFAB />

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 1,
-  "versjon": "V3.1.1"
+  "nummer": 2,
+  "versjon": "V3.1.2"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.1'
+const CACHE_VERSION = 'V3.1.2'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Følger opp #190 — referanse-HTML-en viste at også agenda-sidens overskrift skulle endres, men det var ikke spelt ut i issue-bodyen så det falt utenfor PR #191.

## Endringer i `app/(app)/page.tsx`

- Eyebrow: `Siden 2007 · X herrer` → ukedagen (f.eks. "Tirsdag" → vises "TIRSDAG" via uppercase).
- H1: `Agenda` → dagens dato i italic Instrument Serif (f.eks. "16. mai"), 44px.
- Ny label under h1: `I dag` (mono, små caps).
- Fjernet `count`-spørring på `profiles` (`aktiveMedlemmer`) siden den kun ble brukt i header — én færre DB-runde per forside-render.

Bruker `formaterDato()` fra `lib/dato.ts` så Oslo-tidssone og nb-locale er ivaretatt.

## Verifisering

- `npm run lint` rent
- `npm run build` rent

Visuell verifikasjon på iPhone gjenstår.
