### PR TITLE
Tett chat-spacing og flytt datoskille til høyre marg (#220)

### DIFF
--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -784,26 +784,30 @@ export default function Chat({
             <Fragment key={m.id}>
               {visDatoSkille && (
                 <div
+                  role="separator"
+                  aria-label={`Meldinger fra ${formaterDatoSkille(m.opprettet)}`}
                   style={{
                     display: 'flex',
                     alignItems: 'center',
-                    gap: 10,
-                    margin: '20px 0 12px',
+                    justifyContent: 'flex-end',
+                    gap: 8,
+                    margin: '10px 0 2px',
+                    paddingRight: 2,
                   }}
                 >
-                  <span style={{ flex: 1, height: '0.5px', background: 'var(--border-subtle)' }} />
+                  <span aria-hidden="true" style={{ width: 24, height: '0.5px', background: 'var(--border-subtle)' }} />
                   <span
                     style={{
                       fontFamily: 'var(--font-mono)',
                       fontSize: 9,
-                      letterSpacing: '1.4px',
+                      letterSpacing: '1.2px',
                       fontWeight: 600,
                       color: 'var(--text-tertiary)',
+                      textTransform: 'uppercase',
                     }}
                   >
                     {formaterDatoSkille(m.opprettet)}
                   </span>
-                  <span style={{ flex: 1, height: '0.5px', background: 'var(--border-subtle)' }} />
                 </div>
               )}
             <div
@@ -811,7 +815,7 @@ export default function Chat({
                 display: 'flex',
                 gap: 10,
                 flexDirection: erEgen ? 'row-reverse' : 'row',
-                marginTop: erFortsettelse ? 3 : i === 0 ? 0 : 14,
+                marginTop: erFortsettelse ? 2 : i === 0 ? 0 : 8,
               }}
             >
               <div style={{ flexShrink: 0, alignSelf: 'flex-end' }}>
@@ -837,7 +841,7 @@ export default function Chat({
                       display: 'flex',
                       alignItems: 'baseline',
                       gap: 8,
-                      marginBottom: 4,
+                      marginBottom: 2,
                       paddingLeft: erEgen ? 0 : 2,
                       paddingRight: erEgen ? 2 : 0,
                     }}
@@ -971,7 +975,7 @@ export default function Chat({
                       if (!m.id.startsWith('temp-')) setPickerFor(m.id)
                     }}
                     style={{
-                      padding: '10px 14px',
+                      padding: '7px 12px',
                       borderRadius: erEgen ? '14px 14px 4px 14px' : '14px 14px 14px 4px',
                       background: erEgen ? 'var(--accent-soft)' : 'var(--bg-elevated)',
                       border: `0.5px solid ${

--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -803,7 +803,6 @@ export default function Chat({
                       letterSpacing: '1.2px',
                       fontWeight: 600,
                       color: 'var(--text-tertiary)',
-                      textTransform: 'uppercase',
                     }}
                   >
                     {formaterDatoSkille(m.opprettet)}


### PR DESCRIPTION
Lukker #220.

## Endringer

Alt i `components/chat/Chat.tsx`:

- **Mindre vertikal luft mellom meldinger:** `marginTop` ulike-avsendere 14→8, samme-gruppe 3→2. Header `marginBottom` 4→2.
- **Strammere bobler:** Padding `10px 14px` → `7px 12px`.
- **Datoskille flyttet til høyre marg:** Erstattet full-bredde divider (med horisontale streker rundt sentrert dato) med en høyrejustert badge — 24px mini-strek + dato i mono uppercase. Bevarer visuelt skille uten å spise vertikal plass.

## Designvalg (planleggeren flagget en flertydighet)

Issuen sier "flyttes til høyre marg" — det kan tolkes som:
- **Inline-badge høyrejustert** (valgt) — knytter datoen til meldingsgruppen den hører til
- **Sticky/floating dato** som følger scrollen — ikke valgt, krever større layout-endring som issuen ikke ber om

Si fra hvis sticky var det du tenkte, så lager vi en oppfølger.

## Beslutninger underveis (intern review)

Reviewer fanget to MAJOR-funn som ble rettet:
- **Visuell kollisjon** mellom dato og navn/tid-header for egne meldinger → mini-strek til venstre for badge gjenoppretter skille
- **A11y-regresjon** ved fjerning av implisitt separator → `role="separator"` + `aria-label="Meldinger fra <dato>"` på wrapper

Forsvart: hardkodede px-verdier (eksisterende mønster i filen, ikke ny svakhet), valg av inline-badge over sticky (Reidar har ikke bedt om sticky), stramme single-emoji-bobler (issuen ba om strammere — selektiv emoji-padding kan komme som egen sak).

## Test plan

- [ ] Visuell sjekk på mobil (390×844) — at meldingsgrupper ikke virker klaustrofobiske
- [ ] Sjekk overgang mellom dagsskifte og første melding etter (egen og andres)
- [ ] Skjermleser-test (VoiceOver/TalkBack) — at "Meldinger fra <dato>" leses opp ved dagsskifte
- [ ] Single-emoji-meldinger — at de ikke ser klemt ut

🤖 Generated with [Claude Code](https://claude.com/claude-code)