### PR TITLE
Fiks profil-prikk: tell uleste fra hele DB (#207)

### DIFF
--- a/app/(app)/profil/page.tsx
+++ b/app/(app)/profil/page.tsx
@@ -22,6 +22,7 @@ export default async function Profil() {
     { data: ansvar },
     { data: varselPref },
     { data: varsler },
+    { count: antallUlesteVarsler },
     { data: passInfo },
   ] = await Promise.all([
     supabase
@@ -55,6 +56,14 @@ export default async function Profil() {
       .eq('profil_id', user!.id)
       .order('opprettet', { ascending: false })
       .limit(10),
+    // Total ulest-count på tvers av hele historikken — listen viser kun
+    // top 10, men "Marker alle som lest"-knappen og tellingen i tittelen
+    // må kjenne til alle uleste, også de eldre enn topp 10. Se #207.
+    supabase
+      .from('varsel_logg')
+      .select('id', { count: 'exact', head: true })
+      .eq('profil_id', user!.id)
+      .eq('lest', false),
     // RLS sørger for at vi kun får egen rad. maybeSingle siden raden
     // ikke nødvendigvis finnes ennå.
     supabase
@@ -323,9 +332,13 @@ export default async function Profil() {
       />
 
       {/* Personlige varsler — interaktiv klient-komponent med filter, kollaps
-          og marker-alle-lest. */}
-      {varsler && varsler.length > 0 && (
-        <VarslerListe varsler={varsler} />
+          og marker-alle-lest. Vis seksjonen hvis det enten finnes varsler i
+          top 10 ELLER hvis det finnes uleste eldre enn top 10 (se #207). */}
+      {((varsler && varsler.length > 0) || (antallUlesteVarsler ?? 0) > 0) && (
+        <VarslerListe
+          varsler={varsler ?? []}
+          antallUlesteTotal={antallUlesteVarsler ?? 0}
+        />
       )}
 
       {/* Pass og Innspill samlet nederst — sjeldent brukt, eller mest praktisk

--- a/components/profil/VarslerListe.tsx
+++ b/components/profil/VarslerListe.tsx
@@ -16,31 +16,46 @@ export type VarselRad = {
 
 type Props = {
   varsler: VarselRad[]
+  /**
+   * Totalt antall uleste varsler i DB (også eldre enn de 10 vi henter til
+   * listen). Tellingen i tittelen og "Marker alle som lest"-knappen bruker
+   * denne — uten den ville Reidar med 116 uleste eldre + 0 uleste i top 10
+   * sett "Varsler (0 uleste)" og en disabled knapp, men prikken på avataren
+   * fortsatt aktiv. Se #207.
+   */
+  antallUlesteTotal: number
 }
 
 // Klient-komponent fordi vi vil ha lokal state for kollaps og filter uten
 // å re-fetche fra serveren. Marker-alle-lest kaller server action og lar
 // revalidatePath sørge for at neste render reflekterer endringen — vi
 // oppdaterer også lokal state med en gang for momentan UI-feedback.
-export default function VarslerListe({ varsler: initialVarsler }: Props) {
+export default function VarslerListe({
+  varsler: initialVarsler,
+  antallUlesteTotal: initialAntallUlesteTotal,
+}: Props) {
   const [varsler, setVarsler] = useState(initialVarsler)
+  // Total ulest-count som lokal state så optimistisk marker-alle-lest kan
+  // nulle den umiddelbart uten å vente på revalidatePath.
+  const [antallUlesteTotal, setAntallUlesteTotal] = useState(initialAntallUlesteTotal)
   const [kollapset, setKollapset] = useState(false)
   const [kunUleste, setKunUleste] = useState(false)
   const [isPending, startTransition] = useTransition()
 
-  const antallUleste = varsler.filter(v => !v.lest).length
   const visning = kunUleste ? varsler.filter(v => !v.lest) : varsler
 
   function markerAlleLest() {
-    if (antallUleste === 0) return
+    if (antallUlesteTotal === 0) return
     startTransition(async () => {
       // Optimistisk oppdatering — server action får siste ord via revalidatePath.
       setVarsler(varsler.map(v => ({ ...v, lest: true })))
+      setAntallUlesteTotal(0)
       try {
         await markerAlleVarslerLest()
       } catch {
         // Ved feil: rull tilbake lokal state.
         setVarsler(initialVarsler)
+        setAntallUlesteTotal(initialAntallUlesteTotal)
       }
     })
   }
@@ -94,7 +109,7 @@ export default function VarslerListe({ varsler: initialVarsler }: Props) {
             ▼
           </span>
           <span>
-            Varsler ({antallUleste} uleste)
+            Varsler ({antallUlesteTotal} uleste)
           </span>
         </button>
         <span style={{ flex: 1, height: '0.5px', background: 'var(--border-subtle)' }} />
@@ -136,7 +151,7 @@ export default function VarslerListe({ varsler: initialVarsler }: Props) {
             <button
               type="button"
               onClick={markerAlleLest}
-              disabled={antallUleste === 0 || isPending}
+              disabled={antallUlesteTotal === 0 || isPending}
               style={{
                 background: 'transparent',
                 border: 'none',
@@ -144,9 +159,9 @@ export default function VarslerListe({ varsler: initialVarsler }: Props) {
                 fontFamily: 'var(--font-body)',
                 fontSize: 12,
                 fontWeight: 500,
-                color: antallUleste === 0 ? 'var(--text-tertiary)' : 'var(--accent)',
-                opacity: antallUleste === 0 || isPending ? 0.5 : 1,
-                cursor: antallUleste === 0 ? 'default' : 'pointer',
+                color: antallUlesteTotal === 0 ? 'var(--text-tertiary)' : 'var(--accent)',
+                opacity: antallUlesteTotal === 0 || isPending ? 0.5 : 1,
+                cursor: antallUlesteTotal === 0 ? 'default' : 'pointer',
                 letterSpacing: '-0.1px',
               }}
             >

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 15,
-  "versjon": "V3.1.15"
+  "nummer": 16,
+  "versjon": "V3.1.16"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.15'
+const CACHE_VERSION = 'V3.1.16'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Lukker #207.

Bug: prikken teller alle uleste i DB, men listen viste kun de 10 nyeste. Brukere med uleste eldre enn top 10 ser "Varsler (0 uleste)" og en disabled "Marker alle"-knapp samtidig som prikken er aktiv. Reidar har 116 uleste — kun 1 i top 10.

Fiks: server henter `antallUlesteTotal` som separat count og sender til VarslerListe. Brukes for både tittel og knapp. Seksjonen vises også når det er uleste eldre enn top 10.

`npm run lint` + `npm run build` grønt.