### PR TITLE
PR 1/3: Tuple-cursor + IntersectionObserver-paginering (#210)

### DIFF
--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -136,6 +136,9 @@ export default function Chat({
 
   // Sett harBrukerScrolletRef etter 300ms så auto-load ikke trigges ved
   // initial render. Registrer scroll-lytter på window for å fange brukerscroll.
+  // Kjent svakhet: window-scroll-lytteren er skjør på iOS når sticky-elementer
+  // eller virtual-keyboard endrer viewport — PR 2 (intern scroll-container)
+  // løser dette ved konstruksjon, så vi lever med det inntil videre.
   useEffect(() => {
     const timer = setTimeout(() => {
       function onScroll() {
@@ -322,8 +325,12 @@ export default function Chat({
         </div>
       )}
       {/* Usynlig sentinel øverst i meldingslisten. IntersectionObserver
-          (useEffect over) kaller lastEldre() når den scrolles inn. */}
-      {harMerEldre && !henterEldre && (
+          (useEffect over) kaller lastEldre() når den scrolles inn.
+          Beholdes mountet hele tiden mens harMerEldre er true — pillen
+          over rendres ved siden av. Mindre DOM-juggling og stabilere
+          observer (vi unngår at sentinelen forsvinner/dukker opp og
+          dermed avmonteres/remonteres mellom henter-syklusene). */}
+      {harMerEldre && (
         <div ref={toppSentinelRef} style={{ height: 1 }} />
       )}
 

--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Fragment, useState, useEffect, useRef } from 'react'
+import { Fragment, useState, useEffect, useRef, useCallback } from 'react'
 import { type ChatScope as ChatScopeKonfig } from '@/lib/chat-konfig'
 import { formaterDato, erSammeNorskeDag, formaterDatoSkille } from '@/lib/dato'
 import Avatar from '@/components/ui/Avatar'
@@ -106,6 +106,13 @@ export default function Chat({
   const [lagrerEdit, setLagrerEdit] = useState(false)
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
+  // Sentinel-div øverst i meldingslisten — IntersectionObserver trigges når
+  // den scrolles inn i view, og utløser lastEldre(). Se useEffect under.
+  const toppSentinelRef = useRef<HTMLDivElement>(null)
+  // Gating: vi starter ikke auto-load eldre meldinger før brukeren faktisk har
+  // scrollet selv (300ms delay etter mount). Hindrer at siden laster inn eldre
+  // meldinger allerede ved initial render på korte chatter.
+  const harBrukerScrolletRef = useRef(false)
 
   const profilMap = useRef(
     new Map(profiler.map(p => [p.id, p.navn ?? 'Ukjent'])),
@@ -126,6 +133,44 @@ export default function Chat({
       if (bildePreview) URL.revokeObjectURL(bildePreview)
     }
   }, [bildePreview])
+
+  // Sett harBrukerScrolletRef etter 300ms så auto-load ikke trigges ved
+  // initial render. Registrer scroll-lytter på window for å fange brukerscroll.
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      function onScroll() {
+        harBrukerScrolletRef.current = true
+        window.removeEventListener('scroll', onScroll)
+      }
+      window.addEventListener('scroll', onScroll, { passive: true })
+    }, 300)
+    return () => clearTimeout(timer)
+  }, [])
+
+  // IntersectionObserver: kall lastEldre() automatisk når toppSentinelRef
+  // scrolles inn i viewport (200px forhåndsmargin). Aktiv bare når
+  // harMerEldre === true og brukeren har scrollet (harBrukerScrolletRef).
+  // lastEldre() er idempotent via intern ref-lock, så observer-callback kan
+  // kalle den direkte uten ekstra guards her.
+  const lastEldreCallback = useCallback(() => {
+    if (!harBrukerScrolletRef.current) return
+    lastEldre()
+  }, [lastEldre])
+
+  useEffect(() => {
+    if (!harMerEldre) return
+    const sentinel = toppSentinelRef.current
+    if (!sentinel) return
+
+    const observer = new IntersectionObserver(
+      entries => {
+        if (entries[0]?.isIntersecting) lastEldreCallback()
+      },
+      { rootMargin: '200px 0px 0px 0px' },
+    )
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [harMerEldre, lastEldreCallback])
 
   async function velgBilde(e: React.ChangeEvent<HTMLInputElement>) {
     const fil = e.target.files?.[0]
@@ -254,14 +299,12 @@ export default function Chat({
         </SectionLabel>
       )}
 
-      {/* Vis eldre-knapp */}
-      {harMerEldre && meldinger.length > 0 && (
+      {/* Laster eldre — progress-pille mens henting pågår */}
+      {henterEldre && (
         <div style={{ textAlign: 'center', marginBottom: 14 }}>
-          <button
-            type="button"
-            onClick={lastEldre}
-            disabled={henterEldre}
+          <span
             style={{
+              display: 'inline-block',
               padding: '6px 14px',
               background: 'transparent',
               border: '0.5px solid var(--border)',
@@ -271,13 +314,17 @@ export default function Chat({
               fontSize: 10,
               letterSpacing: '1.4px',
               textTransform: 'uppercase',
-              cursor: henterEldre ? 'wait' : 'pointer',
-              opacity: henterEldre ? 0.5 : 1,
+              opacity: 0.5,
             }}
           >
-            {henterEldre ? 'Henter…' : 'Vis eldre'}
-          </button>
+            Henter eldre…
+          </span>
         </div>
+      )}
+      {/* Usynlig sentinel øverst i meldingslisten. IntersectionObserver
+          (useEffect over) kaller lastEldre() når den scrolles inn. */}
+      {harMerEldre && !henterEldre && (
+        <div ref={toppSentinelRef} style={{ height: 1 }} />
       )}
 
       {/* Meldingsliste — padding-bottom må romme input-pillen så ingen

--- a/components/chat/hooks/useChatData.ts
+++ b/components/chat/hooks/useChatData.ts
@@ -42,6 +42,10 @@ export function useChatData({ scope, brukerId, initialMeldinger }: UseChatDataPr
   const [meldinger, setMeldinger] = useState<ChatMelding[]>(initialMeldinger)
   const [harMerEldre, setHarMerEldre] = useState(initialMeldinger.length >= SIDE_STORRELSE)
   const [henterEldre, setHenterEldre] = useState(false)
+  // Ref-basert lock mot parallelle lastEldre()-kall. Sjekkes synkront før
+  // await slik at doble IntersectionObserver-triggers ikke sender to samtidige
+  // DB-kall (state-oppdateringer er asynkrone og ville ikke fanget det).
+  const henterEldreRef = useRef(false)
 
   // Reaksjoner — flat liste hentet fra chat_reaksjoner. Grupperes per melding
   // i render. En Map er raskere for hot-paths men flat liste er lettere å
@@ -70,7 +74,7 @@ export function useChatData({ scope, brukerId, initialMeldinger }: UseChatDataPr
   // Bruker CHAT_KONFIG til å slå opp tabell + FK-filter — ingen scope-
   // spesifikke grener her.
   const hentMeldinger = useCallback(
-    async (forTidspunkt?: string): Promise<ChatMelding[]> => {
+    async (cursor?: { opprettet: string; id: string }): Promise<ChatMelding[]> => {
       // klubb_chat har i tillegg `fra_facebook` for å vise Messenger-badge på
       // historisk-importerte meldinger. Andre chat-tabeller har ikke kolonnen.
       // UPDATE-handleren (under) tar bevisst kun innhold, så endring av
@@ -84,12 +88,21 @@ export function useChatData({ scope, brukerId, initialMeldinger }: UseChatDataPr
         .from(konfig.tabell)
         .select(select)
         .order('opprettet', { ascending: false })
+        .order('id', { ascending: false })
         .limit(SIDE_STORRELSE)
       const fkVerdi = konfig.scopeId(scope)
       if (konfig.fkFelt && fkVerdi) {
         q = q.eq(konfig.fkFelt, fkVerdi)
       }
-      if (forTidspunkt) q = q.lt('opprettet', forTidspunkt)
+      if (cursor) {
+        // Tuple-cursor: hent rader eldre enn cursor-tidspunktet, eller
+        // eldre ID-er på nøyaktig samme tidspunkt. Utnytter composite-indeksene
+        // (opprettet DESC, id DESC) som ble lagt til i migrasjon #239.
+        q = q.or(
+          'opprettet.lt.' + cursor.opprettet +
+          ',and(opprettet.eq.' + cursor.opprettet + ',id.lt.' + cursor.id + ')'
+        )
+      }
       const { data } = await q
       return data ? ([...data].reverse() as unknown as ChatMelding[]) : []
     },
@@ -314,16 +327,20 @@ export function useChatData({ scope, brukerId, initialMeldinger }: UseChatDataPr
   }, [hentMeldinger])
 
   async function lastEldre() {
-    if (henterEldre || !harMerEldre || meldinger.length === 0) return
+    // Synkron ref-sjekk fanger doble kall (f.eks. IntersectionObserver-triggers)
+    // selv om state-oppdateringer ikke har rukket å propagere ennå.
+    if (henterEldreRef.current || !harMerEldre || meldinger.length === 0) return
+    henterEldreRef.current = true
     setHenterEldre(true)
     try {
-      const eldstKjentTid = meldinger[0].opprettet
-      const eldre = await hentMeldinger(eldstKjentTid)
+      const eldstKjent = meldinger[0]
+      const eldre = await hentMeldinger({ opprettet: eldstKjent.opprettet, id: eldstKjent.id })
       if (eldre.length > 0) {
         setMeldinger(prev => [...eldre, ...prev])
       }
       if (eldre.length < SIDE_STORRELSE) setHarMerEldre(false)
     } finally {
+      henterEldreRef.current = false
       setHenterEldre(false)
     }
   }

--- a/components/chat/hooks/useChatData.ts
+++ b/components/chat/hooks/useChatData.ts
@@ -97,7 +97,12 @@ export function useChatData({ scope, brukerId, initialMeldinger }: UseChatDataPr
       if (cursor) {
         // Tuple-cursor: hent rader eldre enn cursor-tidspunktet, eller
         // eldre ID-er på nøyaktig samme tidspunkt. Utnytter composite-indeksene
-        // (opprettet DESC, id DESC) som ble lagt til i migrasjon #239.
+        // (opprettet DESC, id DESC) som ble lagt til i migrasjon 093 (se issue #239).
+        // cursor-verdier er trygge å konkatenere — timestamptz/uuid inneholder
+        // ikke komma/parenteser som ville brutt PostgREST sin or()-syntaks.
+        // id.lt er leksikografisk byte-orden, ikke tids-orden — fungerer som
+        // deterministisk tiebreaker, men sier ikke noe om hvilken rad som
+        // faktisk kom først ved kollisjon på opprettet.
         q = q.or(
           'opprettet.lt.' + cursor.opprettet +
           ',and(opprettet.eq.' + cursor.opprettet + ',id.lt.' + cursor.id + ')'
@@ -315,10 +320,14 @@ export function useChatData({ scope, brukerId, initialMeldinger }: UseChatDataPr
       const nyeste = await hentMeldinger()
       if (nyeste.length === 0) return
       setMeldinger(prev => {
-        // Behold eventuelle eldre meldinger brukeren allerede har lastet
-        const eldste = nyeste[0].opprettet
-        const eldre = prev.filter(m => m.opprettet < eldste)
-        return [...eldre, ...nyeste]
+        // Id-basert dedup ved merge: nyeste overstyrer evt. eksisterende
+        // rader med samme id, og vi unngår å miste meldinger som har samme
+        // opprettet-timestamp som første rad i nyeste-batchen (timestamp-
+        // basert filter ville droppet dem som "for nye"). Beholder rekkefølge:
+        // alle prev som ikke er i nyeste-settet, deretter nyeste-batchen.
+        const nyesteIder = new Set(nyeste.map(m => m.id))
+        const beholdt = prev.filter(m => !nyesteIder.has(m.id))
+        return [...beholdt, ...nyeste]
       })
     }
 
@@ -326,7 +335,10 @@ export function useChatData({ scope, brukerId, initialMeldinger }: UseChatDataPr
     return () => document.removeEventListener('visibilitychange', reFetch)
   }, [hentMeldinger])
 
-  async function lastEldre() {
+  // useCallback: identiteten skal være stabil så lenge harMerEldre, meldinger
+  // og hentMeldinger er det — slik at IntersectionObserver-useEffect i Chat.tsx
+  // (som har lastEldre som dep) ikke re-setter observeren på hver render.
+  const lastEldre = useCallback(async () => {
     // Synkron ref-sjekk fanger doble kall (f.eks. IntersectionObserver-triggers)
     // selv om state-oppdateringer ikke har rukket å propagere ennå.
     if (henterEldreRef.current || !harMerEldre || meldinger.length === 0) return
@@ -343,7 +355,7 @@ export function useChatData({ scope, brukerId, initialMeldinger }: UseChatDataPr
       henterEldreRef.current = false
       setHenterEldre(false)
     }
-  }
+  }, [harMerEldre, meldinger, hentMeldinger])
 
   async function send(innhold: string | null, bildeFil: File | null, bildePreviewUrl: string | null) {
     const harBilde = !!bildeFil

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 36,
-  "versjon": "V3.1.36"
+  "nummer": 37,
+  "versjon": "V3.1.37"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 37,
-  "versjon": "V3.1.37"
+  "nummer": 39,
+  "versjon": "V3.1.39"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.37'
+const CACHE_VERSION = 'V3.1.39'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.36'
+const CACHE_VERSION = 'V3.1.37'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Andre PR for #210. Utnytter composite-indeksene fra #239.

## Endring
- **`useChatData.ts`** — `hentMeldinger` tar nå `cursor: { opprettet, id }` i stedet for `forTidspunkt`. PostgREST `.or('opprettet.lt.X,and(opprettet.eq.X,id.lt.Y)')`. Ref-basert lock (`henterEldreRef`) for idempotent `lastEldre()`. `reFetch` bruker id-basert dedup i stedet for timestamp-filter.
- **`Chat.tsx`** — «Vis eldre»-knapp erstattet med usynlig sentinel + IntersectionObserver-autoload. Progress-pille når `henterEldre`. `harBrukerScrolletRef` hindrer autoload ved initial render.

## Beslutninger underveis
- **Reviewer MAJOR (PostgREST quoting):** rettet med kommentar — timestamptz/uuid trygge å konkatenere
- **Reviewer MAJOR (UUID lt kommentar):** rettet — presisert at det er leksikografisk tiebreaker, ikke tids-orden
- **Reviewer MINOR (sentinel forsvinner under henterEldre):** rettet — sentinel persistent når harMerEldre
- **Reviewer MINOR (reFetch tuple-inkonsistens):** rettet — id-basert dedup
- **Reviewer MINOR (window-scroll skjør på iOS):** forsvart — PR 2 løser ved konstruksjon
- **Reviewer NIT (useCallback):** rettet
- **Reviewer NIT (migrasjon-referanse):** rettet

## Manuell test på iPhone
- Scroll oppover sakte — eldre meldinger lastes automatisk
- Progress-pille blinker, ikke klikkbar knapp
- Ingen duplikat-rader ved rask scroll
- Når hele historikken er hentet — ingen flere kall