### PR TITLE
Fjern terskel-basert auto-scroll i chat (#236)

### DIFF
--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -48,11 +48,6 @@ export type ChatMelding = {
 // Antall meldinger som lastes first-batch og per "Vis eldre"-klikk
 const SIDE_STORRELSE = 30
 
-// Terskel i px for å skille ekte tastatur-åpning fra iOS PWA overscroll-bounce
-// på visualViewport.offsetTop. iPhone-tastatur er minst ~215px høyt, bounce
-// gir typisk < 100px. 120px er trygt over bounce-spektret. Se #222.
-const TASTATUR_OFFSET_TERSKEL_PX = 120
-
 // Emojis tilgjengelige i reaksjons-picker
 const REAKSJON_EMOJIS = ['👍', '❤️', '😂', '🎉', '🔥', '🙌'] as const
 
@@ -272,9 +267,10 @@ export default function Chat({
   // interactiveWidget='overlays-content' (jf. app/layout.tsx, valgt for å
   // unngå dock-bug-klassen) endrer ikke window.innerHeight seg, men
   // visualViewport.height krymper. Differansen er omtrent tastatur-høyden.
-  // Vi bruker den til å løfte input-pillen over tastaturet — og på chat-
-  // fokuserte sider også til å vokse meldings-listas bunnpadding så siste
-  // melding holder seg synlig. Se #216.
+  // keyboardOffset brukes KUN til layout: løfter input-pillen (sticky-pill
+  // bottom) og vokser paddingBottom på meldingslisten. Ingen scroll-side-
+  // effekter — terskel-basert auto-scroll fjernet fordi bounce-quirk (#222)
+  // på iOS PWA var ikke robust å skille fra ekte tastatur-åpning. Se #236.
   const [keyboardOffset, setKeyboardOffset] = useState(0)
   useEffect(() => {
     if (typeof window === 'undefined' || !window.visualViewport) return
@@ -291,22 +287,6 @@ export default function Chat({
       vv.removeEventListener('scroll', oppdater)
     }
   }, [])
-
-  // Når tastaturet åpner på chat-fokuserte sider, scroll til ny bunn slik
-  // at siste melding fortsetter å være synlig like over input-pillen.
-  // Uten dette ville den vokste paddingBottom-en bare lagt til tom plass
-  // under siste melding uten å flytte brukerens scroll-posisjon.
-  //
-  // Terskelen (TASTATUR_OFFSET_TERSKEL_PX) skiller ekte tastatur-åpning fra
-  // iOS PWA overscroll-bounce som midlertidig endrer visualViewport.offsetTop
-  // ved scroll mot topp. Uten terskel forårsaket bounce-driven offset en
-  // utilsiktet scroll-til-bunn (#222).
-  useEffect(() => {
-    if (!autoScrollTilBunn) return
-    if (keyboardOffset >= TASTATUR_OFFSET_TERSKEL_PX) {
-      requestAnimationFrame(() => scrollTilBunn(true))
-    }
-  }, [keyboardOffset, autoScrollTilBunn, scrollTilBunn])
 
   // Realtime-subscription — én kanal per scope
   useEffect(() => {

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 27,
-  "versjon": "V3.1.27"
+  "nummer": 28,
+  "versjon": "V3.1.28"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.27'
+const CACHE_VERSION = 'V3.1.28'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Lukker #236.

Bestilt av arkitekturstyret etter fjerde runde i bug-klassen "drag-ned på chat-tab kaster til bunn" (#222, #225, #232 før denne). Per CLAUDE.md-policy: tre regresjoner = arkitektonisk reversering, ikke patch fem.

## Endring (Alternativ D fra styreuttalelse)
Sletter `useEffect` i `Chat.tsx` som scroller til bunn når `visualViewport.offsetTop` krysser 120 px-terskelen. iOS PWA hard overscroll-bounce produserte offsetTop > 120 px og feiltolkes som tastatur-åpning.

Konkret:
- Slettet `TASTATUR_OFFSET_TERSKEL_PX`-konstanten
- Slettet auto-scroll-useEffekten
- Oppdatert kommentar over visualViewport-listener: offset driver KUN layout (paddingBottom + sticky-pill), ikke scroll

## Hvorfor det er trygt
iOS' egen `scrollIntoView` ved input-focus dekker det legitime behovet (siste melding synlig når brukeren tapper input). Auto-scroll-effekten var kompensasjon for paddingBottom-vekst vi selv forårsaker — kompensasjons-spiral mot selvskapt problem.

## Behold
- `keyboardOffset`-state + visualViewport-listener (driver paddingBottom + sticky-pill-bottom)
- Realtime-INSERT-scroll (urørt, egen vurdering om oppførsel er optimal)

## Manuell test på iPhone PWA (post-merge)
- [ ] Drag HARDT ned fra toppen av `/chat` — ingen kast til bunn
- [ ] Åpne `/chat` på nytt — kommer fortsatt inn nederst
- [ ] Tap input — tastatur åpner, siste melding fortsatt synlig
- [ ] Nye meldinger via realtime — scroller fortsatt til bunn når man står nederst

## Oppfølger-issues (opprettes etter merge)
- Realtime-INSERT-scroll-vurdering
- Composite-indekser for chat-paginering