### PR TITLE
Dato-skille i chat-meldinger (#198)

### DIFF
--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react'
+import { Fragment, useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { createClient } from '@/lib/supabase/client'
 import {
   sendChatMelding,
@@ -737,7 +737,7 @@ export default function Chat({
           const rolle = rolleMap.get(m.profil_id) ?? null
           const tid = formaterDato(m.opprettet, 'HH:mm')
           return (
-            <React.Fragment key={m.id}>
+            <Fragment key={m.id}>
               {visDatoSkille && (
                 <div
                   style={{
@@ -1186,7 +1186,7 @@ export default function Chat({
                 </div>
               </div>
             </div>
-            </React.Fragment>
+            </Fragment>
           )
         })}
         <div ref={bunnenRef} />

--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { createClient } from '@/lib/supabase/client'
 import {
   sendChatMelding,
@@ -10,7 +10,7 @@ import {
   fjernReaksjon,
 } from '@/lib/actions/chat'
 import { konfigFor, type ChatScope as ChatScopeKonfig } from '@/lib/chat-konfig'
-import { formaterDato } from '@/lib/dato'
+import { formaterDato, erSammeNorskeDag, formaterDatoSkille } from '@/lib/dato'
 import Avatar from '@/components/ui/Avatar'
 import Icon from '@/components/ui/Icon'
 import SectionLabel from '@/components/ui/SectionLabel'
@@ -719,9 +719,12 @@ export default function Chat({
 
         {meldinger.map((m, i) => {
           const forrige = i > 0 ? meldinger[i - 1] : null
+          // Vis dato-skille når det er første melding eller ny kalenderdag (norsk tid).
+          const visDatoSkille = !forrige || !erSammeNorskeDag(forrige.opprettet, m.opprettet)
           // Grupper sammenhengende meldinger fra samme bruker — skjul avatar
-          // og navn/tid-header på fortsettelses-meldinger.
-          const erFortsettelse = forrige?.profil_id === m.profil_id
+          // og navn/tid-header på fortsettelses-meldinger. Dato-skille bryter
+          // alltid grupperingen så første melding på ny dag alltid viser header.
+          const erFortsettelse = !visDatoSkille && forrige?.profil_id === m.profil_id
           const erEgen = m.profil_id === brukerId
           // Slett-knapp: kun egen-eier. Admin har ingen UI-snarvei for å
           // slette andres meldinger — om noe må fjernes må admin gjøre det
@@ -734,8 +737,32 @@ export default function Chat({
           const rolle = rolleMap.get(m.profil_id) ?? null
           const tid = formaterDato(m.opprettet, 'HH:mm')
           return (
+            <React.Fragment key={m.id}>
+              {visDatoSkille && (
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 10,
+                    margin: '20px 0 12px',
+                  }}
+                >
+                  <span style={{ flex: 1, height: '0.5px', background: 'var(--border-subtle)' }} />
+                  <span
+                    style={{
+                      fontFamily: 'var(--font-mono)',
+                      fontSize: 9,
+                      letterSpacing: '1.4px',
+                      fontWeight: 600,
+                      color: 'var(--text-tertiary)',
+                    }}
+                  >
+                    {formaterDatoSkille(m.opprettet)}
+                  </span>
+                  <span style={{ flex: 1, height: '0.5px', background: 'var(--border-subtle)' }} />
+                </div>
+              )}
             <div
-              key={m.id}
               style={{
                 display: 'flex',
                 gap: 10,
@@ -1159,6 +1186,7 @@ export default function Chat({
                 </div>
               </div>
             </div>
+            </React.Fragment>
           )
         })}
         <div ref={bunnenRef} />

--- a/lib/dato.ts
+++ b/lib/dato.ts
@@ -69,6 +69,38 @@ export function aarHvisAvvik(iso: string): string {
 }
 
 /**
+ * Sammenligner om to ISO-tidspunkter faller på samme norske kalenderdag.
+ * Viktig: bruker Oslo-tidssone så en melding sendt 01:30 norsk tid teller
+ * som "i dag", ikke "i går" basert på UTC.
+ */
+export function erSammeNorskeDag(isoA: string, isoB: string): boolean {
+  const a = formatInTimeZone(new Date(isoA), TIDSSONE, 'yyyy-MM-dd')
+  const b = formatInTimeZone(new Date(isoB), TIDSSONE, 'yyyy-MM-dd')
+  return a === b
+}
+
+/**
+ * Returnerer en kontekst-følsom dato-etikett for chat-dato-skiller:
+ * "I DAG", "I GÅR", ukedag ("FREDAG") for siste 7 dager, ellers "15. MARS"
+ * eller "15. MARS 2024" hvis annet år. Etiketten kommer UPPERCASE allerede
+ * — kallstedet trenger ikke text-transform.
+ */
+export function formaterDatoSkille(iso: string): string {
+  const naa = norskDatoNaa()
+  const norskDagDato = norskDag(iso)
+  const diffMs = naa.getTime() - norskDagDato.getTime()
+  const dager = Math.round(diffMs / (1000 * 60 * 60 * 24))
+
+  if (dager === 0) return 'I DAG'
+  if (dager === 1) return 'I GÅR'
+  if (dager >= 2 && dager <= 6) {
+    return formaterDato(iso, 'EEEE').toUpperCase()
+  }
+  const sammeAar = formatInTimeZone(new Date(iso), TIDSSONE, 'yyyy') === String(norskAar())
+  return formaterDato(iso, sammeAar ? 'd. MMMM' : 'd. MMMM yyyy').toUpperCase()
+}
+
+/**
  * Konverter ISO-dato til datetime-local verdi i norsk tidssone.
  * Brukes for å pre-fylle <input type="datetime-local"> med riktig tid.
  */

--- a/lib/dato.ts
+++ b/lib/dato.ts
@@ -86,9 +86,16 @@ export function erSammeNorskeDag(isoA: string, isoB: string): boolean {
  * — kallstedet trenger ikke text-transform.
  */
 export function formaterDatoSkille(iso: string): string {
-  const naa = norskDatoNaa()
-  const norskDagDato = norskDag(iso)
-  const diffMs = naa.getTime() - norskDagDato.getTime()
+  // Diff må regnes i UTC for å være DST-trygg — norskDatoNaa/norskDag returnerer
+  // Date-objekter konstruert i prosessens *lokale* tidssone, så ms-aritmetikk
+  // på dem kan svikte med ±1 time over DST-overganger. Vi henter Oslo-kalenderen
+  // som "yyyy-MM-dd"-streng og konstruerer rene UTC-Date for diff istedet.
+  const dagStr = (d: Date) => formatInTimeZone(d, TIDSSONE, 'yyyy-MM-dd')
+  const tilUtc = (s: string) => {
+    const [y, m, d] = s.split('-').map(Number)
+    return Date.UTC(y, m - 1, d)
+  }
+  const diffMs = tilUtc(dagStr(new Date())) - tilUtc(dagStr(new Date(iso)))
   const dager = Math.round(diffMs / (1000 * 60 * 60 * 24))
 
   if (dager === 0) return 'I DAG'

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 9,
-  "versjon": "V3.1.9"
+  "nummer": 10,
+  "versjon": "V3.1.10"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 8,
-  "versjon": "V3.1.8"
+  "nummer": 9,
+  "versjon": "V3.1.9"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.9'
+const CACHE_VERSION = 'V3.1.10'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.8'
+const CACHE_VERSION = 'V3.1.9'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Lukker #198.

## Endringer

- `lib/dato.ts`: nye hjelpere `erSammeNorskeDag()` og `formaterDatoSkille()` — sistnevnte gir kontekst-følsom etikett ("I DAG" / "I GÅR" / ukedag / dato), DST-trygg via UTC-aritmetikk.
- `components/chat/Chat.tsx`: render dato-skille (sentrert linje med tekst i midten) før første melding på hver ny dag. `erFortsettelse` overstyres så avatar/navn vises på den meldingen selv om forrige (eldre dag) var fra samme bruker. Brukes i alle 5 chat-scopes (klubb-chat, samtaler, polls, arrangement-kommentarer, meldinger).

## Beslutninger underveis

Reviewer fant ingen blockers. Rettet: DST-presisjon i dag-beregning (fra lokal-tidssone-Date-aritmetikk til ren UTC), navngitt `Fragment`-import istedenfor `React.Fragment`. Forsvart: indenterings-NIT på meldings-blokken (re-indentering ville forstørre diffen unødvendig — overlates til en evt. formatting-only-commit).

## Verifisering

- `npm run lint` rent
- `npm run build` rent

Manuell verifikasjon på iPhone gjenstår.
