### PR TITLE
Fjern flikk på chat-fanen (#209)

### DIFF
--- a/app/(app)/chat/page.tsx
+++ b/app/(app)/chat/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { createServerClient } from '@/lib/supabase/server'
 import { getInnloggetBruker, getProfil } from '@/lib/auth-cache'
 import Chat from '@/components/chat/Chat'
+import ChatAutoScrollScript from '@/components/chat/ChatAutoScrollScript'
 import Icon from '@/components/ui/Icon'
 import { kanAdministrere } from '@/lib/roller'
 import { markerChatSett } from '@/lib/actions/ulest'
@@ -43,6 +44,7 @@ export default async function KlubbChatSide() {
 
   return (
     <div style={{ padding: '0 20px 20px' }}>
+      <ChatAutoScrollScript />
       {/* Breadcrumb + tittel */}
       <div style={{ padding: '12px 4px 22px' }}>
         <div

--- a/app/(app)/samtaler/[id]/page.tsx
+++ b/app/(app)/samtaler/[id]/page.tsx
@@ -5,6 +5,7 @@ import { getInnloggetBruker, getProfil } from '@/lib/auth-cache'
 import { kanAdministrere } from '@/lib/roller'
 import Avatar from '@/components/ui/Avatar'
 import Chat from '@/components/chat/Chat'
+import ChatAutoScrollScript from '@/components/chat/ChatAutoScrollScript'
 import { markerSamtaleLest } from '@/lib/actions/samtaler'
 
 type SamtaleRad = {
@@ -81,6 +82,7 @@ export default async function SamtaleDetalj({
 
   return (
     <div style={{ padding: '0 20px 20px' }}>
+      <ChatAutoScrollScript />
       <header style={{ marginTop: 12, marginBottom: 22 }}>
         <Link
           href="/samtaler"

--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -226,10 +226,14 @@ export default function Chat({
   }
 
   const scrollTilBunn = useCallback((instant = false) => {
-    // scrollIntoView legger elementet ved viewport-bunnen, men der ligger
-    // docken (fixed) oppå — så meldingen blir skjult bak. Vi scroller
-    // i stedet hele siden helt nederst. Input-pillet under bunnenRef gir
-    // naturlig avstand mellom siste melding og docken.
+    // window.scrollTo (ikke scrollIntoView) fordi vi vil ha hele siden
+    // til bunnen, ikke kun bunnen av meldingsblokken. Sticky input-pill
+    // under bunnenRef gir naturlig avstand.
+    //
+    // Initial-mount-scroll håndteres nå av <ChatAutoScrollScript /> i
+    // sidens markup (kjører før hydrering, eliminerer flikket fra #209).
+    // Denne useCallback brukes fortsatt for realtime-INSERT-grenen og som
+    // defense-in-depth-fallback hvis inline-scriptet blokkeres.
     if (typeof window === 'undefined') return
     window.scrollTo({
       top: document.documentElement.scrollHeight,

--- a/components/chat/ChatAutoScrollScript.tsx
+++ b/components/chat/ChatAutoScrollScript.tsx
@@ -1,0 +1,27 @@
+/**
+ * Inline script som scroller window til bunn FØR React hydrerer. Brukes
+ * på chat-fokuserte sider (/chat, /samtaler/[id]) for å unngå flikket
+ * der SSR-HTML tegnes med scroll på top, og deretter spretter til bunn
+ * etter at useEffect kjører.
+ *
+ * Tilnærmingen er samme klassiske mønster som brukes for theme-toggle
+ * (light/dark) for å unngå "flash of unstyled content". Synkront script
+ * i body-en kjører før resten av siden er parsed/tegnet — så scroll-
+ * posisjonen er på plass før første frame brukeren ser.
+ *
+ * Defense-in-depth: `Chat.tsx` har fortsatt en useEffect-fallback som
+ * scroller til bunn ved mount. Hvis CSP eller annet hindrer dette
+ * scriptet i å kjøre, faller vi tilbake til den gamle oppførselen.
+ *
+ * Se #209 (bug-fiks) og #210 (langsiktig intern-scroll-arkitektur).
+ */
+export default function ChatAutoScrollScript() {
+  return (
+    <script
+      dangerouslySetInnerHTML={{
+        __html:
+          "try{window.scrollTo(0,document.documentElement.scrollHeight)}catch(e){}",
+      }}
+    />
+  )
+}

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 16,
-  "versjon": "V3.1.16"
+  "nummer": 17,
+  "versjon": "V3.1.17"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.16'
+const CACHE_VERSION = 'V3.1.17'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Lukker #209. Refererer langsiktig refactor i #210.

## Endring

Liten klient-komponent `ChatAutoScrollScript` rendrer et inline `<script>` som setter `window.scrollTo(0, scrollHeight)` synkront før React hydrerer. Mountes øverst i `/chat` og `/samtaler/[id]`. Defense-in-depth: `Chat.tsx` beholder eksisterende useEffect-fallback hvis scriptet skulle feile.

Same mønster som brukes for theme-toggle-flash. Stygt på papir, robust i praksis.

## Beslutninger underveis

Vurdert mot 3 alternativer (column-reverse, intern scroll-container, skjul-til-ferdig). Valgt inline-script som lavest risk + raskest fiks. Den større arkitektur-omleggingen til intern scroll-container er tracket i #210 som eget initiativ.

## Verifisering

- `npm run lint` rent
- `npm run build` rent

Manuell verifikasjon på iPhone gjenstår.