### PR TITLE
Klubb-side: diskret divider med app-versjon

### DIFF
--- a/app/(app)/klubbinfo/page.tsx
+++ b/app/(app)/klubbinfo/page.tsx
@@ -5,6 +5,7 @@ import { getProfil } from '@/lib/auth-cache'
 import { norskAar } from '@/lib/dato'
 import Icon, { IkonNavn } from '@/components/ui/Icon'
 import { kanAdministrere } from '@/lib/roller'
+import versjon from '@/lib/versjon.json'
 
 const KLUBBEN_START_AAR = 2007
 
@@ -103,6 +104,26 @@ export default async function Klubbinfo() {
             Søndre Nordstrand
           </span>
         </div>
+
+        {/* Diskret divider med versjonsnummer høyrejustert. Plassert her etter
+            at headeren ble strippet for versjon i #190 — klubb-siden er nå
+            kanonisk sted for app-versjon. */}
+        <div
+          style={{
+            borderTop: '0.5px solid var(--border-subtle)',
+            margin: '0 0 16px',
+            paddingTop: 6,
+            display: 'flex',
+            justifyContent: 'flex-end',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 9,
+            color: 'var(--text-tertiary)',
+            letterSpacing: '1.5px',
+          }}
+        >
+          {versjon.versjon}
+        </div>
+
         <h2
           style={{
             fontFamily: 'var(--font-display)',

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 2,
-  "versjon": "V3.1.2"
+  "nummer": 3,
+  "versjon": "V3.1.3"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.2'
+const CACHE_VERSION = 'V3.1.3'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Etter at versjon-labelen ble fjernet fra topp-headeren i #190, mangler appen et synlig sted for versjonsnummeret. Reidar ber om at det havner på klubb-siden: en diskret strek under "Stiftet ... · Søndre Nordstrand"-stripen, og versjonsnummeret høyrejustert rett under streken. "Mortensrud Herreklubb" forblir uendret under.