### PR TITLE
Fjern ulest-prikk på profil-avatar uten pull-to-refresh (#218)

### DIFF
--- a/app/(app)/varsler/[id]/page.tsx
+++ b/app/(app)/varsler/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { createServerClient } from '@/lib/supabase/server'
 import { getInnloggetBruker } from '@/lib/auth-cache'
 import { notFound } from 'next/navigation'
+import { revalidatePath } from 'next/cache'
 import Link from 'next/link'
 import { formaterDato } from '@/lib/dato'
 
@@ -19,6 +20,11 @@ export default async function VarselSide({ params }: { params: Promise<{ id: str
 
   if (!varsel.lest) {
     await supabase.from('varsel_logg').update({ lest: true }).eq('id', id)
+    // Revaliderer layoutet så ulest-prikken på profil-avataren (rendres
+    // fra TopHeader i (app)/layout.tsx) oppdaterer seg neste gang
+    // brukeren navigerer. Uten dette beholder Next.js cached layout-RSC
+    // og prikken henger igjen til pull-to-refresh. Se #218.
+    revalidatePath('/profil', 'layout')
   }
 
   return (

--- a/app/(app)/varsler/[id]/page.tsx
+++ b/app/(app)/varsler/[id]/page.tsx
@@ -19,12 +19,19 @@ export default async function VarselSide({ params }: { params: Promise<{ id: str
   if (!varsel) notFound()
 
   if (!varsel.lest) {
-    await supabase.from('varsel_logg').update({ lest: true }).eq('id', id)
-    // Revaliderer layoutet så ulest-prikken på profil-avataren (rendres
-    // fra TopHeader i (app)/layout.tsx) oppdaterer seg neste gang
-    // brukeren navigerer. Uten dette beholder Next.js cached layout-RSC
-    // og prikken henger igjen til pull-to-refresh. Se #218.
-    revalidatePath('/profil', 'layout')
+    const { error: oppdaterFeil } = await supabase
+      .from('varsel_logg')
+      .update({ lest: true })
+      .eq('id', id)
+    // Revaliderer kun ved suksess — ellers ville en stille feil ført
+    // til at vi invaliderer cachen uten at noe har endret seg, og prikken
+    // ville fortsatt hengt igjen. Layoutet revalideres med 'layout' fordi
+    // ulest-prikken rendres fra TopHeader i (app)/layout.tsx. Uten dette
+    // beholder Next.js cached layout-RSC og prikken henger igjen til
+    // pull-to-refresh. Se #218.
+    if (!oppdaterFeil) {
+      revalidatePath('/profil', 'layout')
+    }
   }
 
   return (

--- a/components/profil/VarslerListe.tsx
+++ b/components/profil/VarslerListe.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { useState, useTransition } from 'react'
 import { formaterDato } from '@/lib/dato'
 import { markerAlleVarslerLest } from '@/lib/actions/varsler'
@@ -34,6 +35,7 @@ export default function VarslerListe({
   varsler: initialVarsler,
   antallUlesteTotal: initialAntallUlesteTotal,
 }: Props) {
+  const router = useRouter()
   const [varsler, setVarsler] = useState(initialVarsler)
   // Total ulest-count som lokal state så optimistisk marker-alle-lest kan
   // nulle den umiddelbart uten å vente på revalidatePath.
@@ -52,6 +54,11 @@ export default function VarslerListe({
       setAntallUlesteTotal(0)
       try {
         await markerAlleVarslerLest()
+        // router.refresh() tvinger klientens Router Cache til å re-fetche
+        // layout-RSC, slik at ulest-prikken på profil-avataren forsvinner
+        // umiddelbart. revalidatePath på serveren alene er ikke nok når
+        // layouten allerede er hydrert i klientens cache. Se #218.
+        router.refresh()
       } catch {
         // Ved feil: rull tilbake lokal state.
         setVarsler(initialVarsler)

--- a/lib/actions/varsler.ts
+++ b/lib/actions/varsler.ts
@@ -6,6 +6,11 @@ import { ensureInnlogget } from '@/lib/auth'
 /**
  * Marker alle uleste varsler for innlogget bruker som lest.
  * RLS sørger for at vi kun rører egne rader.
+ *
+ * Revaliderer med 'layout' fordi ulest-prikken på profil-avataren rendres
+ * fra (app)/layout.tsx (TopHeader). Uten 'layout' ville bare page-nivået
+ * revaliderts — TopHeader beholdt cached `ulestVarsler=true` og brukeren
+ * måtte pull-down for å oppdatere prikken. Se #218.
  */
 export async function markerAlleVarslerLest() {
   const { supabase, user } = await ensureInnlogget()
@@ -17,5 +22,5 @@ export async function markerAlleVarslerLest() {
     .eq('lest', false)
 
   if (error) throw new Error(error.message)
-  revalidatePath('/profil')
+  revalidatePath('/profil', 'layout')
 }

--- a/lib/actions/varsler.ts
+++ b/lib/actions/varsler.ts
@@ -9,7 +9,7 @@ import { ensureInnlogget } from '@/lib/auth'
  *
  * Revaliderer med 'layout' fordi ulest-prikken på profil-avataren rendres
  * fra (app)/layout.tsx (TopHeader). Uten 'layout' ville bare page-nivået
- * revaliderts — TopHeader beholdt cached `ulestVarsler=true` og brukeren
+ * revalidert — TopHeader beholdt cached `ulestVarsler=true` og brukeren
  * måtte pull-down for å oppdatere prikken. Se #218.
  */
 export async function markerAlleVarslerLest() {


### PR DESCRIPTION
Lukker #218.

## Hva
- `markerAlleVarslerLest`: `revalidatePath('/profil', 'layout')` (var: `'page'`-nivå).
- `varsler/[id]/page.tsx`: kaller `revalidatePath('/profil', 'layout')` etter at varselet er markert lest.
- `VarslerListe`: `router.refresh()` etter server action — tvinger klientens Router Cache til å re-fetche layout-RSC umiddelbart.

## Hvorfor
Prikken på profil-avataren rendres fra TopHeader i `(app)/layout.tsx` via `harUlestVarsler()`. Når brukeren markerte alle varsler som lest (eller åpnet det siste uleste varselet), ble bare page-nivået revalidert — cached layout-RSC beholdt `ulestVarsler=true`. Brukeren måtte pull-down for å oppdatere prikken.

`router.refresh()` i klienten er defense in depth: `revalidatePath` invaliderer server-cachen, men den allerede hydrerte layouten i klientens Router Cache trenger en eksplisitt re-fetch for å reflektere endringen før neste navigering.

## Test plan
- [ ] /profil med uleste varsler → "Marker alle som lest" → prikken på avatar forsvinner umiddelbart uten pull-to-refresh
- [ ] /profil med ett ulest varsel → klikk varsel → tilbake til /profil → prikken er borte
- [ ] /profil uten uleste → ingen regresjoner (knapp disabled som før)
- [x] Lint, type-check, 122 tester grønt

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvxG9TrYS8kBWjmAtS5aqV)_