### PR TITLE
Animert pill mellom topp-tabs (#200)

### DIFF
--- a/components/TopHeader.tsx
+++ b/components/TopHeader.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { type CSSProperties } from 'react'
+import { type CSSProperties, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import Avatar from '@/components/ui/Avatar'
 import { harGulGloed } from '@/lib/roller'
 
@@ -38,7 +38,8 @@ type Props = {
 
 /**
  * Sticky topp-header med tre alltid-synlige tabs (Agenda / Chat / Klubb) og
- * profil-snarvei høyre. Aktiv tab markert med soft pill-bakgrunn. Path-prefikser
+ * profil-snarvei høyre. Aktiv tab markert med en animert pill-bakgrunn som
+ * glir mellom tabene via CSS transform (FLIP-teknikk). Path-prefikser
  * styrer hvilken tab som er aktiv på undersider (f.eks. `/arrangementer/123`
  * → Agenda aktiv).
  *
@@ -48,6 +49,59 @@ type Props = {
  */
 export default function TopHeader({ brukerNavn, bildeUrl, rolle, ulestChat = false }: Props) {
   const pathname = usePathname()
+
+  // Referanser for å måle pill-posisjon relativt til tabs-containeren
+  const tabsRef = useRef<HTMLDivElement>(null)
+  const tabRefs = useRef<Map<string, HTMLAnchorElement | null>>(new Map())
+
+  // pillRect = null betyr "ingen aktiv tab" (og vi viser ikke pill-en)
+  const [pillRect, setPillRect] = useState<{ left: number; width: number } | null>(null)
+  const [reduserBevegelse, setReduserBevegelse] = useState(false)
+
+  // Lytt på prefers-reduced-motion — skrur av transition for brukere som ønsker det
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
+    setReduserBevegelse(mq.matches)
+    const handler = (e: MediaQueryListEvent) => setReduserBevegelse(e.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [])
+
+  // Trekk ut måling til en lokal funksjon — brukes av både useLayoutEffect og resize-handleren
+  const maalPill = () => {
+    const container = tabsRef.current
+    if (!container) return
+    const aktivTab = TABS.find(t => erAktiv(t, pathname))
+    if (!aktivTab) {
+      setPillRect(null)
+      return
+    }
+    const tabEl = tabRefs.current.get(aktivTab.nokkel)
+    if (!tabEl) return
+    // Mål posisjon relativt til tabs-containeren (ikke viewport) — dette er
+    // translateX-verdien vi sender til pill-elementet
+    const cRect = container.getBoundingClientRect()
+    const tRect = tabEl.getBoundingClientRect()
+    setPillRect({ left: tRect.left - cRect.left, width: tRect.width })
+  }
+
+  // useLayoutEffect = kjører synkront etter DOM-oppdatering, men før paint —
+  // gir riktig posisjon uten visuelt hopp ved navigasjon
+  useLayoutEffect(() => {
+    maalPill()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname, ulestChat])
+
+  // Re-mål ved resize (f.eks. rotering av telefon)
+  useEffect(() => {
+    window.addEventListener('resize', maalPill)
+    window.addEventListener('orientationchange', maalPill)
+    return () => {
+      window.removeEventListener('resize', maalPill)
+      window.removeEventListener('orientationchange', maalPill)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname, ulestChat])
 
   const headerStyle: CSSProperties = {
     position: 'sticky',
@@ -83,13 +137,41 @@ export default function TopHeader({ brukerNavn, bildeUrl, rolle, ulestChat = fal
     <nav style={headerStyle} aria-label="Hovednavigasjon">
       <div style={innerStyle}>
         {/* Tabs */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+        <div
+          ref={tabsRef}
+          style={{ position: 'relative', display: 'flex', alignItems: 'center', gap: 6 }}
+        >
+          {/* Delt pill-bakgrunn — glir mellom tabs via translateX i stedet for
+              at hver tab crossfader sin egen bakgrunn. aria-hidden fordi det
+              kun er et visuelt dekorasjonselement uten semantisk innhold. */}
+          {pillRect && (
+            <span
+              aria-hidden="true"
+              style={{
+                position: 'absolute',
+                top: 0,
+                bottom: 0,
+                left: 0,
+                width: pillRect.width,
+                transform: `translateX(${pillRect.left}px)`,
+                borderRadius: 999,
+                background: 'var(--accent-soft)',
+                pointerEvents: 'none',
+                transition: reduserBevegelse
+                  ? 'none'
+                  : 'transform 220ms cubic-bezier(0.32, 0.72, 0, 1), width 220ms cubic-bezier(0.32, 0.72, 0, 1)',
+                zIndex: 0,
+              }}
+            />
+          )}
+
           {TABS.map(tab => {
             const aktiv = erAktiv(tab, pathname)
             // Prikken vises kun for Chat-taben, og aldri når taben er aktiv
             const visPrikk = tab.nokkel === 'chat' && ulestChat && !aktiv
             const tabStil: CSSProperties = {
-              position: 'relative', // nødvendig for absolutt-posisjonert ulest-prikk
+              position: 'relative', // nødvendig for absolutt-posisjonert ulest-prikk og z-index over pill
+              zIndex: 1, // løft tekst over pill-bakgrunnen
               padding: '8px 14px',
               borderRadius: 999,
               fontFamily: 'var(--font-body)',
@@ -97,16 +179,17 @@ export default function TopHeader({ brukerNavn, bildeUrl, rolle, ulestChat = fal
               fontWeight: aktiv ? 600 : 400,
               color: aktiv ? 'var(--accent)' : 'var(--text-tertiary)',
               opacity: aktiv ? 1 : 0.6,
-              background: aktiv ? 'var(--accent-soft)' : 'transparent',
+              // Ingen background her — pill-elementet over håndterer bakgrunnen
               textDecoration: 'none',
               letterSpacing: '-0.3px',
               lineHeight: 1,
-              transition: 'color 180ms ease, background-color 180ms ease, opacity 180ms ease',
+              transition: 'color 180ms ease, opacity 180ms ease',
             }
             return (
               <Link
                 key={tab.href}
                 href={tab.href}
+                ref={(el) => { tabRefs.current.set(tab.nokkel, el) }}
                 aria-current={aktiv ? 'page' : undefined}
                 style={tabStil}
                 prefetch

--- a/components/TopHeader.tsx
+++ b/components/TopHeader.tsx
@@ -86,22 +86,32 @@ export default function TopHeader({ brukerNavn, bildeUrl, rolle, ulestChat = fal
   }
 
   // useLayoutEffect = kjører synkront etter DOM-oppdatering, men før paint —
-  // gir riktig posisjon uten visuelt hopp ved navigasjon
+  // gir riktig posisjon uten visuelt hopp ved navigasjon. Tradeoff: på første
+  // SSR-render finnes ikke pill (pillRect er null) — den popper inn umiddelbart
+  // etter hydrering. Knapt synlig og vurdert akseptabelt for å unngå at vi må
+  // duplisere aktiv-logikken i en SSR-fallback. Se #200-review.
   useLayoutEffect(() => {
     maalPill()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pathname, ulestChat])
+  }, [pathname])
 
-  // Re-mål ved resize (f.eks. rotering av telefon)
+  // Re-mål ved resize (f.eks. rotering av telefon). rAF-throttles så vi ikke
+  // gjør getBoundingClientRect 60+ ganger i sekundet under desktop-window-drag.
   useEffect(() => {
-    window.addEventListener('resize', maalPill)
-    window.addEventListener('orientationchange', maalPill)
+    let raf = 0
+    const onResize = () => {
+      cancelAnimationFrame(raf)
+      raf = requestAnimationFrame(maalPill)
+    }
+    window.addEventListener('resize', onResize)
+    window.addEventListener('orientationchange', onResize)
     return () => {
-      window.removeEventListener('resize', maalPill)
-      window.removeEventListener('orientationchange', maalPill)
+      cancelAnimationFrame(raf)
+      window.removeEventListener('resize', onResize)
+      window.removeEventListener('orientationchange', onResize)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pathname, ulestChat])
+  }, [pathname])
 
   const headerStyle: CSSProperties = {
     position: 'sticky',

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 11,
-  "versjon": "V3.1.11"
+  "nummer": 12,
+  "versjon": "V3.1.12"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 10,
-  "versjon": "V3.1.10"
+  "nummer": 11,
+  "versjon": "V3.1.11"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.11'
+const CACHE_VERSION = 'V3.1.12'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.10'
+const CACHE_VERSION = 'V3.1.11'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Lukker #200. Følger opp #190 som eksplisitt skrinla animasjonen som "out of scope".

## Endringer

Kun `components/TopHeader.tsx`. Ingen nye avhengigheter.

Pill-bakgrunnen er løftet ut fra per-tab-stilen til ett delt absolutt-posisjonert `<span>`-element som glir mellom posisjonene via `translateX` + `width`-transition. `useLayoutEffect` måler aktiv tab synkront før paint så pill-en alltid står riktig ved navigasjon. iOS spring-easing (`cubic-bezier(0.32, 0.72, 0, 1)`, 220 ms). `prefers-reduced-motion` respekteres — pill hopper umiddelbart for brukere som har bedt om mindre bevegelse.

## Beslutninger underveis

Reviewer fant én MAJOR (SSR-flash første frame) som er akseptert med inline-kommentar — knapt synlig, og alternativet ville duplisert aktiv-logikken i en SSR-fallback. To MINOR rettet: rAF-throttle på resize, fjernet unødvendig `ulestChat`-dependency. NIT om `useCallback`-wrap forsvart (la stå — fungerer som det er).

## Verifisering

- `npm run lint` rent
- `npm run build` rent

Manuell verifikasjon på iPhone gjenstår.
