### PR TITLE
Bisect 1: lang cache-TTL (#215)

### DIFF
--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 30,
-  "versjon": "V3.1.30"
+  "nummer": 31,
+  "versjon": "V3.1.31"
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -27,6 +27,10 @@ const nextConfig: NextConfig = {
     },
   },
   images: {
+    // Bisect-test 1/N etter regresjon i #215 / PR #242: bare lang cache-TTL.
+    // Skal ikke kunne brekke bilder — endrer kun hvor lenge Vercel cacher.
+    // Vi lager alltid unike filnavn (R2) så det er trygt med 31 dager.
+    minimumCacheTTL: 60 * 60 * 24 * 31,
     remotePatterns: [
       {
         protocol: 'https',

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.30'
+const CACHE_VERSION = 'V3.1.31'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Test 1 av N etter regresjon i PR #242. Bare `minimumCacheTTL: 31 dager`. Skal være 100% trygt — endrer kun cache. Verifiser preview før merge.