### PR TITLE
Samle Chat-tab-prefikser i lib/navigasjon.ts (#231)

### DIFF
--- a/components/DraNedForOppdater.tsx
+++ b/components/DraNedForOppdater.tsx
@@ -6,19 +6,10 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
+import { erChatTab } from '@/lib/navigasjon'
 
 const TERSKEL = 80
 const MAX = 120
-
-// Ruter hvor pull-to-refresh er deaktivert. Chat-sidene har egen
-// visibilitychange-refetch og realtime-subscription som holder
-// meldingslisten ajour — pull-to-refresh trengs ikke der, og en
-// uventet router.refresh() forårsaket scroll-til-bunn-bug (#222).
-function erChatRute(pathname: string): boolean {
-  if (pathname === '/chat') return true
-  if (pathname.startsWith('/samtaler/')) return true
-  return false
-}
 
 export default function DraNedForOppdater() {
   const [dra, setDra] = useState(0)
@@ -32,7 +23,10 @@ export default function DraNedForOppdater() {
   const avbrutt = useRef(false)
 
   useEffect(() => {
-    if (erChatRute(pathname)) return
+    // Chat-sidene har eigen visibilitychange-refetch og realtime-subscription
+    // som holder meldingslisten ajour — pull-to-refresh trengs ikke der, og
+    // ein uventet router.refresh() forårsaket scroll-til-bunn-bug (#222).
+    if (erChatTab(pathname)) return
     // Sjekker om brukeren skriver i et tekstfelt (chat-input, kommentar,
     // tittel-redigering osv). Da skal dra-ned ikke aktiveres — én gest
     // mindre som kan kollidere med tastatur og forskyve input-pillen

--- a/components/DraNedForOppdater.tsx
+++ b/components/DraNedForOppdater.tsx
@@ -23,9 +23,9 @@ export default function DraNedForOppdater() {
   const avbrutt = useRef(false)
 
   useEffect(() => {
-    // Chat-sidene har eigen visibilitychange-refetch og realtime-subscription
+    // Chat-sidene har egen visibilitychange-refetch og realtime-subscription
     // som holder meldingslisten ajour — pull-to-refresh trengs ikke der, og
-    // ein uventet router.refresh() forårsaket scroll-til-bunn-bug (#222).
+    // en uventet router.refresh() forårsaket scroll-til-bunn-bug (#222).
     if (erChatTab(pathname)) return
     // Sjekker om brukeren skriver i et tekstfelt (chat-input, kommentar,
     // tittel-redigering osv). Da skal dra-ned ikke aktiveres — én gest

--- a/components/TopHeader.tsx
+++ b/components/TopHeader.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'next/navigation'
 import { type CSSProperties, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import Avatar from '@/components/ui/Avatar'
 import { harGulGloed } from '@/lib/roller'
+import { CHAT_TAB_PREFIKSER } from '@/lib/navigasjon'
 
 type Tab = {
   href: string
@@ -16,7 +17,7 @@ type Tab = {
 
 const TABS: Tab[] = [
   { href: '/', label: 'Agenda', nokkel: 'agenda', prefikser: ['/poll', '/arrangementer', '/meldinger'] },
-  { href: '/chat', label: 'Chat', nokkel: 'chat', prefikser: ['/chat', '/samtaler'] },
+  { href: '/chat', label: 'Chat', nokkel: 'chat', prefikser: [...CHAT_TAB_PREFIKSER] },
   { href: '/klubbinfo', label: 'Klubb', nokkel: 'klubb', prefikser: ['/klubbinfo', '/kaaringer', '/album'] },
 ]
 

--- a/lib/navigasjon.ts
+++ b/lib/navigasjon.ts
@@ -4,7 +4,17 @@
 
 export const CHAT_TAB_PREFIKSER = ['/chat', '/samtaler'] as const
 
-/** Returnerer true når pathname hører til Chat-taben. */
+/**
+ * Returnerer true når pathname hører til Chat-taben.
+ *
+ * Bruker streng segment-grense (`/chat` eller `/chat/...`, ikke `/chatannet`)
+ * fordi denne brukes til å DEAKTIVERE pull-to-refresh — en false positive
+ * her ville stille fjerne funksjonalitet på en urelatert rute.
+ *
+ * TopHeader's `erAktiv()` bruker bevisst løsere prefix-matching for visuell
+ * highlight: en feilaktig markert tab er en kosmetisk bagatell sammenliknet
+ * med tap av pull-to-refresh, så asymmetrien er tilsiktet.
+ */
 export function erChatTab(pathname: string): boolean {
   return CHAT_TAB_PREFIKSER.some(
     p => pathname === p || pathname.startsWith(p + '/')

--- a/lib/navigasjon.ts
+++ b/lib/navigasjon.ts
@@ -1,0 +1,12 @@
+// Én sannhet for Chat-tab'ens omfang — brukes av både TopHeader (for å
+// markere taben aktiv) og DraNedForOppdater (for å deaktivere pull-to-refresh
+// på chat-ruter). Se #231 for bakgrunn.
+
+export const CHAT_TAB_PREFIKSER = ['/chat', '/samtaler'] as const
+
+/** Returnerer true når pathname hører til Chat-taben. */
+export function erChatTab(pathname: string): boolean {
+  return CHAT_TAB_PREFIKSER.some(
+    p => pathname === p || pathname.startsWith(p + '/')
+  )
+}

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 22,
-  "versjon": "V3.1.22"
+  "nummer": 23,
+  "versjon": "V3.1.23"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 23,
-  "versjon": "V3.1.23"
+  "nummer": 24,
+  "versjon": "V3.1.24"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.22'
+const CACHE_VERSION = 'V3.1.23'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.23'
+const CACHE_VERSION = 'V3.1.24'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Lukker #231.

## Endring
Trekker Chat-tab-prefiksene (`/chat`, `/samtaler`) ut til delt konstant i ny fil `lib/navigasjon.ts`, brukt fra både `TopHeader.tsx` og `DraNedForOppdater.tsx`. Løser samtidig konkret bug: `/samtaler` (uten trailing slash) falt utenfor pull-to-refresh-disable og var fortsatt aktiv der.

## Filer
- `lib/navigasjon.ts` (ny) — `CHAT_TAB_PREFIKSER` + `erChatTab()`-helper med streng segment-grense
- `components/DraNedForOppdater.tsx` — bruker `erChatTab()` i stedet for lokal `erChatRute()`
- `components/TopHeader.tsx` — importerer `CHAT_TAB_PREFIKSER`, beholder eksisterende `erAktiv()`-matching

## Beslutninger underveis
- **Reviewer MINOR (semantisk asymmetri mellom `erChatTab` og `erAktiv`):** rettet med JSDoc-kommentar — streng segment-grense i `erChatTab` er bevisst (false positive deaktiverer pull-to-refresh), løsere `startsWith` i TopHeader er ok (false positive = kosmetisk highlight). TopHeader-koden urørt.
- **Reviewer NIT (nynorsk i kommentar):** rettet til bokmål.
- **Reviewer NIT (`[...CHAT_TAB_PREFIKSER]` spread):** forsvart — idiomatisk TS.

## Hvorfor dette ikke er enda en patch
Tidligere runder (#222, #224, #225, #226 → #227) la nye sjekker oppå eksisterende. Roten var at to filer eide samme sannhet og drev fra hverandre. Nå er det én konstant. Neste rute under Chat-tab'en oppdaterer automatisk pull-to-refresh-disable. Per CLAUDE.md patch-policy: arkitektonisk reversering, ikke patch fem.

## Manuell test (iOS PWA, post-merge)
Per testplan i issuet — dra ned på `/chat`, `/samtaler`, `/samtaler/[id]` (ingenting skal skje), bekreft at andre sider beholder pull-to-refresh.