### PR TITLE
Rotfix #222: terskel på visualViewport-offset hindrer bounce-scroll

### DIFF
--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -48,6 +48,11 @@ export type ChatMelding = {
 // Antall meldinger som lastes first-batch og per "Vis eldre"-klikk
 const SIDE_STORRELSE = 30
 
+// Terskel i px for å skille ekte tastatur-åpning fra iOS PWA overscroll-bounce
+// på visualViewport.offsetTop. iPhone-tastatur er minst ~215px høyt, bounce
+// gir typisk < 100px. 120px er trygt over bounce-spektret. Se #222.
+const TASTATUR_OFFSET_TERSKEL_PX = 120
+
 // Emojis tilgjengelige i reaksjons-picker
 const REAKSJON_EMOJIS = ['👍', '❤️', '😂', '🎉', '🔥', '🙌'] as const
 
@@ -292,13 +297,13 @@ export default function Chat({
   // Uten dette ville den vokste paddingBottom-en bare lagt til tom plass
   // under siste melding uten å flytte brukerens scroll-posisjon.
   //
-  // Terskel på 120px skiller ekte tastatur-åpning (typisk 200-300px) fra
-  // iOS PWA overscroll-bounce (typisk < 100px) som midlertidig endrer
-  // visualViewport.offsetTop ved scroll mot topp. Uten terskel forårsaket
-  // bounce-driven offset en utilsiktet scroll-til-bunn (#222).
+  // Terskelen (TASTATUR_OFFSET_TERSKEL_PX) skiller ekte tastatur-åpning fra
+  // iOS PWA overscroll-bounce som midlertidig endrer visualViewport.offsetTop
+  // ved scroll mot topp. Uten terskel forårsaket bounce-driven offset en
+  // utilsiktet scroll-til-bunn (#222).
   useEffect(() => {
     if (!autoScrollTilBunn) return
-    if (keyboardOffset > 120) {
+    if (keyboardOffset >= TASTATUR_OFFSET_TERSKEL_PX) {
       requestAnimationFrame(() => scrollTilBunn(true))
     }
   }, [keyboardOffset, autoScrollTilBunn, scrollTilBunn])

--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -291,9 +291,14 @@ export default function Chat({
   // at siste melding fortsetter å være synlig like over input-pillen.
   // Uten dette ville den vokste paddingBottom-en bare lagt til tom plass
   // under siste melding uten å flytte brukerens scroll-posisjon.
+  //
+  // Terskel på 120px skiller ekte tastatur-åpning (typisk 200-300px) fra
+  // iOS PWA overscroll-bounce (typisk < 100px) som midlertidig endrer
+  // visualViewport.offsetTop ved scroll mot topp. Uten terskel forårsaket
+  // bounce-driven offset en utilsiktet scroll-til-bunn (#222).
   useEffect(() => {
     if (!autoScrollTilBunn) return
-    if (keyboardOffset > 0) {
+    if (keyboardOffset > 120) {
       requestAnimationFrame(() => scrollTilBunn(true))
     }
   }, [keyboardOffset, autoScrollTilBunn, scrollTilBunn])


### PR DESCRIPTION
Endelig den faktiske roten av #222.

## Hva det IKKE var
- ❌ `DraNedForOppdater` (forrige PR #223 endret gest-deteksjon, ingen effekt)
- ❌ Pull-to-refresh på chat-sider (forrige PR #224 deaktiverte den helt, ingen effekt)
- ❌ Safaris native pull-to-refresh (Reidar bruker PWA, har ikke det)

## Hva det FAKTISK er
`Chat.tsx` lytter på `visualViewport`-endringer for å detektere tastatur-åpning:

\`\`\`js
function oppdater() {
  const offset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop)
  setKeyboardOffset(offset)
}
\`\`\`

Når brukeren overscroller mot topp på iOS PWA, endrer `visualViewport.offsetTop` seg midlertidig — selv om tastaturet aldri åpnes. Det gjør at `keyboardOffset` blir > 0 i et kort øyeblikk, og denne useEffect-en utløses:

\`\`\`js
useEffect(() => {
  if (!autoScrollTilBunn) return
  if (keyboardOffset > 0) {
    requestAnimationFrame(() => scrollTilBunn(true))   // <-- instant til bunn
  }
}, [keyboardOffset, autoScrollTilBunn, scrollTilBunn])
\`\`\`

Resultatet: instant scroll til bunn ved overscroll mot topp. Det matcher alle observasjonene Reidar har rapportert:
- ✓ Kun iOS (visualViewport-bounce er iOS-spesifikk)
- ✓ Kun ved scroll til absolutte topp (overscroll der)
- ✓ Instant scroll til bunn (`scrollTilBunn(true)`)
- ✓ Ingen tap nødvendig (ren bounce-effekt)
- ✓ Kun på chat-sider (kun Chat.tsx har denne useEffect)

## Fix
Terskel på 120px på `keyboardOffset` skiller ekte tastatur-åpning (typisk 200-300px) fra bounce-offset (typisk < 100px). Tastaturet trigger fortsatt scroll-til-bunn som forventet.

## Hvorfor det blir riktig
- iPhone-tastatur er minst ~215px høyt (mini-modeller)
- iOS PWA overscroll-bounce gir typisk < 100px visualViewport-offset
- 120px-terskel er trygt over bounce-spektret, godt under tastatur-bunnen

## Test plan

- [ ] iOS PWA: scroll til absolutte topp av chat → ingen hopp til bunn 🎯
- [ ] iOS PWA: trykk i input-feltet for å åpne tastatur → siste melding fortsatt synlig over input
- [ ] iOS PWA: pull-to-refresh fungerer fortsatt på andre sider (agenda etc.)

## Hva som ikke er gjort
PR #224 (deaktivering av pull-to-refresh på chat-sider) er fortsatt aktiv. Den kan reverseres etter denne PR-en er bekreftet å fikse roten, hvis pull-to-refresh på chat blir savnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)