### PR TITLE
Chat: hold input-pillen alltid nederst i viewportet, og over tastaturet (#216)

### DIFF
--- a/components/DraNedForOppdater.tsx
+++ b/components/DraNedForOppdater.tsx
@@ -19,8 +19,22 @@ export default function DraNedForOppdater() {
   const draRef = useRef(0)
 
   useEffect(() => {
+    // Sjekker om brukeren skriver i et tekstfelt (chat-input, kommentar,
+    // tittel-redigering osv). Da skal dra-ned ikke aktiveres — én gest
+    // mindre som kan kollidere med tastatur og forskyve input-pillen
+    // (jf. #216).
+    function brukerSkriver() {
+      const el = document.activeElement
+      if (!el) return false
+      const tag = el.tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return true
+      if ((el as HTMLElement).isContentEditable) return true
+      return false
+    }
+
     function start(e: TouchEvent) {
       if (window.scrollY > 0) return
+      if (brukerSkriver()) return
       startY.current = e.touches[0].clientY
       tracking.current = true
       draRef.current = 0

--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -263,6 +263,41 @@ export default function Chat({
     if (autoScrollTilBunn && diff > 0 && diff <= 3) scrollTilBunn()
   }, [meldinger.length, scrollTilBunn, autoScrollTilBunn])
 
+  // Tastatur-høyde via visualViewport. Når iOS-tastaturet åpner med
+  // interactiveWidget='overlays-content' (jf. app/layout.tsx, valgt for å
+  // unngå dock-bug-klassen) endrer ikke window.innerHeight seg, men
+  // visualViewport.height krymper. Differansen er omtrent tastatur-høyden.
+  // Vi bruker den til å løfte input-pillen over tastaturet — og på chat-
+  // fokuserte sider også til å vokse meldings-listas bunnpadding så siste
+  // melding holder seg synlig. Se #216.
+  const [keyboardOffset, setKeyboardOffset] = useState(0)
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.visualViewport) return
+    const vv = window.visualViewport
+    function oppdater() {
+      const offset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop)
+      setKeyboardOffset(offset)
+    }
+    vv.addEventListener('resize', oppdater)
+    vv.addEventListener('scroll', oppdater)
+    oppdater()
+    return () => {
+      vv.removeEventListener('resize', oppdater)
+      vv.removeEventListener('scroll', oppdater)
+    }
+  }, [])
+
+  // Når tastaturet åpner på chat-fokuserte sider, scroll til ny bunn slik
+  // at siste melding fortsetter å være synlig like over input-pillen.
+  // Uten dette ville den vokste paddingBottom-en bare lagt til tom plass
+  // under siste melding uten å flytte brukerens scroll-posisjon.
+  useEffect(() => {
+    if (!autoScrollTilBunn) return
+    if (keyboardOffset > 0) {
+      requestAnimationFrame(() => scrollTilBunn(true))
+    }
+  }, [keyboardOffset, autoScrollTilBunn, scrollTilBunn])
+
   // Realtime-subscription — én kanal per scope
   useEffect(() => {
     let cancelled = false
@@ -692,18 +727,23 @@ export default function Chat({
         </div>
       )}
 
-      {/* Meldingsliste — padding-bottom må romme sticky input-pillen så ingen
+      {/* Meldingsliste — padding-bottom må romme input-pillen så ingen
           melding havner visuelt bak den. ~48px = pill-høyde (button 32 + 8+8
           padding) + buffer for grupperingsavstand. Tidligere kuttet ned til
           bare safe-area, men siden iOS-safe-area-inset-bottom (~34px) er
           større enn wrapperens 20px padding, endte sticky-pillen et stykke
-          over sin naturlige posisjon og dekket siste melding. */}
+          over sin naturlige posisjon og dekket siste melding.
+          På chat-fokuserte sider vokser paddingen i tillegg med keyboardOffset
+          slik at dokumentet blir høyt nok til å scrolle siste melding opp
+          over tastaturet når det åpner (jf. #216). */}
       <div
         style={{
           display: 'flex',
           flexDirection: 'column',
           marginBottom: 4,
-          paddingBottom: 'calc(64px + env(safe-area-inset-bottom))',
+          paddingBottom: autoScrollTilBunn
+            ? `calc(64px + ${keyboardOffset}px + env(safe-area-inset-bottom))`
+            : 'calc(64px + env(safe-area-inset-bottom))',
         }}
       >
         {meldinger.length === 0 && (
@@ -1196,16 +1236,57 @@ export default function Chat({
         <div ref={bunnenRef} />
       </div>
 
-      {/* Sticky-container med mention-chips, bilde-preview, evt. feilmelding
-          og input-pill. Mention-chips ligger inni sticky for å unngå at de
-          skjules bak input-pill når flere chips wrappes til flere linjer. */}
+      {/* Container med mention-chips, bilde-preview, evt. feilmelding
+          og input-pill. Mention-chips ligger inni for å unngå at de
+          skjules bak input-pill når flere chips wrappes til flere linjer.
+          På chat-fokuserte sider er container fixed til bunn av viewportet
+          så pillen alltid er synlig (også når innholdet er kortere enn
+          skjermen); ellers sticky, sånn at den følger med når brukeren
+          scroller chat-seksjonen inn i bilde på detalj-sider.
+          `bottom` løftes med keyboardOffset så pillen holder seg over
+          iOS-tastaturet (jf. #216). */}
       <div
-        style={{
-          position: 'sticky',
-          bottom: 'env(safe-area-inset-bottom)',
-          zIndex: 20,
-        }}
+        style={
+          autoScrollTilBunn
+            ? {
+                position: 'fixed',
+                left: 0,
+                right: 0,
+                bottom:
+                  keyboardOffset > 0
+                    ? `${keyboardOffset}px`
+                    : 'env(safe-area-inset-bottom)',
+                zIndex: 20,
+                display: 'flex',
+                justifyContent: 'center',
+                // pointer-events: none på ytre wrapper så taps over/under
+                // pillen treffer chat-innholdet under; inner gjenoppretter
+                // pointer-events for selve pillen.
+                pointerEvents: 'none',
+              }
+            : {
+                position: 'sticky',
+                bottom:
+                  keyboardOffset > 0
+                    ? `${keyboardOffset}px`
+                    : 'env(safe-area-inset-bottom)',
+                zIndex: 20,
+              }
+        }
       >
+        <div
+          style={
+            autoScrollTilBunn
+              ? {
+                  width: '100%',
+                  maxWidth: 480,
+                  padding: '0 20px',
+                  boxSizing: 'border-box',
+                  pointerEvents: 'auto',
+                }
+              : undefined
+          }
+        >
       {/* @mention-forslag */}
       <MentionVelger forslag={mentionForslag} onVelg={velgMention} />
       {/* Bilde-forhåndsvisning over input når et bilde er valgt */}
@@ -1362,6 +1443,7 @@ export default function Chat({
         >
           <Icon name="arrowRight" size={14} color="#0a0a0a" strokeWidth={2.5} />
         </button>
+      </div>
       </div>
       </div>
 


### PR DESCRIPTION
Lukker #216.

## Hva
- Sporer `keyboardOffset` via `visualViewport` så input-pillen kan løftes over iOS-tastaturet (vi kjører `interactiveWidget: 'overlays-content'` som krymper kun `visualViewport`, ikke layout-viewport).
- På chat-fokuserte sider (`autoScrollTilBunn`) bytter input-wrapperen fra `position: sticky` til `position: fixed`, sentrert innenfor 480 px-kolonnen. Pillen er nå **alltid** nederst i viewportet — også når innholdet er kortere enn skjermen.
- Meldings-listas `paddingBottom` vokser med `keyboardOffset` og siden re-scrolles til bunn så siste melding holder seg synlig rett over pillen når tastaturet åpner.
- På detalj-sider (chat som seksjon under hoved-innhold) beholdes `sticky`, men `bottom` løftes også med `keyboardOffset`.
- `DraNedForOppdater` hopper over touch-tracking når brukeren er i et tekstfelt — én gest mindre som kan kollidere med tastatur og forskyve pillen.

## Hvorfor
Issue #216: input-bobla skulle alltid være nederst i vinduet (i motsetning til docken som kunne forsvinne), og flytte seg opp med tastaturet. Tidligere sticky-posisjon brøyt med kort innhold (pillen havnet midt på skjermen) og med åpent tastatur på iOS (pillen havnet bak tastaturet siden layout-viewport ikke krymper med `overlays-content`).

## Test plan
- [ ] Manuelt på iPhone PWA: åpne /chat, sjekk at pillen er nederst både ved få meldinger og full chat-historikk
- [ ] Manuelt på iPhone PWA: tap input → pillen skal følge tastaturet opp, siste melding skal være synlig rett over pillen
- [ ] Manuelt på iPhone PWA: prøv å dra ned (pull-to-refresh) mens du skriver — skal ikke trigge
- [ ] /samtaler/[id]: samme oppførsel som /chat
- [ ] Detalj-sider (/arrangementer/[id], /poll/[id], /meldinger/[id]): chat-seksjon fortsatt scrollbar og pillen sticky til bunn av seksjonen
- [x] Lint, type-check, vitest (122 tester) grønt

Playwright fanger ikke iOS-tastatur-quirks (jf. CLAUDE.md "Policy: Visuell verifikasjon") — manuell iPhone-test trengs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvxG9TrYS8kBWjmAtS5aqV)_