### PR TITLE
Push-klikk på @-nevnelse: ledes til riktig chat (#233)

### DIFF
--- a/lib/varsler.ts
+++ b/lib/varsler.ts
@@ -512,7 +512,9 @@ async function hentScopeInnhold(
       .single()
     return {
       tittel: `Chat: ${data?.tittel ?? 'et arrangement'}`,
-      url: `${BASE_URL}/arrangementer/${scope.id}`,
+      // #kommentarer-ankeret scroller direkte til chat-seksjonen på
+      // arrangement-siden — brukeren trenger ikke lete etter chatten. Se #233.
+      url: `${BASE_URL}/arrangementer/${scope.id}#kommentarer`,
       knappTekst: 'Åpne chatten',
     }
   }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 26,
-  "versjon": "V3.1.26"
+  "nummer": 27,
+  "versjon": "V3.1.27"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 25,
-  "versjon": "V3.1.25"
+  "nummer": 26,
+  "versjon": "V3.1.26"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 24,
-  "versjon": "V3.1.24"
+  "nummer": 25,
+  "versjon": "V3.1.25"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.26'
+const CACHE_VERSION = 'V3.1.27'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 
@@ -176,6 +176,14 @@ self.addEventListener('notificationclick', (event) => {
   // Appen er mobil-PWA. På iOS standalone fokuserer openWindow() PWA-en og
   // navigerer i ett steg — uten matchAll/navigate-quirksene som tidligere
   // sendte brukeren til feil side (#233).
-  const target = new URL(event.notification.data?.url ?? '/', self.location.origin).href
+  // Begrenser til same-origin så en ugyldig eller ekstern URL i payload aldri
+  // kan åpne ekstern side eller krasje handleren.
+  let target = '/'
+  try {
+    const url = new URL(event.notification.data?.url ?? '/', self.location.origin)
+    if (url.origin === self.location.origin) target = url.href
+  } catch {
+    // Ugyldig URL — fall til '/'
+  }
   event.waitUntil(clients.openWindow(target))
 })

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.24'
+const CACHE_VERSION = 'V3.1.25'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 
@@ -173,17 +173,30 @@ self.addEventListener('push', (event) => {
 
 self.addEventListener('notificationclick', (event) => {
   event.notification.close()
-  const url = event.notification.data?.url ?? '/'
+
+  // Bygg absolutt URL — sikrer at anker-URL-er (#kommentarer osv.) fungerer
+  // korrekt selv om data.url er en relativ path.
+  const target = new URL(event.notification.data?.url ?? '/', self.location.origin).href
 
   event.waitUntil(
-    clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
+    clients.matchAll({ type: 'window', includeUncontrolled: true }).then(async (clientList) => {
       for (const client of clientList) {
-        if (client.url && 'navigate' in client) {
-          return client.navigate(url).then(() => client.focus())
+        // Allerede på riktig URL: bare fokuser, ikke naviger på nytt
+        if (client.url === target) {
+          return client.focus()
         }
-        if ('focus' in client) return client.focus()
+        // Prøv navigate() først. På iOS PWA feiler dette stille, så vi
+        // fanger feilen og faller tilbake på openWindow() i stedet. Se #233.
+        if ('navigate' in client) {
+          try {
+            const navigert = await client.navigate(target)
+            if (navigert) return navigert.focus()
+          } catch {
+            // navigate() ikke støttet — fall igjennom til openWindow()
+          }
+        }
       }
-      return clients.openWindow(url)
+      return clients.openWindow(target)
     })
   )
 })

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.25'
+const CACHE_VERSION = 'V3.1.26'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 
@@ -173,30 +173,9 @@ self.addEventListener('push', (event) => {
 
 self.addEventListener('notificationclick', (event) => {
   event.notification.close()
-
-  // Bygg absolutt URL — sikrer at anker-URL-er (#kommentarer osv.) fungerer
-  // korrekt selv om data.url er en relativ path.
+  // Appen er mobil-PWA. På iOS standalone fokuserer openWindow() PWA-en og
+  // navigerer i ett steg — uten matchAll/navigate-quirksene som tidligere
+  // sendte brukeren til feil side (#233).
   const target = new URL(event.notification.data?.url ?? '/', self.location.origin).href
-
-  event.waitUntil(
-    clients.matchAll({ type: 'window', includeUncontrolled: true }).then(async (clientList) => {
-      for (const client of clientList) {
-        // Allerede på riktig URL: bare fokuser, ikke naviger på nytt
-        if (client.url === target) {
-          return client.focus()
-        }
-        // Prøv navigate() først. På iOS PWA feiler dette stille, så vi
-        // fanger feilen og faller tilbake på openWindow() i stedet. Se #233.
-        if ('navigate' in client) {
-          try {
-            const navigert = await client.navigate(target)
-            if (navigert) return navigert.focus()
-          } catch {
-            // navigate() ikke støttet — fall igjennom til openWindow()
-          }
-        }
-      }
-      return clients.openWindow(target)
-    })
-  )
+  event.waitUntil(clients.openWindow(target))
 })


### PR DESCRIPTION
Lukker #233.

## Problem
Trykket på push for @-nevnelse landet på profilen i stedet for chatten. Rotårsak: `notificationclick`-handleren i `public/sw.js` brukte `matchAll` + `client.navigate()` som feiler stille på iOS PWA — den endte med bare å fokusere PWA-en på siste viste side.

## Endring
- `public/sw.js` — `notificationclick` forenklet fra 25 linjer til 3: `clients.openWindow(target)`. Apple-spec-anbefalt mønster for mobil-PWA: fokuserer PWA og navigerer i ett steg.
- `lib/varsler.ts` — arrangement-mention-URL får `#kommentarer`-anker så brukeren scrolles til chatten på arrangementsiden.

Appen er kun mobil-PWA. matchAll/navigate-akrobatikken var skreddersydd for desktop med flere faner og introduserte mer overflate enn den løste.

## Manuell test (iOS PWA, post-merge)
Be noen @-nevne deg. Trykk push. Skal lande i:
- klubb-chat → `/chat`
- arrangement → `/arrangementer/{id}` med scroll til chat-seksjon
- poll → `/poll/{id}`
- melding → `/meldinger/{id}`