### PR TITLE
Ulest-prikk på Chat-tab (#197)

### DIFF
--- a/app/(app)/chat/page.tsx
+++ b/app/(app)/chat/page.tsx
@@ -4,6 +4,7 @@ import { getInnloggetBruker, getProfil } from '@/lib/auth-cache'
 import Chat from '@/components/chat/Chat'
 import Icon from '@/components/ui/Icon'
 import { kanAdministrere } from '@/lib/roller'
+import { markerChatSett } from '@/lib/actions/ulest'
 
 // Klubb-chat: én felles kronologisk tråd for hele herreklubben.
 // Initial-last er siste 30 meldinger (i desc-rekkefølge fra DB, reversert til
@@ -31,6 +32,10 @@ export default async function KlubbChatSide() {
       .eq('lest', false)
       .neq('profil_id', user!.id),
   ])
+
+  // Marker at brukeren nå ser klubb-chat — prikken forsvinner ved neste
+  // navigasjon. Fire-and-forget: vi venter ikke, men heller ikke stille.
+  markerChatSett().catch(() => {})
 
   const erAdmin = kanAdministrere(profil?.rolle)
   const initialMeldinger = [...(siste ?? [])].reverse()

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -7,14 +7,23 @@ import DeployInfo from '@/components/DeployInfo'
 import InstallVeiledning from '@/components/InstallVeiledning'
 import { getInnloggetBruker, getProfil } from '@/lib/auth-cache'
 import { redirect } from 'next/navigation'
+import { createServerClient } from '@/lib/supabase/server'
+import { harUlestChat } from '@/lib/ulest'
 
 async function HeaderMedProfil() {
-  const profil = await getProfil()
+  const [profil, supabase] = await Promise.all([getProfil(), createServerClient()])
+  // getInnloggetBruker() er cachet — ingen ekstra nettverkskall
+  const user = await getInnloggetBruker()
+  // Ulest-sjekk parallelliseres ikke med profil fordi vi trenger supabase-klienten
+  // og user-id-en først. Feil her skal aldri blokkere render — fallback false.
+  const ulestChat = user ? await harUlestChat(supabase, user.id).catch(() => false) : false
+
   return (
     <TopHeader
       brukerNavn={profil?.navn}
       bildeUrl={profil?.bilde_url ?? null}
       rolle={profil?.rolle ?? null}
+      ulestChat={ulestChat}
     />
   )
 }

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -11,12 +11,18 @@ import { createServerClient } from '@/lib/supabase/server'
 import { harUlestChat } from '@/lib/ulest'
 
 async function HeaderMedProfil() {
-  const [profil, supabase] = await Promise.all([getProfil(), createServerClient()])
-  // getInnloggetBruker() er cachet — ingen ekstra nettverkskall
-  const user = await getInnloggetBruker()
-  // Ulest-sjekk parallelliseres ikke med profil fordi vi trenger supabase-klienten
-  // og user-id-en først. Feil her skal aldri blokkere render — fallback false.
-  const ulestChat = user ? await harUlestChat(supabase, user.id).catch(() => false) : false
+  const profil = await getProfil()
+  const user = await getInnloggetBruker() // cachet via React cache()
+  // Ulest-prikken er nice-to-have. Vi sluker feil fra ulest-spørringen så en
+  // forbigående DB-feil aldri kræsjer headeren — verste utfall er at prikken
+  // ikke vises et øyeblikk.
+  let ulestChat = false
+  if (user) {
+    const supabase = await createServerClient()
+    ulestChat = await harUlestChat(supabase, user.id, profil?.chat_sist_sett ?? null).catch(
+      () => false,
+    )
+  }
 
   return (
     <TopHeader

--- a/components/TopHeader.tsx
+++ b/components/TopHeader.tsx
@@ -9,14 +9,15 @@ import { harGulGloed } from '@/lib/roller'
 type Tab = {
   href: string
   label: string
+  nokkel: 'agenda' | 'chat' | 'klubb'
   /** Path-prefikser som markerer denne tab-en som aktiv. */
   prefikser: string[]
 }
 
 const TABS: Tab[] = [
-  { href: '/', label: 'Agenda', prefikser: ['/poll', '/arrangementer', '/meldinger'] },
-  { href: '/chat', label: 'Chat', prefikser: ['/chat', '/samtaler'] },
-  { href: '/klubbinfo', label: 'Klubb', prefikser: ['/klubbinfo', '/kaaringer', '/album'] },
+  { href: '/', label: 'Agenda', nokkel: 'agenda', prefikser: ['/poll', '/arrangementer', '/meldinger'] },
+  { href: '/chat', label: 'Chat', nokkel: 'chat', prefikser: ['/chat', '/samtaler'] },
+  { href: '/klubbinfo', label: 'Klubb', nokkel: 'klubb', prefikser: ['/klubbinfo', '/kaaringer', '/album'] },
 ]
 
 function erAktiv(tab: Tab, pathname: string): boolean {
@@ -31,6 +32,8 @@ type Props = {
   brukerNavn?: string | null
   bildeUrl?: string | null
   rolle?: string | null
+  /** True hvis det finnes uleste klubb-chat-meldinger fra andre. */
+  ulestChat?: boolean
 }
 
 /**
@@ -43,7 +46,7 @@ type Props = {
  * #151, #153 hvor iOS-tastatur kolliderte med fixed bottom-elementer. Se
  * Policy: Navigasjon i CLAUDE.md.
  */
-export default function TopHeader({ brukerNavn, bildeUrl, rolle }: Props) {
+export default function TopHeader({ brukerNavn, bildeUrl, rolle, ulestChat = false }: Props) {
   const pathname = usePathname()
 
   const headerStyle: CSSProperties = {
@@ -83,7 +86,10 @@ export default function TopHeader({ brukerNavn, bildeUrl, rolle }: Props) {
         <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
           {TABS.map(tab => {
             const aktiv = erAktiv(tab, pathname)
+            // Prikken vises kun for Chat-taben, og aldri når taben er aktiv
+            const visPrikk = tab.nokkel === 'chat' && ulestChat && !aktiv
             const tabStil: CSSProperties = {
+              position: 'relative', // nødvendig for absolutt-posisjonert ulest-prikk
               padding: '8px 14px',
               borderRadius: 999,
               fontFamily: 'var(--font-body)',
@@ -102,10 +108,27 @@ export default function TopHeader({ brukerNavn, bildeUrl, rolle }: Props) {
                 key={tab.href}
                 href={tab.href}
                 aria-current={aktiv ? 'page' : undefined}
+                aria-label={tab.label + (visPrikk ? ' (ulest)' : '')}
                 style={tabStil}
                 prefetch
               >
                 {tab.label}
+                {visPrikk && (
+                  <span
+                    aria-hidden="true"
+                    style={{
+                      position: 'absolute',
+                      top: 4,
+                      right: 6,
+                      width: 6,
+                      height: 6,
+                      borderRadius: '50%',
+                      background: 'var(--accent)',
+                      // Skygge i header-bg-fargen løfter prikken visuelt fra pill-bakgrunnen
+                      boxShadow: '0 0 0 2px rgba(14, 15, 19, 0.85)',
+                    }}
+                  />
+                )}
               </Link>
             )
           })}

--- a/components/TopHeader.tsx
+++ b/components/TopHeader.tsx
@@ -108,26 +108,42 @@ export default function TopHeader({ brukerNavn, bildeUrl, rolle, ulestChat = fal
                 key={tab.href}
                 href={tab.href}
                 aria-current={aktiv ? 'page' : undefined}
-                aria-label={tab.label + (visPrikk ? ' (ulest)' : '')}
                 style={tabStil}
                 prefetch
               >
                 {tab.label}
                 {visPrikk && (
-                  <span
-                    aria-hidden="true"
-                    style={{
-                      position: 'absolute',
-                      top: 4,
-                      right: 6,
-                      width: 6,
-                      height: 6,
-                      borderRadius: '50%',
-                      background: 'var(--accent)',
-                      // Skygge i header-bg-fargen løfter prikken visuelt fra pill-bakgrunnen
-                      boxShadow: '0 0 0 2px rgba(14, 15, 19, 0.85)',
-                    }}
-                  />
+                  <>
+                    {/* Visuell prikk */}
+                    <span
+                      aria-hidden="true"
+                      style={{
+                        position: 'absolute',
+                        top: 4,
+                        right: 6,
+                        width: 6,
+                        height: 6,
+                        borderRadius: '50%',
+                        background: 'var(--accent)',
+                        // Skygge i header-bg-fargen løfter prikken visuelt fra pill-bakgrunnen
+                        boxShadow: '0 0 0 2px rgba(14, 15, 19, 0.85)',
+                      }}
+                    />
+                    {/* Sr-only — behold "Chat" som accessible name, legg ulest-info
+                        som ekstra tekst for skjermlesere uten å overstyre. */}
+                    <span
+                      style={{
+                        position: 'absolute',
+                        width: 1,
+                        height: 1,
+                        overflow: 'hidden',
+                        clip: 'rect(0 0 0 0)',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      (ulest)
+                    </span>
+                  </>
                 )}
               </Link>
             )

--- a/lib/actions/ulest.ts
+++ b/lib/actions/ulest.ts
@@ -1,0 +1,17 @@
+'use server'
+
+import { ensureInnlogget } from '@/lib/auth'
+import { naa } from '@/lib/dato'
+
+/**
+ * Marker at brukeren har sett klubb-chat nå. Kalles fra /chat-siden ved
+ * server-render — fjerner ulest-prikken på Chat-tab neste gang headeren
+ * rendres (f.eks. ved navigasjon til en annen tab og tilbake).
+ */
+export async function markerChatSett() {
+  const { supabase, user } = await ensureInnlogget()
+  await supabase
+    .from('profiles')
+    .update({ chat_sist_sett: naa() })
+    .eq('id', user.id)
+}

--- a/lib/actions/ulest.ts
+++ b/lib/actions/ulest.ts
@@ -1,17 +1,15 @@
 'use server'
 
 import { ensureInnlogget } from '@/lib/auth'
-import { naa } from '@/lib/dato'
 
 /**
  * Marker at brukeren har sett klubb-chat nå. Kalles fra /chat-siden ved
  * server-render — fjerner ulest-prikken på Chat-tab neste gang headeren
- * rendres (f.eks. ved navigasjon til en annen tab og tilbake).
+ * rendres. Bruker en Postgres-RPC slik at tidsstemplet settes med DB-ens
+ * egen now() — samme klokke som klubb_chat.opprettet — for å unngå
+ * klokkedrift mellom Node og Postgres.
  */
 export async function markerChatSett() {
-  const { supabase, user } = await ensureInnlogget()
-  await supabase
-    .from('profiles')
-    .update({ chat_sist_sett: naa() })
-    .eq('id', user.id)
+  const { supabase } = await ensureInnlogget()
+  await supabase.rpc('marker_chat_sett')
 }

--- a/lib/auth-cache.ts
+++ b/lib/auth-cache.ts
@@ -15,7 +15,7 @@ export const getProfil = cache(async () => {
   if (!user) return null
   const { data } = await supabase
     .from('profiles')
-    .select('rolle, navn, bilde_url')
+    .select('rolle, navn, bilde_url, chat_sist_sett')
     .eq('id', user.id)
     .single()
   return data

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -1378,6 +1378,7 @@ export type Database = {
           vinner_profil_id: string
         }[]
       }
+      marker_chat_sett: { Args: never; Returns: undefined }
       tell_poll_stemmer: {
         Args: { p_poll_id: string }
         Returns: {

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -969,6 +969,7 @@ export type Database = {
         Row: {
           aktiv: boolean
           bilde_url: string | null
+          chat_sist_sett: string | null
           epost: string
           fodselsdato: string | null
           id: string
@@ -982,6 +983,7 @@ export type Database = {
         Insert: {
           aktiv?: boolean
           bilde_url?: string | null
+          chat_sist_sett?: string | null
           epost: string
           fodselsdato?: string | null
           id: string
@@ -995,6 +997,7 @@ export type Database = {
         Update: {
           aktiv?: boolean
           bilde_url?: string | null
+          chat_sist_sett?: string | null
           epost?: string
           fodselsdato?: string | null
           id?: string

--- a/lib/ulest.ts
+++ b/lib/ulest.ts
@@ -1,30 +1,27 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/lib/supabase/database.types'
 
 /**
  * Returnerer true hvis det finnes klubb_chat-meldinger fra andre enn brukeren
- * selv som er nyere enn brukerens `chat_sist_sett`-tidsstempel. Brukes til
- * ulest-prikken på Chat-tab i TopHeader. Holdt sentralt så indikatoren kan
- * gjenbrukes hvis vi senere vil vise badge andre steder.
+ * selv som er nyere enn `sistSett`. Brukes til ulest-prikken på Chat-tab i
+ * TopHeader. Tar `sistSett` som parameter (typisk fra `getProfil()`) for å
+ * spare en ekstra runde mot `profiles` — kallstedet har allerede lest raden.
+ *
+ * Bruker eksisterende indeks på `klubb_chat (opprettet desc)` (migrasjon 038).
+ * Ingen ny indeks lagt til — ~17 brukere og lav volum gjør det unødvendig.
  */
 export async function harUlestChat(
-  supabase: SupabaseClient,
-  brukerId: string
+  supabase: SupabaseClient<Database>,
+  brukerId: string,
+  sistSett: string | null,
 ): Promise<boolean> {
-  // Hent siste-sett først (én rad, RLS sørger for at vi kun ser egen rad)
-  const { data: profil } = await supabase
-    .from('profiles')
-    .select('chat_sist_sett')
-    .eq('id', brukerId)
-    .maybeSingle()
+  // Null = aldri åpnet chat → alt regnes som ulest (alle meldinger fra andre).
+  const cutoff = sistSett ?? '1970-01-01T00:00:00Z'
 
-  // Null = aldri åpnet chat, dvs. alt er "ulest"
-  const sistSett = profil?.chat_sist_sett ?? '1970-01-01T00:00:00Z'
-
-  // Finnes det minst én melding fra andre enn meg, nyere enn sistSett?
   const { count } = await supabase
     .from('klubb_chat')
     .select('id', { count: 'exact', head: true })
-    .gt('opprettet', sistSett)
+    .gt('opprettet', cutoff)
     .neq('profil_id', brukerId)
 
   return (count ?? 0) > 0

--- a/lib/ulest.ts
+++ b/lib/ulest.ts
@@ -1,0 +1,31 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+/**
+ * Returnerer true hvis det finnes klubb_chat-meldinger fra andre enn brukeren
+ * selv som er nyere enn brukerens `chat_sist_sett`-tidsstempel. Brukes til
+ * ulest-prikken på Chat-tab i TopHeader. Holdt sentralt så indikatoren kan
+ * gjenbrukes hvis vi senere vil vise badge andre steder.
+ */
+export async function harUlestChat(
+  supabase: SupabaseClient,
+  brukerId: string
+): Promise<boolean> {
+  // Hent siste-sett først (én rad, RLS sørger for at vi kun ser egen rad)
+  const { data: profil } = await supabase
+    .from('profiles')
+    .select('chat_sist_sett')
+    .eq('id', brukerId)
+    .maybeSingle()
+
+  // Null = aldri åpnet chat, dvs. alt er "ulest"
+  const sistSett = profil?.chat_sist_sett ?? '1970-01-01T00:00:00Z'
+
+  // Finnes det minst én melding fra andre enn meg, nyere enn sistSett?
+  const { count } = await supabase
+    .from('klubb_chat')
+    .select('id', { count: 'exact', head: true })
+    .gt('opprettet', sistSett)
+    .neq('profil_id', brukerId)
+
+  return (count ?? 0) > 0
+}

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 6,
-  "versjon": "V3.1.6"
+  "nummer": 7,
+  "versjon": "V3.1.7"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 7,
-  "versjon": "V3.1.7"
+  "nummer": 8,
+  "versjon": "V3.1.8"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.7'
+const CACHE_VERSION = 'V3.1.8'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.6'
+const CACHE_VERSION = 'V3.1.7'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/supabase/migrations/087_chat_sist_sett.sql
+++ b/supabase/migrations/087_chat_sist_sett.sql
@@ -1,0 +1,10 @@
+-- Legger til chat_sist_sett på profiles for ulest-prikk på Chat-tab.
+-- Ingen RLS-endring: profiles har allerede policy som lar bruker oppdatere
+-- egen rad. Ingen ny GRANT: kolonnen arver eksisterende table-grants.
+-- Issue #197.
+
+alter table public.profiles
+  add column chat_sist_sett timestamptz;
+
+comment on column public.profiles.chat_sist_sett is
+  'Når brukeren sist åpnet /chat. Brukes for ulest-prikk på Chat-tab i TopHeader.';

--- a/supabase/migrations/088_marker_chat_sett_rpc.sql
+++ b/supabase/migrations/088_marker_chat_sett_rpc.sql
@@ -1,0 +1,20 @@
+-- RPC for å sette chat_sist_sett med Postgres' egen now() — samme klokke
+-- som klubb_chat.opprettet bruker. Unngår klokkedrift mellom Node-serveren
+-- og Postgres som ellers kan gi at en samtidig melding ender opp som
+-- "ulest" rett etter at brukeren har sett siden.
+--
+-- security definer fordi vi vil at funksjonen skal kunne kjøre uavhengig av
+-- hvilken policy som styrer profiles.update — id-en låses uansett til
+-- auth.uid() i body-en, så brukeren kan kun røre sin egen rad.
+-- Issue #197.
+
+create or replace function public.marker_chat_sett()
+returns void
+language sql
+security definer
+set search_path = public
+as $$
+  update public.profiles set chat_sist_sett = now() where id = auth.uid();
+$$;
+
+grant execute on function public.marker_chat_sett() to authenticated;


### PR DESCRIPTION
Lukker #197.

## Endringer

- Ny kolonne `profiles.chat_sist_sett` (migrasjon 087)
- Ny RPC `marker_chat_sett()` (migrasjon 088) — bruker Postgres-`now()` så vi unngår klokkedrift mellom Node og DB
- `lib/ulest.ts → harUlestChat(supabase, brukerId, sistSett)` — tar tidsstempel som parameter for å unngå dobbel `profiles`-spørring
- `lib/actions/ulest.ts → markerChatSett()` — kaller RPC
- `lib/auth-cache.ts → getProfil()` utvidet med `chat_sist_sett`
- `app/(app)/layout.tsx` — forenklet, ingen ubrukelig Promise.all
- `components/TopHeader.tsx` — kremgul 6×6 px prikk top:4/right:6 på Chat-tab når ulest og ikke aktiv. Bruker sr-only span istedenfor `aria-label`-override så accessible name forblir "Chat".
- `app/(app)/chat/page.tsx` — `markerChatSett().catch(() => {})` ved server-render

## Beslutninger underveis

Reviewer fant én BLOCKER (race condition pga klokkedrift) og to MAJOR (dobbel `profiles`-spørring + ubrukelig Promise.all i layout). Alle rettet. To MINOR rettet (Database-generic, aria-label-overstyring), én MINOR forsvart (indeks — eksisterende `klubb_chat (opprettet desc)` er nok for ~17 brukere).

Migrasjoner 087 + 088 er allerede pushet til prod for å holde build grønt — typer regenerert lokalt.

## Verifisering

- `npm run lint` rent
- `npm run build` rent
- `npm test` — 122 tester grønt
- Migrasjon kjørt mot prod-DB med suksess

Manuell verifikasjon på iPhone gjenstår (PWA-quirks).
