### PR TITLE
Ulest-prikk på profil-avatar (#203)

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -8,21 +8,22 @@ import InstallVeiledning from '@/components/InstallVeiledning'
 import { getInnloggetBruker, getProfil } from '@/lib/auth-cache'
 import { redirect } from 'next/navigation'
 import { createServerClient } from '@/lib/supabase/server'
-import { harUlestChat } from '@/lib/ulest'
+import { harUlestChat, harUlestVarsler } from '@/lib/ulest'
 
 async function HeaderMedProfil() {
   const profil = await getProfil()
   const user = await getInnloggetBruker() // cachet via React cache()
-  // Ulest-prikken er nice-to-have. Vi sluker feil fra ulest-spørringen så en
+  // Ulest-prikkene er nice-to-have. Vi sluker feil fra ulest-spørringene så en
   // forbigående DB-feil aldri kræsjer headeren — verste utfall er at prikken
-  // ikke vises et øyeblikk.
-  let ulestChat = false
-  if (user) {
-    const supabase = await createServerClient()
-    ulestChat = await harUlestChat(supabase, user.id, profil?.chat_sist_sett ?? null).catch(
-      () => false,
-    )
-  }
+  // ikke vises et øyeblikk. De to spørringene kjøres parallelt for å unngå
+  // serielle DB-runder.
+  const supabase = await createServerClient()
+  const [ulestChat, ulestVarsler] = user
+    ? await Promise.all([
+        harUlestChat(supabase, user.id, profil?.chat_sist_sett ?? null).catch(() => false),
+        harUlestVarsler(supabase, user.id).catch(() => false),
+      ])
+    : [false, false]
 
   return (
     <TopHeader
@@ -30,6 +31,7 @@ async function HeaderMedProfil() {
       bildeUrl={profil?.bilde_url ?? null}
       rolle={profil?.rolle ?? null}
       ulestChat={ulestChat}
+      ulestVarsler={ulestVarsler}
     />
   )
 }

--- a/components/TopHeader.tsx
+++ b/components/TopHeader.tsx
@@ -269,13 +269,15 @@ export default function TopHeader({ brukerNavn, bildeUrl, rolle, ulestChat = fal
           />
           {visProfilPrikk && (
             <>
-              {/* Visuell prikk — samme stil som chat-tab-prikken */}
+              {/* Visuell prikk — samme stil som chat-tab-prikken. Plassert
+                  med top/right -1 så den stikker akkurat utenfor avatar-sirkelen
+                  istedenfor å overlappe den (og evt. generalsekretærens gule glød). */}
               <span
                 aria-hidden="true"
                 style={{
                   position: 'absolute',
-                  top: 0,
-                  right: 0,
+                  top: -1,
+                  right: -1,
                   width: 6,
                   height: 6,
                   borderRadius: '50%',

--- a/components/TopHeader.tsx
+++ b/components/TopHeader.tsx
@@ -34,6 +34,8 @@ type Props = {
   rolle?: string | null
   /** True hvis det finnes uleste klubb-chat-meldinger fra andre. */
   ulestChat?: boolean
+  /** True hvis det finnes uleste varsler i varsel_logg for denne brukeren. */
+  ulestVarsler?: boolean
 }
 
 /**
@@ -47,7 +49,7 @@ type Props = {
  * #151, #153 hvor iOS-tastatur kolliderte med fixed bottom-elementer. Se
  * Policy: Navigasjon i CLAUDE.md.
  */
-export default function TopHeader({ brukerNavn, bildeUrl, rolle, ulestChat = false }: Props) {
+export default function TopHeader({ brukerNavn, bildeUrl, rolle, ulestChat = false, ulestVarsler = false }: Props) {
   const pathname = usePathname()
 
   // Referanser for å måle pill-posisjon relativt til tabs-containeren
@@ -142,6 +144,8 @@ export default function TopHeader({ brukerNavn, bildeUrl, rolle, ulestChat = fal
   // outline i tillegg gir to overlappende gule ringer. Drop outline her,
   // gloeden alene markerer at /profil er aktiv siden for ham.
   const visAktivOutline = profilAktiv && !harGulGloed(rolle ?? null)
+  // Prikken vises kun når profil-siden ikke er aktiv (samme logikk som chat-prikken)
+  const visProfilPrikk = ulestVarsler && !profilAktiv
 
   return (
     <nav style={headerStyle} aria-label="Hovednavigasjon">
@@ -249,6 +253,7 @@ export default function TopHeader({ brukerNavn, bildeUrl, rolle, ulestChat = fal
           aria-label="Min profil"
           aria-current={profilAktiv ? 'page' : undefined}
           style={{
+            position: 'relative', // nødvendig for absolutt-posisjonert ulest-prikk
             display: 'block',
             borderRadius: '50%',
             outline: visAktivOutline ? '1.5px solid var(--accent)' : 'none',
@@ -262,6 +267,37 @@ export default function TopHeader({ brukerNavn, bildeUrl, rolle, ulestChat = fal
             rolle={rolle ?? null}
             size={38}
           />
+          {visProfilPrikk && (
+            <>
+              {/* Visuell prikk — samme stil som chat-tab-prikken */}
+              <span
+                aria-hidden="true"
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  right: 0,
+                  width: 6,
+                  height: 6,
+                  borderRadius: '50%',
+                  background: 'var(--accent)',
+                  boxShadow: '0 0 0 2px rgba(14, 15, 19, 0.85)',
+                }}
+              />
+              {/* Sr-only — behold "Min profil" som accessible name */}
+              <span
+                style={{
+                  position: 'absolute',
+                  width: 1,
+                  height: 1,
+                  overflow: 'hidden',
+                  clip: 'rect(0 0 0 0)',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                (ulest)
+              </span>
+            </>
+          )}
         </Link>
       </div>
     </nav>

--- a/lib/ulest.ts
+++ b/lib/ulest.ts
@@ -26,3 +26,23 @@ export async function harUlestChat(
 
   return (count ?? 0) > 0
 }
+
+/**
+ * Returnerer true hvis brukeren har minst én ulest rad i `varsel_logg`.
+ * Brukes til ulest-prikken på profil-avataren i TopHeader. Vi trenger ingen
+ * `sist_sett`-kolonne her fordi `varsel_logg.lest` bærer per-rad-statusen —
+ * markering skjer automatisk når man åpner et varsel eller bruker "Marker
+ * alle som lest"-knappen på profilsiden.
+ */
+export async function harUlestVarsler(
+  supabase: SupabaseClient<Database>,
+  brukerId: string,
+): Promise<boolean> {
+  const { count } = await supabase
+    .from('varsel_logg')
+    .select('id', { count: 'exact', head: true })
+    .eq('profil_id', brukerId)
+    .eq('lest', false)
+
+  return (count ?? 0) > 0
+}

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 12,
-  "versjon": "V3.1.12"
+  "nummer": 13,
+  "versjon": "V3.1.13"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 13,
-  "versjon": "V3.1.13"
+  "nummer": 14,
+  "versjon": "V3.1.14"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.13'
+const CACHE_VERSION = 'V3.1.14'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.12'
+const CACHE_VERSION = 'V3.1.13'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Lukker #203. Speiler #197-mønsteret (ulest-prikk på chat-tab) for profil-avataren.

## Endringer

- `lib/ulest.ts`: ny `harUlestVarsler(supabase, brukerId)` — `count` på `varsel_logg` med `lest = false`. Trenger ikke `sist_sett`-kolonne fordi `lest`-feltet bærer per-rad-statusen, og markering skjer allerede via `/varsler/[id]`-besøk + "Marker alle som lest"-knappen på profil.
- `app/(app)/layout.tsx`: `harUlestChat` og `harUlestVarsler` kjøres parallelt via `Promise.all`.
- `components/TopHeader.tsx`: ny prop `ulestVarsler`. Når ulest og ikke på `/profil`: render 6×6 px kremgul prikk + sr-only "(ulest)"-span inni profil-Link. `position: relative` lagt til Link-en. Plassert med `top:-1, right:-1` så prikken stikker akkurat utenfor avatar-sirkelen.

## Beslutninger underveis

Reviewer fant ingen blockers. MINOR om prikk-plassering rettet (`-1px` offset så den ikke kolliderer med avatar-kanten eller generalsekretærens gule ring). MINOR om unødvendig spørring for brukere uten varsler forsvart (Promise.all parallelliserer, count med head:true er lett). NIT-er om duplisert sr-only-markup forsvart — to bruk er ikke en regel ennå, refaktor venter til tredje tilfelle.

## Verifisering

- `npm run lint` rent
- `npm run build` rent

Visuell verifikasjon (særlig på Andrés profil med gul glød) gjenstår på iPhone.
