### PR TITLE
Scroll til bunn i chat: kun nær bunn eller egen melding (#238)

### DIFF
--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -25,6 +25,7 @@ import {
   type ChatProfil,
 } from '@/lib/mention'
 import MentionVelger from '@/components/agenda/MentionVelger'
+import { CHAT_NAER_BUNN_TERSKEL_PX } from '@/lib/konstanter'
 
 // ChatScope er sentralt definert i lib/chat-konfig.ts og re-eksportert her
 // for kall-ergonomi (eksisterende callsites importerer fra Chat.tsx).
@@ -241,14 +242,9 @@ export default function Chat({
     })
   }, [])
 
-  // Terskel i piksler fra bunnen — under dette scrolles det automatisk
-  // ved andres meldinger. Justert UI-fintuning: langt nok til at litt
-  // scroll-margin ikke trigger, kort nok til at «nesten i bunn» teller.
-  const NÆR_BUNN_TERSKEL_PX = 150
-
   // Sjekker om brukeren befinner seg nær bunnen av siden.
   // Kjøres kun klient-side (window er undefined under SSR).
-  function erNaerBunn(terskel = NÆR_BUNN_TERSKEL_PX) {
+  function erNaerBunn(terskel = CHAT_NAER_BUNN_TERSKEL_PX) {
     if (typeof window === 'undefined') return true
     const rest = document.documentElement.scrollHeight - window.scrollY - window.innerHeight
     return rest <= terskel

--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -241,6 +241,19 @@ export default function Chat({
     })
   }, [])
 
+  // Terskel i piksler fra bunnen — under dette scrolles det automatisk
+  // ved andres meldinger. Justert UI-fintuning: langt nok til at litt
+  // scroll-margin ikke trigger, kort nok til at «nesten i bunn» teller.
+  const NÆR_BUNN_TERSKEL_PX = 150
+
+  // Sjekker om brukeren befinner seg nær bunnen av siden.
+  // Kjøres kun klient-side (window er undefined under SSR).
+  function erNaerBunn(terskel = NÆR_BUNN_TERSKEL_PX) {
+    if (typeof window === 'undefined') return true
+    const rest = document.documentElement.scrollHeight - window.scrollY - window.innerHeight
+    return rest <= terskel
+  }
+
   // Scroll til bunn ved første mount (instant), og når nye meldinger
   // dukker opp i bunnen (smooth). Ikke ved paginering (store diff)
   // eller når listen krymper.
@@ -259,8 +272,13 @@ export default function Chat({
       }
       return
     }
-    // Bare scroll hvis nye meldinger dukker opp i bunnen (positive diff <= 3)
-    if (autoScrollTilBunn && diff > 0 && diff <= 3) scrollTilBunn()
+    if (autoScrollTilBunn && diff > 0 && diff <= 3) {
+      const sisteEgen = meldinger[meldinger.length - 1]?.profil_id === brukerId
+      // Egen melding: alltid scroll (forventet at vi ser det vi sendte).
+      // Andres melding: scroll bare hvis brukeren står nær bunnen — ellers
+      // er det irriterende å bli kastet ned mens han leser eldre. Se #238.
+      if (sisteEgen || erNaerBunn()) scrollTilBunn()
+    }
   }, [meldinger.length, scrollTilBunn, autoScrollTilBunn])
 
   // Tastatur-høyde via visualViewport. Når iOS-tastaturet åpner med

--- a/lib/konstanter.ts
+++ b/lib/konstanter.ts
@@ -39,3 +39,8 @@ export const TIDLIGERE_SIDESTOERRELSE = 30
 // Maks antall bilder per melding-innlegg. Cap forhindrer at én melding
 // dominerer feeden visuelt og begrenser R2-opplastinger per POST.
 export const MELDING_MAKS_BILDER = 10
+
+// Terskel i piksler fra bunnen av siden for å regne brukeren som «nær
+// bunn» i chatten. Under terskelen auto-scroller vi når andres melding
+// kommer inn; over terskelen lar vi ham være i fred. Se #238.
+export const CHAT_NAER_BUNN_TERSKEL_PX = 150

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 28,
-  "versjon": "V3.1.28"
+  "nummer": 29,
+  "versjon": "V3.1.29"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 29,
-  "versjon": "V3.1.29"
+  "nummer": 30,
+  "versjon": "V3.1.30"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.28'
+const CACHE_VERSION = 'V3.1.29'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.29'
+const CACHE_VERSION = 'V3.1.30'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Lukker #238.

## Endring
useEffect på `meldinger.length` auto-scroller nå kun når brukeren står innen 150 px fra bunnen, eller når siste melding er egen.

## Filer
- `lib/konstanter.ts` — ny `CHAT_NAER_BUNN_TERSKEL_PX = 150`
- `components/chat/Chat.tsx` — ny `erNaerBunn()`-hjelper, sjekk om siste melding er egen

## Beslutninger underveis
- **Reviewer MINOR (flytt konstant til konstanter.ts):** rettet — per Policy: Konstanter
- **Reviewer NIT (norsk Æ):** rettet implisitt via konstant-flytting (ASCII)
- **Reviewer NIT (useCallback):** forsvart — overforbruk uten gevinst

## Manuell test på iPhone PWA
- [ ] Initial mount → kommer fortsatt inn nederst
- [ ] Egen send → scroller alltid
- [ ] Andres melding mens nederst → scroller normalt
- [ ] Andres melding mens scrollet opp >150 px → INGEN scroll