### PR TITLE
Tydeligere ulest-prikk på profil-avatar (#205)

### DIFF
--- a/components/TopHeader.tsx
+++ b/components/TopHeader.tsx
@@ -269,20 +269,20 @@ export default function TopHeader({ brukerNavn, bildeUrl, rolle, ulestChat = fal
           />
           {visProfilPrikk && (
             <>
-              {/* Visuell prikk — samme stil som chat-tab-prikken. Plassert
-                  med top/right -1 så den stikker akkurat utenfor avatar-sirkelen
-                  istedenfor å overlappe den (og evt. generalsekretærens gule glød). */}
+              {/* Visuell prikk — større og mer "stikker ut" enn chat-tab-prikken
+                  fordi avataren er rundt og prikken må konkurrere mot bilde-innholdet.
+                  Se #205 — Reidar ba om mer tydelig versjon. */}
               <span
                 aria-hidden="true"
                 style={{
                   position: 'absolute',
-                  top: -1,
-                  right: -1,
-                  width: 6,
-                  height: 6,
+                  top: -2,
+                  right: -2,
+                  width: 10,
+                  height: 10,
                   borderRadius: '50%',
                   background: 'var(--accent)',
-                  boxShadow: '0 0 0 2px rgba(14, 15, 19, 0.85)',
+                  boxShadow: '0 0 0 2.5px rgba(14, 15, 19, 0.95)',
                 }}
               />
               {/* Sr-only — behold "Min profil" som accessible name */}

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 14,
-  "versjon": "V3.1.14"
+  "nummer": 15,
+  "versjon": "V3.1.15"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.14'
+const CACHE_VERSION = 'V3.1.15'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Lukker #205. Prikken økt fra 6×6 → 10×10 px, offset fra -1 → -2, og mørk skygge-ring fra 2px → 2.5px så den stikker tydeligere ut fra avatar-sirkelen.