### PR TITLE
Tuning av next/image for mobile-only (#215)

### DIFF
--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 30,
-  "versjon": "V3.1.30"
+  "nummer": 31,
+  "versjon": "V3.1.31"
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -27,6 +27,14 @@ const nextConfig: NextConfig = {
     },
   },
   images: {
+    // Mobile-only: smal deviceSizes-liste reduserer Vercel Image Optimization-
+    // transformasjoner fra ~25 til ~5 per bilde. Kun WebP (ikke AVIF) for å
+    // halvere antall transformasjoner. Lang TTL fordi vi alltid genererer
+    // unike filnavn på opplastede bilder (R2). Se #215.
+    deviceSizes: [640, 828, 1200],
+    imageSizes: [64, 128, 256],
+    formats: ['image/webp'],
+    minimumCacheTTL: 60 * 60 * 24 * 31, // 31 dager
     remotePatterns: [
       {
         protocol: 'https',

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.30'
+const CACHE_VERSION = 'V3.1.31'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Lukker #215.

## Endring
Utvider `images`-blokken i `next.config.ts` med:
- `deviceSizes: [640, 828, 1200]` (var: default 8 bredder)
- `imageSizes: [64, 128, 256]`
- `formats: ['image/webp']` (drop AVIF)
- `minimumCacheTTL: 31 dager`

## Forventet effekt
~5 transformasjoner per bilde i stedet for ~25. Bør holde oss godt under Vercels 5000/måned gratis-kvote.

## Audit av `<Image fill>`
Listen i issuet ble verifisert — alle bruksted har allerede `sizes`-prop. Ingen kode-endringer nødvendig.

## Manuell verifikasjon (post-deploy)
Åpne et arrangement med bilde på iPhone, sjekk i Vercel-dashboardet i 7 dager at transformasjoner ligger betydelig lavere.

## Endrings-strategi
Alt. 1 fra issuet (tuning). Hvis vi treffer kvoten igjen senere, kan vi gjøre Alt. 2 (custom loader for R2) som permanent fiks.