### PR TITLE
Bytt nærvær til deltakelse i år (#228)

### DIFF
--- a/app/(app)/klubbinfo/medlemmer/page.tsx
+++ b/app/(app)/klubbinfo/medlemmer/page.tsx
@@ -3,6 +3,7 @@ import { createServerClient } from '@/lib/supabase/server'
 import { getProfil } from '@/lib/auth-cache'
 import MedlemmerListe from './MedlemmerListe'
 import { kanAdministrere } from '@/lib/roller'
+import { norskAar } from '@/lib/dato'
 
 type Deltagelse = {
   id: string
@@ -10,11 +11,15 @@ type Deltagelse = {
   totalt: number
   siste12: number
   arrangert: number
+  /** Antall ja-svar i inneværende kalenderår — se migrasjon 090 */
+  i_aar?: number
 }
 
 type Statistikk = {
   totalt: number
   siste12: number
+  /** Antall avholdte arrangementer i inneværende kalenderår (Oslo-tid) */
+  i_aar_totalt?: number
   deltagelse: Deltagelse[] | null
   per_aar: unknown
 }
@@ -32,16 +37,20 @@ export default async function Medlemmer() {
   ])
 
   const statistikk = stat as unknown as Statistikk | null
+  const iAarTotalt = statistikk?.i_aar_totalt ?? 0
+  // Beholder totalHistoriske for undertittel-visning (antall sammenkomster totalt)
   const totalHistoriske = statistikk?.totalt ?? 0
   const deltagelseMap = new Map<string, number>()
   for (const d of statistikk?.deltagelse ?? []) {
-    deltagelseMap.set(d.id, d.totalt)
+    // i_aar er nytt felt fra migrasjon 090 — fallback til 0 til typer er regenerert
+    deltagelseMap.set(d.id, d.i_aar ?? 0)
   }
 
   const medlemmer = (profiler ?? []).map(p => {
     const ja = deltagelseMap.get(p.id) ?? 0
+    // Nærvær beregnes nå på inneværende kalenderår, ikke alle historiske
     const narv =
-      totalHistoriske > 0 ? Math.round((ja / totalHistoriske) * 100) : null
+      iAarTotalt > 0 ? Math.round((ja / iAarTotalt) * 100) : null
     return {
       id: p.id,
       navn: p.navn,
@@ -110,7 +119,7 @@ export default async function Medlemmer() {
             letterSpacing: '0.1px',
           }}
         >
-          {antallAktive} aktive · {totalHistoriske} sammenkomster
+          {antallAktive} aktive · {iAarTotalt} sammenkomster i {norskAar()}
         </div>
       </div>
 

--- a/app/(app)/klubbinfo/medlemmer/page.tsx
+++ b/app/(app)/klubbinfo/medlemmer/page.tsx
@@ -38,8 +38,6 @@ export default async function Medlemmer() {
 
   const statistikk = stat as unknown as Statistikk | null
   const iAarTotalt = statistikk?.i_aar_totalt ?? 0
-  // Beholder totalHistoriske for undertittel-visning (antall sammenkomster totalt)
-  const totalHistoriske = statistikk?.totalt ?? 0
   const deltagelseMap = new Map<string, number>()
   for (const d of statistikk?.deltagelse ?? []) {
     // i_aar er nytt felt fra migrasjon 090 — fallback til 0 til typer er regenerert

--- a/components/klubbinfo/MedlemRad.tsx
+++ b/components/klubbinfo/MedlemRad.tsx
@@ -103,7 +103,7 @@ export default function MedlemRad({
               marginTop: 1,
             }}
           >
-            Nærvær
+            I år
           </div>
         </div>
       )}

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 20,
-  "versjon": "V3.1.20"
+  "nummer": 21,
+  "versjon": "V3.1.21"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 21,
-  "versjon": "V3.1.21"
+  "nummer": 22,
+  "versjon": "V3.1.22"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.21'
+const CACHE_VERSION = 'V3.1.22'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.20'
+const CACHE_VERSION = 'V3.1.21'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/supabase/migrations/090_statistikk_deltakelse_i_aar.sql
+++ b/supabase/migrations/090_statistikk_deltakelse_i_aar.sql
@@ -1,0 +1,73 @@
+-- Legg til i_aar og i_aar_totalt i get_statistikk() for "Deltakelse i år"-kolonnen
+-- på /klubbinfo/medlemmer. Beregner basert på inneværende kalenderår (Oslo-tid).
+-- Alle eksisterende felter (totalt, siste12, arrangert, per_aar) beholdes uendret
+-- slik at /klubbinfo/statistikk ikke påvirkes.
+
+create or replace function get_statistikk()
+returns json
+language sql
+security definer
+stable
+as $$
+  with historiske as (
+    select id, start_tidspunkt, opprettet_av
+    from arrangementer
+    where start_tidspunkt < now()
+  ),
+  -- Inneværende kalenderår sammenlignes i Oslo-tid for å håndtere nyttårsaften
+  i_aar_arr as (
+    select id
+    from historiske
+    where extract(year from start_tidspunkt at time zone 'Europe/Oslo')
+          = extract(year from (now() at time zone 'Europe/Oslo'))
+  ),
+  deltagelse as (
+    select
+      p.profil_id,
+      count(*) as totalt,
+      count(*) filter (where a.start_tidspunkt >= now() - interval '12 months') as siste12,
+      -- Antall ja-svar i inneværende kalenderår
+      count(*) filter (where a.id in (select id from i_aar_arr)) as i_aar
+    from paameldinger p
+    join historiske a on a.id = p.arrangement_id
+    where p.status = 'ja'
+    group by p.profil_id
+  ),
+  arrangert as (
+    select opprettet_av, count(*) as antall
+    from historiske
+    group by opprettet_av
+  ),
+  per_aar as (
+    select extract(year from start_tidspunkt)::int as aar, count(*)::int as antall
+    from historiske
+    group by 1
+  )
+  select json_build_object(
+    'totalt', (select count(*) from historiske),
+    'siste12', (select count(*) from historiske where start_tidspunkt >= now() - interval '12 months'),
+    -- Antall avholdte arrangementer i inneværende kalenderår (Oslo-tid)
+    'i_aar_totalt', (select count(*) from i_aar_arr),
+    'deltagelse', (
+      select json_agg(
+        json_build_object(
+          'id', pr.id,
+          'navn', pr.navn,
+          'totalt', coalesce(d.totalt, 0),
+          'siste12', coalesce(d.siste12, 0),
+          'arrangert', coalesce(arr.antall, 0),
+          'i_aar', coalesce(d.i_aar, 0)
+        )
+        order by coalesce(d.totalt, 0) desc, pr.navn
+      )
+      from profiles pr
+      left join deltagelse d on d.profil_id = pr.id
+      left join arrangert arr on arr.opprettet_av = pr.id
+      where pr.aktiv = true
+    ),
+    'per_aar', (
+      select json_agg(json_build_object('aar', aar, 'antall', antall) order by aar desc)
+      from per_aar
+    )
+  )
+$$;

--- a/supabase/migrations/091_get_statistikk_search_path.sql
+++ b/supabase/migrations/091_get_statistikk_search_path.sql
@@ -1,7 +1,8 @@
--- Legg til i_aar og i_aar_totalt i get_statistikk() for "Deltakelse i år"-kolonnen
--- på /klubbinfo/medlemmer. Beregner basert på inneværende kalenderår (Oslo-tid).
--- Alle eksisterende felter (totalt, siste12, arrangert, per_aar) beholdes uendret
--- slik at /klubbinfo/statistikk ikke påvirkes.
+-- Sikkerhetsfiks: lås search_path og stram inn EXECUTE-grants på get_statistikk().
+-- SECURITY DEFINER uten eksplisitt search_path er sårbart for hijacking via pg_temp
+-- (en angriper kan skygge tabeller/funksjoner ved å plassere objekter i en søkbar
+-- schema før public). Mig. 090 introduserte den oppdaterte funksjonen uten dette.
+-- Mønsteret er det samme som i mig. 079 (tell_poll_stemmer).
 
 create or replace function get_statistikk()
 returns json
@@ -15,7 +16,6 @@ as $$
     from arrangementer
     where start_tidspunkt < now()
   ),
-  -- Inneværende kalenderår sammenlignes i Oslo-tid for å håndtere nyttårsaften
   i_aar_arr as (
     select id
     from historiske
@@ -27,7 +27,6 @@ as $$
       p.profil_id,
       count(*) as totalt,
       count(*) filter (where a.start_tidspunkt >= now() - interval '12 months') as siste12,
-      -- Antall ja-svar i inneværende kalenderår
       count(*) filter (where a.id in (select id from i_aar_arr)) as i_aar
     from paameldinger p
     join historiske a on a.id = p.arrangement_id
@@ -47,7 +46,6 @@ as $$
   select json_build_object(
     'totalt', (select count(*) from historiske),
     'siste12', (select count(*) from historiske where start_tidspunkt >= now() - interval '12 months'),
-    -- Antall avholdte arrangementer i inneværende kalenderår (Oslo-tid)
     'i_aar_totalt', (select count(*) from i_aar_arr),
     'deltagelse', (
       select json_agg(


### PR DESCRIPTION
Lukker #228.

## Endring
På `/klubbinfo/medlemmer` viser «I år»-kolonnen nå prosent beregnet på inneværende kalenderår (ja-svar / avholdte arrangementer i året), i stedet for historisk nærvær.

## Filer
- `supabase/migrations/090_statistikk_deltakelse_i_aar.sql` — utvider `get_statistikk()` med `i_aar_totalt` og `i_aar` per medlem (Oslo-tid).
- `app/(app)/klubbinfo/medlemmer/page.tsx` — bytter nevner og oppdaterer undertittel med årstall.
- `components/klubbinfo/MedlemRad.tsx` — label «Nærvær» → «I år».

## Beslutninger underveis
- **Reviewer MAJOR (skjev statistikk tidlig i året):** forsvart — Reidar valgte bevisst prosent-representasjon og kalenderår.
- **Reviewer MINOR (`per_aar` bruker rå UTC):** pre-existing, skjøvet til oppfølger #229.
- **Reviewer MINOR (null-rendering):** forsvart — `MedlemRad` skjuler tall-blokken når `narv` er null.

## Oppfølging
- Steg 10.5 (post-merge): `supabase db push` + regenerér typer.