### PR TITLE
Profil varsler: filter, marker-alle-lest, kollaps

### DIFF
--- a/app/(app)/profil/page.tsx
+++ b/app/(app)/profil/page.tsx
@@ -1,10 +1,11 @@
 import Link from 'next/link'
 import { createServerClient } from '@/lib/supabase/server'
 import { getInnloggetBruker } from '@/lib/auth-cache'
-import { norskAar, formaterDato } from '@/lib/dato'
+import { norskAar } from '@/lib/dato'
 import Avatar from '@/components/ui/Avatar'
 import SectionLabel from '@/components/ui/SectionLabel'
 import VarslerInnstillinger from '@/components/VarslerInnstillinger'
+import VarslerListe from '@/components/profil/VarslerListe'
 import PassInfoKort from '@/components/profil/PassInfoKort'
 import { tittelFor } from '@/lib/roller'
 import LoggUtKnapp from './LoggUtKnapp'
@@ -321,91 +322,10 @@ export default async function Profil() {
         epostAktiv={varselPref?.epost_aktiv ?? true}
       />
 
-      {/* Personlige varsler */}
+      {/* Personlige varsler — interaktiv klient-komponent med filter, kollaps
+          og marker-alle-lest. */}
       {varsler && varsler.length > 0 && (
-        <section style={{ marginBottom: 24, marginTop: 24 }}>
-          <SectionLabel count={varsler.filter(v => !v.lest).length || undefined}>
-            Varsler
-          </SectionLabel>
-          <div style={{ display: 'flex', flexDirection: 'column' }}>
-            {varsler.map((v, i) => (
-              <Link
-                key={v.id}
-                href={`/varsler/${v.id}`}
-                style={{
-                  display: 'flex',
-                  alignItems: 'flex-start',
-                  gap: 14,
-                  padding: '14px 4px',
-                  borderBottom:
-                    i < varsler.length - 1 ? '0.5px solid var(--border-subtle)' : 'none',
-                  textDecoration: 'none',
-                  color: 'inherit',
-                  opacity: v.lest ? 0.6 : 1,
-                }}
-              >
-                <div
-                  style={{
-                    width: 8,
-                    height: 8,
-                    borderRadius: '50%',
-                    background: v.lest ? 'var(--border-subtle)' : 'var(--accent)',
-                    marginTop: 6,
-                    flexShrink: 0,
-                    boxShadow: v.lest
-                      ? 'none'
-                      : '0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent)',
-                  }}
-                />
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <div
-                    style={{
-                      fontFamily: 'var(--font-display)',
-                      fontSize: 15,
-                      fontWeight: 500,
-                      color: 'var(--text-primary)',
-                      letterSpacing: '-0.2px',
-                      lineHeight: 1.2,
-                      marginBottom: 3,
-                    }}
-                  >
-                    {v.tittel}
-                  </div>
-                  <div
-                    style={{
-                      fontFamily: 'var(--font-body)',
-                      fontSize: 12,
-                      color: 'var(--text-secondary)',
-                      lineHeight: 1.45,
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      display: '-webkit-box',
-                      WebkitLineClamp: 2,
-                      WebkitBoxOrient: 'vertical',
-                    }}
-                  >
-                    {v.melding}
-                  </div>
-                  {v.opprettet && (
-                    <div
-                      style={{
-                        fontFamily: 'var(--font-mono)',
-                        fontSize: 9,
-                        color: 'var(--text-tertiary)',
-                        letterSpacing: '1.4px',
-                        fontWeight: 600,
-                        textTransform: 'uppercase',
-                        marginTop: 4,
-                      }}
-                    >
-                      {formaterDato(v.opprettet, 'd. MMM · HH:mm')}
-                    </div>
-                  )}
-                </div>
-              </Link>
-            ))}
-          </div>
-        </section>
+        <VarslerListe varsler={varsler} />
       )}
 
       {/* Pass og Innspill samlet nederst — sjeldent brukt, eller mest praktisk

--- a/components/profil/VarslerListe.tsx
+++ b/components/profil/VarslerListe.tsx
@@ -1,0 +1,255 @@
+'use client'
+
+import Link from 'next/link'
+import { useState, useTransition } from 'react'
+import { formaterDato } from '@/lib/dato'
+import { markerAlleVarslerLest } from '@/lib/actions/varsler'
+
+export type VarselRad = {
+  id: string
+  tittel: string
+  melding: string | null
+  lest: boolean
+  opprettet: string | null
+  url: string | null
+}
+
+type Props = {
+  varsler: VarselRad[]
+}
+
+// Klient-komponent fordi vi vil ha lokal state for kollaps og filter uten
+// å re-fetche fra serveren. Marker-alle-lest kaller server action og lar
+// revalidatePath sørge for at neste render reflekterer endringen — vi
+// oppdaterer også lokal state med en gang for momentan UI-feedback.
+export default function VarslerListe({ varsler: initialVarsler }: Props) {
+  const [varsler, setVarsler] = useState(initialVarsler)
+  const [kollapset, setKollapset] = useState(false)
+  const [kunUleste, setKunUleste] = useState(false)
+  const [isPending, startTransition] = useTransition()
+
+  const antallUleste = varsler.filter(v => !v.lest).length
+  const visning = kunUleste ? varsler.filter(v => !v.lest) : varsler
+
+  function markerAlleLest() {
+    if (antallUleste === 0) return
+    startTransition(async () => {
+      // Optimistisk oppdatering — server action får siste ord via revalidatePath.
+      setVarsler(varsler.map(v => ({ ...v, lest: true })))
+      try {
+        await markerAlleVarslerLest()
+      } catch {
+        // Ved feil: rull tilbake lokal state.
+        setVarsler(initialVarsler)
+      }
+    })
+  }
+
+  return (
+    <section style={{ marginBottom: 24, marginTop: 24 }}>
+      {/* Header med tittel + antall + toggle-knapp for kollaps */}
+      <div
+        style={{
+          fontFamily: 'var(--font-mono)',
+          fontSize: 10,
+          fontWeight: 500,
+          color: 'var(--text-tertiary)',
+          textTransform: 'uppercase',
+          letterSpacing: '1.6px',
+          marginBottom: 10,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+        }}
+      >
+        <button
+          type="button"
+          onClick={() => setKollapset(k => !k)}
+          aria-expanded={!kollapset}
+          aria-controls="varsler-innhold"
+          style={{
+            background: 'transparent',
+            border: 'none',
+            padding: 0,
+            color: 'inherit',
+            font: 'inherit',
+            letterSpacing: 'inherit',
+            textTransform: 'inherit',
+            cursor: 'pointer',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+          }}
+        >
+          <span
+            aria-hidden="true"
+            style={{
+              display: 'inline-block',
+              transform: kollapset ? 'rotate(-90deg)' : 'rotate(0deg)',
+              transition: 'transform 150ms ease',
+              fontSize: 9,
+              opacity: 0.7,
+            }}
+          >
+            ▼
+          </span>
+          <span>
+            Varsler ({antallUleste} uleste)
+          </span>
+        </button>
+        <span style={{ flex: 1, height: '0.5px', background: 'var(--border-subtle)' }} />
+      </div>
+
+      {!kollapset && (
+        <div id="varsler-innhold">
+          {/* Filter + marker-alle-lest */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 12,
+              marginBottom: 10,
+              padding: '0 4px',
+            }}
+          >
+            <button
+              type="button"
+              onClick={() => setKunUleste(v => !v)}
+              style={{
+                background: kunUleste ? 'var(--accent-soft)' : 'transparent',
+                border: '0.5px solid var(--border-subtle)',
+                borderRadius: 999,
+                padding: '6px 12px',
+                fontFamily: 'var(--font-body)',
+                fontSize: 12,
+                fontWeight: 500,
+                color: kunUleste ? 'var(--accent)' : 'var(--text-tertiary)',
+                cursor: 'pointer',
+                letterSpacing: '-0.1px',
+              }}
+              aria-pressed={kunUleste}
+            >
+              {kunUleste ? 'Viser uleste' : 'Vis kun uleste'}
+            </button>
+
+            <button
+              type="button"
+              onClick={markerAlleLest}
+              disabled={antallUleste === 0 || isPending}
+              style={{
+                background: 'transparent',
+                border: 'none',
+                padding: '6px 4px',
+                fontFamily: 'var(--font-body)',
+                fontSize: 12,
+                fontWeight: 500,
+                color: antallUleste === 0 ? 'var(--text-tertiary)' : 'var(--accent)',
+                opacity: antallUleste === 0 || isPending ? 0.5 : 1,
+                cursor: antallUleste === 0 ? 'default' : 'pointer',
+                letterSpacing: '-0.1px',
+              }}
+            >
+              Marker alle som lest
+            </button>
+          </div>
+
+          {visning.length === 0 ? (
+            <div
+              style={{
+                fontFamily: 'var(--font-body)',
+                fontSize: 13,
+                color: 'var(--text-tertiary)',
+                padding: '18px 4px',
+                textAlign: 'center',
+              }}
+            >
+              {kunUleste ? 'Ingen uleste varsler' : 'Ingen varsler'}
+            </div>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column' }}>
+              {visning.map((v, i) => (
+                <Link
+                  key={v.id}
+                  href={`/varsler/${v.id}`}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'flex-start',
+                    gap: 14,
+                    padding: '14px 4px',
+                    borderBottom:
+                      i < visning.length - 1 ? '0.5px solid var(--border-subtle)' : 'none',
+                    textDecoration: 'none',
+                    color: 'inherit',
+                    opacity: v.lest ? 0.6 : 1,
+                  }}
+                >
+                  <div
+                    style={{
+                      width: 8,
+                      height: 8,
+                      borderRadius: '50%',
+                      background: v.lest ? 'var(--border-subtle)' : 'var(--accent)',
+                      marginTop: 6,
+                      flexShrink: 0,
+                      boxShadow: v.lest
+                        ? 'none'
+                        : '0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent)',
+                    }}
+                  />
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div
+                      style={{
+                        fontFamily: 'var(--font-display)',
+                        fontSize: 15,
+                        fontWeight: 500,
+                        color: 'var(--text-primary)',
+                        letterSpacing: '-0.2px',
+                        lineHeight: 1.2,
+                        marginBottom: 3,
+                      }}
+                    >
+                      {v.tittel}
+                    </div>
+                    {v.melding && (
+                      <div
+                        style={{
+                          fontFamily: 'var(--font-body)',
+                          fontSize: 12,
+                          color: 'var(--text-secondary)',
+                          lineHeight: 1.45,
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          display: '-webkit-box',
+                          WebkitLineClamp: 2,
+                          WebkitBoxOrient: 'vertical',
+                        }}
+                      >
+                        {v.melding}
+                      </div>
+                    )}
+                    {v.opprettet && (
+                      <div
+                        style={{
+                          fontFamily: 'var(--font-mono)',
+                          fontSize: 9,
+                          color: 'var(--text-tertiary)',
+                          letterSpacing: '1.4px',
+                          fontWeight: 600,
+                          textTransform: 'uppercase',
+                          marginTop: 4,
+                        }}
+                      >
+                        {formaterDato(v.opprettet, 'd. MMM · HH:mm')}
+                      </div>
+                    )}
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/lib/actions/varsler.ts
+++ b/lib/actions/varsler.ts
@@ -1,0 +1,21 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { ensureInnlogget } from '@/lib/auth'
+
+/**
+ * Marker alle uleste varsler for innlogget bruker som lest.
+ * RLS sørger for at vi kun rører egne rader.
+ */
+export async function markerAlleVarslerLest() {
+  const { supabase, user } = await ensureInnlogget()
+
+  const { error } = await supabase
+    .from('varsel_logg')
+    .update({ lest: true })
+    .eq('profil_id', user.id)
+    .eq('lest', false)
+
+  if (error) throw new Error(error.message)
+  revalidatePath('/profil')
+}

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 5,
-  "versjon": "V3.1.5"
+  "nummer": 6,
+  "versjon": "V3.1.6"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.5'
+const CACHE_VERSION = 'V3.1.6'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Per Reidar — gjør varsler-seksjonen på profil-fanen interaktiv:

## Endringer

- Ny klient-komponent `components/profil/VarslerListe.tsx` erstatter den server-rendrede listen.
- Tittel: `Varsler (X uleste)` (parantes-format heller enn SectionLabel-count).
- **Kollaps:** chevron-knapp på tittelen — klikk for å skjule listen.
- **Filter:** pill-toggle "Vis kun uleste" / "Viser uleste". Filtrerer lokalt uten re-fetch.
- **Marker alle som lest:** knapp i samme rad — kaller server action `markerAlleVarslerLest` med optimistisk UI (rull tilbake ved feil).
- Tom-state-tekst når filteret skjuler alt: "Ingen uleste varsler".

## Ny server action

`lib/actions/varsler.ts → markerAlleVarslerLest()` — bruker `ensureInnlogget()` per auth-policy, RLS sørger for at vi kun rører egne rader. `revalidatePath('/profil')` etter update.

## Verifisering

- `npm run lint` rent
- `npm run build` rent
