### PR TITLE
Deaktiver pull-to-refresh på chat-sider (oppfølger #222)

### DIFF
--- a/components/DraNedForOppdater.tsx
+++ b/components/DraNedForOppdater.tsx
@@ -5,15 +5,26 @@
 // trigger router.refresh() når brukeren har dratt forbi terskelen.
 
 import { useEffect, useRef, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 
 const TERSKEL = 80
 const MAX = 120
+
+// Ruter hvor pull-to-refresh er deaktivert. Chat-sidene har egen
+// visibilitychange-refetch og realtime-subscription som holder
+// meldingslisten ajour — pull-to-refresh trengs ikke der, og en
+// uventet router.refresh() forårsaket scroll-til-bunn-bug (#222).
+function erChatRute(pathname: string): boolean {
+  if (pathname === '/chat') return true
+  if (pathname.startsWith('/samtaler/')) return true
+  return false
+}
 
 export default function DraNedForOppdater() {
   const [dra, setDra] = useState(0)
   const [laster, setLaster] = useState(false)
   const router = useRouter()
+  const pathname = usePathname()
   const startY = useRef(0)
   const tracking = useRef(false)
   const draRef = useRef(0)
@@ -21,6 +32,7 @@ export default function DraNedForOppdater() {
   const avbrutt = useRef(false)
 
   useEffect(() => {
+    if (erChatRute(pathname)) return
     // Sjekker om brukeren skriver i et tekstfelt (chat-input, kommentar,
     // tittel-redigering osv). Da skal dra-ned ikke aktiveres — én gest
     // mindre som kan kollidere med tastatur og forskyve input-pillen
@@ -130,7 +142,7 @@ export default function DraNedForOppdater() {
       window.removeEventListener('touchend', end)
       window.removeEventListener('touchcancel', cancel)
     }
-  }, [router])
+  }, [router, pathname])
 
   const synlig = dra > 0 || laster
   const progress = Math.min(dra / TERSKEL, 1)


### PR DESCRIPTION
Pragmatisk fix etter at #223 ikke traff roten av #222 — scroll-til-topp på iOS sendte fortsatt brukeren til bunn.

## Endring

`DraNedForOppdater` returnerer tidlig fra `useEffect` hvis `pathname === '/chat'` eller starter med `/samtaler/`. Touch-listenere monteres ikke der, og bug-en kan ikke trigges på de sidene.

## Hvorfor det er trygt på chat

Chat-komponenten har allerede to mekanismer som holder meldingslisten ajour uten manuell refresh:
- `visibilitychange`-handler som re-fetcher når appen blir aktiv (`Chat.tsx:495-512`)
- Realtime-subscription via Supabase som tar imot nye meldinger automatisk (`Chat.tsx:301-365`)

## Hva som ikke er løst

Den dypere roten av #222 (hvorfor min forrige fix ikke fanget alle kodebaner i `DraNedForOppdater`) er fortsatt ukjent. Vi kan komme tilbake til det hvis pull-to-refresh blir savnet et annet sted, eller hvis vi ser samme symptom på andre sider.

## Test plan

- [ ] iOS: scroll til absolutte topp av /chat → ingen hopp til bunn
- [ ] iOS: scroll til topp av /samtaler/[id] → ingen hopp til bunn
- [ ] iOS: pull-to-refresh fortsatt fungerer på andre sider (f.eks. /agenda)

🤖 Generated with [Claude Code](https://claude.com/claude-code)