### PR TITLE
Agenda-header: fjern 'I dag', vertikal-align plussknapp

### DIFF
--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -420,7 +420,7 @@ export default async function Forside() {
       <header
         style={{
           display: 'flex',
-          alignItems: 'flex-end',
+          alignItems: 'center',
           justifyContent: 'space-between',
           marginTop: 12,
           marginBottom: 26,
@@ -454,19 +454,6 @@ export default async function Forside() {
           >
             {idagDato}
           </h1>
-          <div
-            style={{
-              fontFamily: 'var(--font-mono)',
-              fontSize: 9.5,
-              fontWeight: 600,
-              color: 'rgba(255,255,255,0.4)',
-              letterSpacing: '2px',
-              textTransform: 'uppercase',
-              marginTop: 10,
-            }}
-          >
-            I dag
-          </div>
         </div>
 
         <NyFAB />

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 3,
-  "versjon": "V3.1.3"
+  "nummer": 4,
+  "versjon": "V3.1.4"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.3'
+const CACHE_VERSION = 'V3.1.4'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Per Reidar — fjerner overflødig 'I dag'-label under datoen, og endrer header-flex fra `flex-end` til `center` så NyFAB ligger horisontalt på linje med dato-h1-en.