### PR TITLE
PR 2/3: ChatV2 + resizes-content + scroll-anchor + env-flag (#210)

### DIFF
--- a/app/(app)/chat/layout.tsx
+++ b/app/(app)/chat/layout.tsx
@@ -1,0 +1,21 @@
+// Layout kun for /chat-ruten. Setter interactiveWidget='resizes-content'
+// slik at iOS-tastaturet skyver opp hele layout-treet i stedet for å
+// overlappe det. Kun /chat bruker dette — andre sider beholder
+// 'overlays-content' fra root-layoutet (for å unngå resize-quirks på
+// sider som ikke er fullskjerm-chat). Se issue #210 PR 2.
+import type { Viewport } from 'next'
+
+export const viewport: Viewport = {
+  // resizes-content: iOS/Chrome skyver viewporten opp ved tastaturåpning.
+  // Det fjerner behovet for keyboardOffset-juks i ChatV2.
+  interactiveWidget: 'resizes-content',
+  // cover: fyller hele skjermen inkl. notch — safe-area-inset-* håndterer
+  // innrykk der det trengs.
+  viewportFit: 'cover',
+  maximumScale: 1,
+  userScalable: false,
+}
+
+export default function ChatLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/app/(app)/chat/page.tsx
+++ b/app/(app)/chat/page.tsx
@@ -2,19 +2,26 @@ import Link from 'next/link'
 import { createServerClient } from '@/lib/supabase/server'
 import { getInnloggetBruker, getProfil } from '@/lib/auth-cache'
 import Chat from '@/components/chat/Chat'
+import ChatV2 from '@/components/chat/ChatV2'
 import ChatAutoScrollScript from '@/components/chat/ChatAutoScrollScript'
 import Icon from '@/components/ui/Icon'
 import { kanAdministrere } from '@/lib/roller'
 import { markerChatSett } from '@/lib/actions/ulest'
+import { CHAT_LEGACY_FALLBACK } from '@/lib/config'
 
 // Klubb-chat: én felles kronologisk tråd for hele herreklubben.
 // Initial-last er siste 30 meldinger (i desc-rekkefølge fra DB, reversert til
 // ascending for UI). «Vis eldre»-knappen i felleskomponenten henter flere.
-export default async function KlubbChatSide() {
-  const [supabase, user, profil] = await Promise.all([
+export default async function KlubbChatSide({
+  searchParams,
+}: {
+  searchParams: Promise<{ legacy?: string }>
+}) {
+  const [supabase, user, profil, { legacy }] = await Promise.all([
     createServerClient(),
     getInnloggetBruker(),
     getProfil(),
+    searchParams,
   ])
 
   const [{ data: siste }, { data: profiler }, { count: ulestPrivat }] = await Promise.all([
@@ -42,41 +49,44 @@ export default async function KlubbChatSide() {
   const initialMeldinger = [...(siste ?? [])].reverse()
   const ulest = ulestPrivat ?? 0
 
-  return (
-    <div style={{ padding: '0 20px 20px' }}>
-      <ChatAutoScrollScript />
-      {/* Breadcrumb + tittel */}
-      <div style={{ padding: '12px 4px 22px' }}>
-        <div
-          style={{
-            fontFamily: 'var(--font-mono)',
-            fontSize: 9,
-            color: 'var(--text-tertiary)',
-            letterSpacing: '2.5px',
-            textTransform: 'uppercase',
-            marginBottom: 18,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 10,
-          }}
-        >
-          <span style={{ width: 18, height: '0.5px', background: 'var(--border-strong)' }} />
-          Klubbchat
-        </div>
-        <h1
-          style={{
-            fontFamily: 'var(--font-display)',
-            fontSize: 36,
-            fontWeight: 500,
-            letterSpacing: '-0.5px',
-            lineHeight: 1,
-            margin: 0,
-            color: 'var(--text-primary)',
-          }}
-        >
-          Samtalen
-        </h1>
+  // Kill-switch: CHAT_LEGACY_FALLBACK (env) eller ?legacy=1 i URL tvinger
+  // gammel Chat.tsx. Fjernes i PR 3 etter at ChatV2 er bekreftet stabil.
+  const brukLegacy = CHAT_LEGACY_FALLBACK || legacy === '1'
+
+  // Header-blokken — breadcrumb + tittel + privatmelding-lenke.
+  // I ChatV2 sender vi dette som headerSlot slik at det scroller med
+  // meldingslisten (iMessage-aktig). I legacy-modus legges det direkte i siden.
+  const headerBlokk = (
+    <div style={{ padding: '12px 4px 22px' }}>
+      <div
+        style={{
+          fontFamily: 'var(--font-mono)',
+          fontSize: 9,
+          color: 'var(--text-tertiary)',
+          letterSpacing: '2.5px',
+          textTransform: 'uppercase',
+          marginBottom: 18,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+        }}
+      >
+        <span style={{ width: 18, height: '0.5px', background: 'var(--border-strong)' }} />
+        Klubbchat
       </div>
+      <h1
+        style={{
+          fontFamily: 'var(--font-display)',
+          fontSize: 36,
+          fontWeight: 500,
+          letterSpacing: '-0.5px',
+          lineHeight: 1,
+          margin: 0,
+          color: 'var(--text-primary)',
+        }}
+      >
+        Samtalen
+      </h1>
 
       {/* Lenke til private samtaler — vises alltid for at funksjonen skal
           være oppdagbar. Ulest-badge til høyre når det finnes uleste. */}
@@ -87,7 +97,7 @@ export default async function KlubbChatSide() {
           alignItems: 'center',
           gap: 12,
           padding: '12px 14px',
-          marginBottom: 22,
+          marginTop: 22,
           background: 'var(--bg-elevated)',
           border: '0.5px solid var(--border)',
           borderRadius: 'var(--radius-card)',
@@ -128,16 +138,36 @@ export default async function KlubbChatSide() {
         )}
         <Icon name="chevron" size={14} color="var(--text-tertiary)" />
       </Link>
-
-      <Chat
-        scope={{ type: 'klubb' }}
-        brukerId={user!.id}
-        erAdmin={erAdmin}
-        initialMeldinger={initialMeldinger}
-        profiler={profiler ?? []}
-        visSeksjonsLabel={false}
-        autoScrollTilBunn
-      />
     </div>
+  )
+
+  if (brukLegacy) {
+    return (
+      <div style={{ padding: '0 20px 20px' }}>
+        <ChatAutoScrollScript />
+        {headerBlokk}
+        <Chat
+          scope={{ type: 'klubb' }}
+          brukerId={user!.id}
+          erAdmin={erAdmin}
+          initialMeldinger={initialMeldinger}
+          profiler={profiler ?? []}
+          visSeksjonsLabel={false}
+          autoScrollTilBunn
+        />
+      </div>
+    )
+  }
+
+  return (
+    <ChatV2
+      scope={{ type: 'klubb' }}
+      brukerId={user!.id}
+      erAdmin={erAdmin}
+      initialMeldinger={initialMeldinger}
+      profiler={profiler ?? []}
+      autoScrollTilBunn
+      headerSlot={headerBlokk}
+    />
   )
 }

--- a/components/chat/ChatV2.tsx
+++ b/components/chat/ChatV2.tsx
@@ -886,11 +886,12 @@ export default function ChatV2({
         <div
           style={{
             position: 'absolute',
-            bottom: 'calc(var(--input-bar-h, 56px) + env(safe-area-inset-bottom) + 8px)',
+            // 56px = input-pille (~48px) + flex-wrapper-padding. env() i tillegg for safe-area.
+            bottom: 'calc(56px + env(safe-area-inset-bottom) + 8px)',
             left: '50%',
             transform: 'translateX(-50%)',
             zIndex: 25,
-            animation: 'fadeIn 200ms ease',
+            animation: 'page-fadein 200ms ease',
           }}
         >
           <button

--- a/components/chat/ChatV2.tsx
+++ b/components/chat/ChatV2.tsx
@@ -1,0 +1,1093 @@
+'use client'
+
+// ChatV2: ny fullskjerm-chat-implementasjon med intern scroll-container
+// i stedet for window-scroll. Krever resizes-content i chat/layout.tsx.
+// Erstatter Chat.tsx på /chat-ruten når CHAT_LEGACY_FALLBACK=false (default).
+// Se issue #210 for bakgrunn og PR 2 for denne implementasjonen.
+
+import { Fragment, useState, useEffect, useRef, useCallback, type ReactNode } from 'react'
+import { type ChatScope as ChatScopeKonfig } from '@/lib/chat-konfig'
+import { formaterDato, erSammeNorskeDag, formaterDatoSkille } from '@/lib/dato'
+import Avatar from '@/components/ui/Avatar'
+import Icon from '@/components/ui/Icon'
+import BildeLightbox from '@/components/ui/BildeLightbox'
+import MessengerBadge from '@/components/ui/MessengerBadge'
+import { komprimer } from '@/lib/bilde-utils'
+import {
+  beregnMentionSøk,
+  velgMentionTekst,
+  lagMentionForslag,
+  type ChatProfil,
+} from '@/lib/mention'
+import MentionVelger from '@/components/agenda/MentionVelger'
+import { useChatData } from './hooks/useChatData'
+import { useChatScrollV2 } from './hooks/useChatScrollV2'
+import type { ChatMelding as ChatMeldingType } from './types'
+
+export type ChatScope = ChatScopeKonfig
+export type ChatMelding = ChatMeldingType
+
+// Emojis tilgjengelige i reaksjons-picker
+const REAKSJON_EMOJIS = ['👍', '❤️', '😂', '🎉', '🔥', '🙌'] as const
+
+function renderMedMentions(tekst: string | null) {
+  if (!tekst) return null
+  const deler = tekst.split(/(@[\wæøåÆØÅ][\w æøåÆØÅ-]*)/g)
+  return deler.map((del, i) =>
+    del.startsWith('@') ? (
+      <span key={i} style={{ fontWeight: 600, color: 'var(--accent)' }}>
+        {del}
+      </span>
+    ) : (
+      del
+    ),
+  )
+}
+
+type Props = {
+  scope: ChatScope
+  brukerId: string
+  erAdmin: boolean
+  initialMeldinger: ChatMelding[]
+  profiler: ChatProfil[]
+  /** Hvis true: scroll containeren til siste melding ved mount og ved nye
+   * meldinger. Alltid true på /chat — prop beholdes for konsistens med Chat.tsx. */
+  autoScrollTilBunn?: boolean
+  /** Header-blokk (breadcrumb + tittel + privatmelding-lenke) som skal
+   * scrolle med meldingslisten i stedet for å ligge sticky over den.
+   * Sender page.tsx inn dette som ReactNode. */
+  headerSlot?: ReactNode
+}
+
+export default function ChatV2({
+  scope,
+  brukerId,
+  erAdmin,
+  initialMeldinger,
+  profiler,
+  autoScrollTilBunn = false,
+  headerSlot,
+}: Props) {
+  const {
+    meldinger,
+    reaksjoner,
+    reaksjonerPerMelding,
+    harMerEldre,
+    henterEldre,
+    lastEldre,
+    send,
+    slett,
+    redigerMelding,
+    toggleReaksjon: toggleReaksjonHook,
+    konfig,
+  } = useChatData({ scope, brukerId, initialMeldinger })
+
+  // scrollContainerRef peker på den indre scroll-div-en.
+  // Sendes ned til useChatScrollV2 og IntersectionObserver.
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null)
+
+  const { bunnenRef, visNyMeldingPille, scrollTilBunn } = useChatScrollV2({
+    containerRef: scrollContainerRef,
+    meldinger,
+    brukerId,
+    autoScrollTilBunn,
+  })
+
+  const [tekst, setTekst] = useState('')
+  const [sender, setSender] = useState(false)
+  const [mentionSøk, setMentionSøk] = useState<string | null>(null)
+  // Vedheng-bilde (file holdes til submit, lastes opp først ved send)
+  const [bildeFil, setBildeFil] = useState<File | null>(null)
+  const [bildePreview, setBildePreview] = useState<string | null>(null)
+  const [bildeFeil, setBildeFeil] = useState('')
+  const bildeInputRef = useRef<HTMLInputElement>(null)
+  // Lightbox-visning av bilder
+  const [lightboxSrc, setLightboxSrc] = useState<string | null>(null)
+  // Hvilken melding viser picker. Null = ingen.
+  const [pickerFor, setPickerFor] = useState<string | null>(null)
+  // Hvilken melding redigeres. Null = ingen. editTekst holder editert innhold.
+  const [editerer, setEditerer] = useState<string | null>(null)
+  const [editTekst, setEditTekst] = useState('')
+  const [lagrerEdit, setLagrerEdit] = useState(false)
+  const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  // Sentinel-div øverst i meldingslisten. IntersectionObserver trigges når
+  // den scrolles inn i scroll-containeren (ikke viewport) — oppgi root
+  // eksplisitt i observer-options, ellers brukes window og sentinel-en
+  // er alltid «synlig» siden containeren er utenfor viewport. Se #210.
+  const toppSentinelRef = useRef<HTMLDivElement>(null)
+  // Gating: vi starter ikke auto-load eldre meldinger før brukeren faktisk
+  // har scrollet. 300ms delay etter mount hindrer at siden laster eldre
+  // meldinger allerede ved initial render på korte chatter.
+  // I ChatV2 lytter vi på container-scroll (ikke window-scroll).
+  const harBrukerScrolletRef = useRef(false)
+
+  const profilMap = useRef(
+    new Map(profiler.map(p => [p.id, p.navn ?? 'Ukjent'])),
+  ).current
+  const bildeMap = useRef(
+    new Map(profiler.map(p => [p.id, p.bilde_url])),
+  ).current
+  const rolleMap = useRef(
+    new Map(profiler.map(p => [p.id, p.rolle ?? null])),
+  ).current
+  const andreProfiler = useRef(
+    profiler.filter(p => p.id !== brukerId && p.navn),
+  ).current
+
+  // Frigjør blob-URL når preview byttes
+  useEffect(() => {
+    return () => {
+      if (bildePreview) URL.revokeObjectURL(bildePreview)
+    }
+  }, [bildePreview])
+
+  // Sett harBrukerScrolletRef etter 300ms, lyt på container-scroll (ikke
+  // window) slik at vi vet at brukeren faktisk har scrollet i chatten.
+  useEffect(() => {
+    const container = scrollContainerRef.current
+    if (!container) return
+    // container er ikke-null her (sjekket over), men TypeScript mister
+    // narrowing inn i setTimeout-callback — eksplisitt capture i lokal const.
+    const el = container
+    const timer = setTimeout(() => {
+      function onScroll() {
+        harBrukerScrolletRef.current = true
+        el.removeEventListener('scroll', onScroll)
+      }
+      el.addEventListener('scroll', onScroll, { passive: true })
+    }, 300)
+    return () => clearTimeout(timer)
+  }, [])
+
+  // IntersectionObserver: kall lastEldre() automatisk når toppSentinelRef
+  // scrolles inn i scroll-containeren (root = containerRef.current).
+  // 200px forhåndsmargin trigger hentingen litt før sentinelen er fullt
+  // synlig — seamless paginering. Aktiv bare når harMerEldre === true og
+  // brukeren har scrollet (harBrukerScrolletRef).
+  // lastEldre() er idempotent via intern ref-lock, så observer-callback
+  // kan kalle den direkte uten ekstra guards her.
+  const lastEldreCallback = useCallback(() => {
+    if (!harBrukerScrolletRef.current) return
+    lastEldre()
+  }, [lastEldre])
+
+  useEffect(() => {
+    if (!harMerEldre) return
+    const sentinel = toppSentinelRef.current
+    const container = scrollContainerRef.current
+    if (!sentinel || !container) return
+
+    const observer = new IntersectionObserver(
+      entries => {
+        if (entries[0]?.isIntersecting) lastEldreCallback()
+      },
+      {
+        root: container,
+        rootMargin: '200px 0px 0px 0px',
+      },
+    )
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [harMerEldre, lastEldreCallback])
+
+  async function velgBilde(e: React.ChangeEvent<HTMLInputElement>) {
+    const fil = e.target.files?.[0]
+    if (!fil) return
+    setBildeFeil('')
+    try {
+      const komprimert = await komprimer(fil)
+      setBildeFil(komprimert)
+      if (bildePreview) URL.revokeObjectURL(bildePreview)
+      setBildePreview(URL.createObjectURL(komprimert))
+    } catch (err) {
+      setBildeFeil(err instanceof Error ? err.message : 'Kunne ikke lese bildet')
+    } finally {
+      if (bildeInputRef.current) bildeInputRef.current.value = ''
+    }
+  }
+
+  function fjernBilde() {
+    setBildeFil(null)
+    if (bildePreview) URL.revokeObjectURL(bildePreview)
+    setBildePreview(null)
+    setBildeFeil('')
+  }
+
+  // Mention-state og -forslag styres av hjelperne i lib/mention.ts.
+  // andreProfiler-filteret over ekskluderer allerede innlogget bruker, men vi
+  // sender brukerId likevel som ekskluder for å gjøre kontrakten eksplisitt.
+  const mentionForslag = lagMentionForslag(mentionSøk, andreProfiler, brukerId)
+
+  function velgMention(navn: string) {
+    const nyTekst = velgMentionTekst(tekst, navn)
+    setTekst(nyTekst)
+    setMentionSøk(null)
+    inputRef.current?.focus()
+  }
+
+  async function handleSend() {
+    const melding = tekst.trim() || null
+    const harBilde = !!bildeFil
+    if (!melding && !harBilde) return
+    if (sender) return
+
+    setTekst('')
+    setMentionSøk(null)
+    setSender(true)
+    const filUploadKopi = bildeFil
+    const previewUrlKopi = bildePreview
+    setBildeFil(null)
+    setBildePreview(null) // ikke revoke ennå — optimistisk rad bruker den
+
+    try {
+      await send(melding, filUploadKopi, previewUrlKopi)
+    } catch {
+      setBildeFeil('Kunne ikke sende meldingen')
+    } finally {
+      setSender(false)
+      inputRef.current?.focus()
+    }
+  }
+
+  function startLongPress(meldingId: string) {
+    if (meldingId.startsWith('temp-')) return
+    clearLongPress()
+    longPressTimer.current = setTimeout(() => {
+      setPickerFor(meldingId)
+      // Haptisk feedback på mobil hvis tilgjengelig
+      if (typeof window !== 'undefined' && 'navigator' in window) {
+        navigator.vibrate?.(12)
+      }
+    }, 420)
+  }
+
+  function clearLongPress() {
+    if (longPressTimer.current) {
+      clearTimeout(longPressTimer.current)
+      longPressTimer.current = null
+    }
+  }
+
+  async function toggleReaksjon(meldingId: string, emoji: string) {
+    setPickerFor(null)
+    await toggleReaksjonHook(meldingId, emoji)
+  }
+
+  function startEdit(meldingId: string, naavarende: string) {
+    setPickerFor(null)
+    setEditerer(meldingId)
+    setEditTekst(naavarende)
+  }
+
+  function avbrytEdit() {
+    setEditerer(null)
+    setEditTekst('')
+  }
+
+  async function lagreEdit(id: string) {
+    const ny = editTekst.trim()
+    if (!ny || lagrerEdit) return
+    // No-op hvis tekst er uendret
+    const forrige = meldinger.find(m => m.id === id)
+    if (forrige && forrige.innhold === ny) {
+      avbrytEdit()
+      return
+    }
+    setLagrerEdit(true)
+    try {
+      await redigerMelding(id, ny)
+      avbrytEdit()
+    } catch {
+      // Rollback skjer inne i useChatData.redigerMelding — ingenting å gjøre her.
+    } finally {
+      setLagrerEdit(false)
+    }
+  }
+
+  async function handleSlett(id: string) {
+    if (!confirm('Slette denne meldingen?')) return
+    await slett(id)
+  }
+
+  return (
+    // Ytre flex-container tar nøyaktig den høyden som gjenstår under
+    // top-headeren. CSS-var(--top-header-h) settes av TopHeader-komponenten;
+    // 60px er fallback. Med resizes-content krymper dette arealet når
+    // tastaturet åpner — containeren + input-baren følger med automatisk.
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: 'calc(100dvh - var(--top-header-h, 60px))',
+      }}
+    >
+      {/* Indre scroll-container — tar all ledig plass, scroller internt.
+          overscrollBehavior:contain hindrer at pull-to-refresh på /chat
+          trigges ved scrolling til toppen av meldingslisten. */}
+      <div
+        ref={scrollContainerRef}
+        style={{
+          flex: 1,
+          overflowY: 'auto',
+          overscrollBehavior: 'contain',
+          WebkitOverflowScrolling: 'touch',
+          padding: '0 20px',
+        }}
+      >
+        {/* Header scroller med innholdet (iMessage-aktig). page.tsx
+            sender headerSlot slik at /chat-siden kan kontrollere innholdet
+            uten at ChatV2 trenger å vite om breadcrumb / privatmelding-lenke. */}
+        {headerSlot}
+
+        {/* Laster eldre — progress-pille mens henting pågår */}
+        {henterEldre && (
+          <div style={{ textAlign: 'center', marginBottom: 14 }}>
+            <span
+              style={{
+                display: 'inline-block',
+                padding: '6px 14px',
+                background: 'transparent',
+                border: '0.5px solid var(--border)',
+                borderRadius: 999,
+                color: 'var(--text-secondary)',
+                fontFamily: 'var(--font-mono)',
+                fontSize: 10,
+                letterSpacing: '1.4px',
+                textTransform: 'uppercase',
+                opacity: 0.5,
+              }}
+            >
+              Henter eldre…
+            </span>
+          </div>
+        )}
+        {/* Usynlig sentinel øverst i meldingslisten. IntersectionObserver
+            (useEffect over) kaller lastEldre() når den scrolles inn.
+            Beholdes mountet hele tiden mens harMerEldre er true — pillen
+            over rendres ved siden av. root er scrollContainerRef slik at
+            vi observerer mot containeren, ikke mot viewporten. */}
+        {harMerEldre && (
+          <div ref={toppSentinelRef} style={{ height: 1 }} />
+        )}
+
+        {/* Meldingsliste */}
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            marginBottom: 4,
+            // Litt padding i bunn av scroll-containeren så siste melding
+            // ikke klistrer seg mot input-baren
+            paddingBottom: 8,
+          }}
+        >
+          {meldinger.length === 0 && (
+            <div
+              style={{
+                textAlign: 'center',
+                padding: '24px 0',
+                fontFamily: 'var(--font-body)',
+                fontSize: 13,
+                color: 'var(--text-tertiary)',
+                fontStyle: 'italic',
+              }}
+            >
+              Ingen meldinger ennå.
+            </div>
+          )}
+
+          {meldinger.map((m, i) => {
+            const forrige = i > 0 ? meldinger[i - 1] : null
+            // Vis dato-skille når det er første melding eller ny kalenderdag (norsk tid).
+            const visDatoSkille = !forrige || !erSammeNorskeDag(forrige.opprettet, m.opprettet)
+            // Grupper sammenhengende meldinger fra samme bruker — skjul avatar
+            // og navn/tid-header på fortsettelses-meldinger. Dato-skille bryter
+            // alltid grupperingen så første melding på ny dag alltid viser header.
+            const erFortsettelse = !visDatoSkille && forrige?.profil_id === m.profil_id
+            const erEgen = m.profil_id === brukerId
+            // Slett-knapp: kun egen-eier. Admin har ingen UI-snarvei for å
+            // slette andres meldinger — om noe må fjernes må admin gjøre det
+            // direkte i DB. Gjelder også FB-importerte: sendte du meldingen
+            // (i appen eller i Messenger som senere ble importert), kan du
+            // slette den her.
+            const kanSlette = erEgen
+            const navn = profilMap.get(m.profil_id) ?? 'Ukjent'
+            const bilde = bildeMap.get(m.profil_id)
+            const rolle = rolleMap.get(m.profil_id) ?? null
+            const tid = formaterDato(m.opprettet, 'HH:mm')
+            return (
+              <Fragment key={m.id}>
+                {visDatoSkille && (
+                  <div
+                    role="separator"
+                    aria-label={`Meldinger fra ${formaterDatoSkille(m.opprettet)}`}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'flex-end',
+                      gap: 8,
+                      margin: '10px 0 2px',
+                      paddingRight: 2,
+                    }}
+                  >
+                    <span aria-hidden="true" style={{ width: 24, height: '0.5px', background: 'var(--border-subtle)' }} />
+                    <span
+                      style={{
+                        fontFamily: 'var(--font-mono)',
+                        fontSize: 9,
+                        letterSpacing: '1.2px',
+                        fontWeight: 600,
+                        color: 'var(--text-tertiary)',
+                      }}
+                    >
+                      {formaterDatoSkille(m.opprettet)}
+                    </span>
+                  </div>
+                )}
+              <div
+                style={{
+                  display: 'flex',
+                  gap: 10,
+                  flexDirection: erEgen ? 'row-reverse' : 'row',
+                  marginTop: erFortsettelse ? 2 : i === 0 ? 0 : 8,
+                }}
+              >
+                <div style={{ flexShrink: 0, alignSelf: 'flex-end' }}>
+                  {erFortsettelse ? (
+                    // Tom plassholder så meldingene linjerer opp mot forrige boble
+                    <div style={{ width: 26, height: 1 }} />
+                  ) : (
+                    <Avatar name={navn} size={26} src={bilde} rolle={rolle} />
+                  )}
+                </div>
+                <div
+                  style={{
+                    maxWidth: '78%',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: erEgen ? 'flex-end' : 'flex-start',
+                    minWidth: 0,
+                  }}
+                >
+                  {!erFortsettelse && (
+                    <div
+                      style={{
+                        display: 'flex',
+                        alignItems: 'baseline',
+                        gap: 8,
+                        marginBottom: 2,
+                        paddingLeft: erEgen ? 0 : 2,
+                        paddingRight: erEgen ? 2 : 0,
+                      }}
+                    >
+                      <span
+                        style={{
+                          fontFamily: 'var(--font-body)',
+                          fontSize: 12,
+                          color: 'var(--text-secondary)',
+                          fontWeight: 500,
+                        }}
+                      >
+                        {navn}
+                      </span>
+                      <span
+                        style={{
+                          fontFamily: 'var(--font-mono)',
+                          fontSize: 9,
+                          color: 'var(--text-tertiary)',
+                          letterSpacing: '1.2px',
+                        }}
+                      >
+                        {tid}
+                      </span>
+                    </div>
+                  )}
+                  <div style={{ position: 'relative' }} className="chat-boble">
+                    {editerer === m.id ? (
+                      <div
+                        style={{
+                          padding: '8px 10px',
+                          borderRadius: erEgen ? '14px 14px 4px 14px' : '14px 14px 14px 4px',
+                          background: erEgen ? 'var(--accent-soft)' : 'var(--bg-elevated)',
+                          border: '0.5px solid var(--accent)',
+                          display: 'flex',
+                          flexDirection: 'column',
+                          gap: 6,
+                          minWidth: 220,
+                        }}
+                      >
+                        <textarea
+                          autoFocus
+                          value={editTekst}
+                          onChange={e => setEditTekst(e.target.value)}
+                          onKeyDown={e => {
+                            if (e.key === 'Enter' && !e.shiftKey) {
+                              e.preventDefault()
+                              lagreEdit(m.id)
+                            } else if (e.key === 'Escape') {
+                              e.preventDefault()
+                              avbrytEdit()
+                            }
+                          }}
+                          maxLength={konfig.charLimit}
+                          rows={2}
+                          style={{
+                            width: '100%',
+                            resize: 'none',
+                            background: 'transparent',
+                            border: 'none',
+                            outline: 'none',
+                            color: 'var(--text-primary)',
+                            fontFamily: 'var(--font-body)',
+                            fontSize: 13,
+                            lineHeight: 1.5,
+                            padding: '2px 4px',
+                          }}
+                        />
+                        <div
+                          style={{
+                            display: 'flex',
+                            gap: 6,
+                            justifyContent: 'flex-end',
+                            alignItems: 'center',
+                          }}
+                        >
+                          <button
+                            type="button"
+                            onClick={avbrytEdit}
+                            disabled={lagrerEdit}
+                            style={{
+                              padding: '4px 10px',
+                              borderRadius: 999,
+                              background: 'transparent',
+                              border: 'none',
+                              color: 'var(--text-secondary)',
+                              fontFamily: 'var(--font-mono)',
+                              fontSize: 9,
+                              letterSpacing: '1.4px',
+                              textTransform: 'uppercase',
+                              fontWeight: 600,
+                              cursor: lagrerEdit ? 'wait' : 'pointer',
+                            }}
+                          >
+                            Avbryt
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => lagreEdit(m.id)}
+                            disabled={lagrerEdit || !editTekst.trim()}
+                            style={{
+                              padding: '4px 12px',
+                              borderRadius: 999,
+                              background: 'var(--accent)',
+                              border: 'none',
+                              color: '#0a0a0a',
+                              fontFamily: 'var(--font-mono)',
+                              fontSize: 9,
+                              letterSpacing: '1.4px',
+                              textTransform: 'uppercase',
+                              fontWeight: 700,
+                              cursor:
+                                lagrerEdit || !editTekst.trim() ? 'default' : 'pointer',
+                              opacity: lagrerEdit || !editTekst.trim() ? 0.5 : 1,
+                            }}
+                          >
+                            {lagrerEdit ? 'Lagrer…' : 'Lagre'}
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                    <div
+                      onTouchStart={() => startLongPress(m.id)}
+                      onTouchEnd={clearLongPress}
+                      onTouchMove={clearLongPress}
+                      onTouchCancel={clearLongPress}
+                      onContextMenu={e => {
+                        // Hindrer iOS sin native callout (kopier/del) og
+                        // fungerer som desktop-høyreklikk-trigger.
+                        e.preventDefault()
+                        if (!m.id.startsWith('temp-')) setPickerFor(m.id)
+                      }}
+                      style={{
+                        padding: '7px 12px',
+                        borderRadius: erEgen ? '14px 14px 4px 14px' : '14px 14px 14px 4px',
+                        background: erEgen ? 'var(--accent-soft)' : 'var(--bg-elevated)',
+                        border: `0.5px solid ${
+                          erEgen ? 'var(--border-strong)' : 'var(--border-subtle)'
+                        }`,
+                        fontFamily: 'var(--font-body)',
+                        fontSize: 13,
+                        lineHeight: 1.5,
+                        color: 'var(--text-primary)',
+                        letterSpacing: '0.1px',
+                        whiteSpace: 'pre-wrap',
+                        wordBreak: 'break-word',
+                        cursor: 'default',
+                        userSelect: 'none',
+                        WebkitUserSelect: 'none',
+                        WebkitTouchCallout: 'none',
+                        touchAction: 'manipulation',
+                      }}
+                    >
+                      {m.bilde_url && (
+                        <button
+                          type="button"
+                          onClick={() => setLightboxSrc(m.bilde_url)}
+                          style={{
+                            display: 'block',
+                            padding: 0,
+                            border: 'none',
+                            background: 'none',
+                            margin: m.innhold ? '0 0 8px' : 0,
+                            cursor: 'zoom-in',
+                            maxWidth: '100%',
+                          }}
+                          aria-label="Vis bilde i full skjerm"
+                        >
+                          {/* eslint-disable-next-line @next/next/no-img-element */}
+                          <img
+                            src={m.bilde_url}
+                            alt=""
+                            loading="lazy"
+                            style={{
+                              display: 'block',
+                              maxWidth: 280,
+                              maxHeight: 280,
+                              borderRadius: 8,
+                              objectFit: 'cover',
+                            }}
+                          />
+                        </button>
+                      )}
+                      {m.video_url && (
+                        <video
+                          src={m.video_url}
+                          controls
+                          preload="metadata"
+                          playsInline
+                          style={{
+                            display: 'block',
+                            maxWidth: 280,
+                            height: 'auto',
+                            maxHeight: 280,
+                            borderRadius: 8,
+                            marginBottom: m.innhold ? 8 : 0,
+                          }}
+                        />
+                      )}
+                      {m.innhold && renderMedMentions(m.innhold)}
+                    </div>
+                    )}
+                    {m.fra_facebook && <MessengerBadge erEgen={erEgen} />}
+                    {/* Reaksjons-chips — flyter på bunnkanten av bobla, ikke
+                        egen linje. Negativ margin trekker dem opp slik at de
+                        overlapper bobla, padding holder dem litt inn fra
+                        kanten. Bottom-margin på .chat-boble (under) gir plass
+                        til at de stikker ut. */}
+                    {(() => {
+                      const mineReaksjoner = reaksjonerPerMelding.get(m.id)
+                      if (!mineReaksjoner || mineReaksjoner.length === 0) return null
+                      const grupper = new Map<string, { antall: number; minReaksjon: boolean }>()
+                      for (const r of mineReaksjoner) {
+                        const g = grupper.get(r.emoji) ?? { antall: 0, minReaksjon: false }
+                        g.antall += 1
+                        if (r.profil_id === brukerId) g.minReaksjon = true
+                        grupper.set(r.emoji, g)
+                      }
+                      return (
+                        <div
+                          style={{
+                            display: 'flex',
+                            flexWrap: 'wrap',
+                            gap: 2,
+                            marginTop: -10,
+                            paddingLeft: erEgen ? 0 : 8,
+                            paddingRight: erEgen ? 8 : 0,
+                            position: 'relative',
+                            zIndex: 1,
+                            justifyContent: erEgen ? 'flex-end' : 'flex-start',
+                          }}
+                        >
+                          {[...grupper.entries()].map(([emoji, { antall, minReaksjon }]) => (
+                            <button
+                              key={emoji}
+                              type="button"
+                              onClick={() => toggleReaksjon(m.id, emoji)}
+                              style={{
+                                display: 'inline-flex',
+                                alignItems: 'center',
+                                gap: 3,
+                                padding: '1px 6px',
+                                borderRadius: 999,
+                                border: `0.5px solid ${minReaksjon ? 'var(--accent)' : 'var(--border)'}`,
+                                background: 'var(--bg-elevated-2)',
+                                boxShadow: '0 2px 6px rgba(0,0,0,0.25)',
+                                fontSize: 11,
+                                lineHeight: 1.2,
+                                color: 'var(--text-primary)',
+                                cursor: 'pointer',
+                                fontFamily: 'var(--font-body)',
+                              }}
+                              aria-label={`${emoji} ${antall} ${minReaksjon ? '(fjern din reaksjon)' : '(reager også)'}`}
+                            >
+                              <span>{emoji}</span>
+                              {antall > 1 && (
+                                <span
+                                  style={{
+                                    fontFamily: 'var(--font-mono)',
+                                    fontSize: 9,
+                                    color: minReaksjon ? 'var(--accent)' : 'var(--text-secondary)',
+                                    fontWeight: 600,
+                                  }}
+                                >
+                                  {antall}
+                                </span>
+                              )}
+                            </button>
+                          ))}
+                        </div>
+                      )
+                    })()}
+                    {/* Picker — vises over bobla når long-press trigger */}
+                    {pickerFor === m.id && (
+                      <>
+                        {/* Overlay som fanger klikk utenfor */}
+                        <div
+                          onClick={() => setPickerFor(null)}
+                          style={{
+                            position: 'fixed',
+                            inset: 0,
+                            zIndex: 90,
+                            background: 'transparent',
+                          }}
+                        />
+                        <div
+                          style={{
+                            position: 'absolute',
+                            bottom: 'calc(100% + 6px)',
+                            [erEgen ? 'right' : 'left']: 0,
+                            zIndex: 100,
+                            display: 'flex',
+                            gap: 4,
+                            padding: '6px 8px',
+                            borderRadius: 999,
+                            background: 'var(--bg-elevated)',
+                            border: '0.5px solid var(--border-strong)',
+                            boxShadow: '0 6px 20px rgba(0,0,0,0.3)',
+                          }}
+                        >
+                          {REAKSJON_EMOJIS.map(emoji => (
+                            <button
+                              key={emoji}
+                              type="button"
+                              onClick={() => toggleReaksjon(m.id, emoji)}
+                              style={{
+                                width: 34,
+                                height: 34,
+                                borderRadius: '50%',
+                                border: 'none',
+                                background: 'transparent',
+                                fontSize: 20,
+                                cursor: 'pointer',
+                                padding: 0,
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                              }}
+                              aria-label={`Reager med ${emoji}`}
+                            >
+                              {emoji}
+                            </button>
+                          ))}
+                          {erEgen && m.innhold !== null && (
+                            <>
+                              <div
+                                style={{
+                                  width: '0.5px',
+                                  background: 'var(--border-subtle)',
+                                  margin: '4px 4px',
+                                }}
+                                aria-hidden="true"
+                              />
+                              <button
+                                type="button"
+                                onClick={() => startEdit(m.id, m.innhold!)}
+                                style={{
+                                  height: 34,
+                                  borderRadius: 999,
+                                  border: 'none',
+                                  background: 'transparent',
+                                  fontFamily: 'var(--font-mono)',
+                                  fontSize: 9,
+                                  color: 'var(--text-secondary)',
+                                  letterSpacing: '1.4px',
+                                  textTransform: 'uppercase',
+                                  fontWeight: 600,
+                                  cursor: 'pointer',
+                                  padding: '0 12px',
+                                  display: 'flex',
+                                  alignItems: 'center',
+                                }}
+                                aria-label="Rediger melding"
+                              >
+                                Rediger
+                              </button>
+                            </>
+                          )}
+                        </div>
+                      </>
+                    )}
+                    {kanSlette && !m.id.startsWith('temp-') && (
+                      <button
+                        type="button"
+                        onClick={() => handleSlett(m.id)}
+                        className="chat-slett-knapp"
+                        style={{
+                          position: 'absolute',
+                          top: -6,
+                          [erEgen ? 'left' : 'right']: -6,
+                          width: 20,
+                          height: 20,
+                          borderRadius: '50%',
+                          background: 'var(--bg-elevated)',
+                          border: '0.5px solid var(--border)',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          cursor: 'pointer',
+                          padding: 0,
+                          color: 'var(--danger)',
+                          opacity: 0,
+                          transition: 'opacity 120ms',
+                        }}
+                        aria-label="Slett melding"
+                      >
+                        <Icon name="x" size={10} color="var(--danger)" strokeWidth={2} />
+                      </button>
+                    )}
+                  </div>
+                </div>
+              </div>
+              </Fragment>
+            )
+          })}
+          <div ref={bunnenRef} />
+        </div>
+      </div>
+
+      {/* «Ny melding»-pille — absolutt-posisjonert relativt til ytre flex-wrapper,
+          rett over input-baren. Fade-in 200ms. Tap scroller til bunn og skjuler pilla.
+          Ingen pointer-events på ytre wrapper (pilla er eneste interaksjonsflate her). */}
+      {visNyMeldingPille && (
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 'calc(var(--input-bar-h, 56px) + env(safe-area-inset-bottom) + 8px)',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            zIndex: 25,
+            animation: 'fadeIn 200ms ease',
+          }}
+        >
+          <button
+            type="button"
+            onClick={() => scrollTilBunn()}
+            style={{
+              padding: '6px 14px',
+              borderRadius: 999,
+              background: 'rgba(30,32,40,0.92)',
+              border: '0.5px solid var(--border-strong)',
+              color: 'var(--text-primary)',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 10,
+              letterSpacing: '1.2px',
+              textTransform: 'uppercase',
+              fontWeight: 600,
+              cursor: 'pointer',
+              backdropFilter: 'blur(8px)',
+              WebkitBackdropFilter: 'blur(8px)',
+              boxShadow: '0 4px 16px rgba(0,0,0,0.4)',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            ↓ Ny melding
+          </button>
+        </div>
+      )}
+
+      {/* Input-bar — flexShrink:0 slik at den aldri komprimeres av scroll-
+          containeren. Ingen sticky/fixed: resizes-content sørger for at hele
+          layout-treet flyttes opp ved tastatur-åpning. */}
+      <div
+        style={{
+          flexShrink: 0,
+          padding: '0 20px',
+          paddingBottom: 'env(safe-area-inset-bottom)',
+        }}
+      >
+        {/* @mention-forslag */}
+        <MentionVelger forslag={mentionForslag} onVelg={velgMention} />
+        {/* Bilde-forhåndsvisning over input når et bilde er valgt */}
+        {bildePreview && (
+          <div
+            style={{
+              position: 'relative',
+              marginBottom: 6,
+              display: 'inline-block',
+            }}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={bildePreview}
+              alt="Forhåndsvisning"
+              style={{
+                maxWidth: 120,
+                maxHeight: 120,
+                borderRadius: 8,
+                border: '0.5px solid var(--border)',
+                objectFit: 'cover',
+              }}
+            />
+            <button
+              type="button"
+              onClick={fjernBilde}
+              aria-label="Fjern bilde"
+              style={{
+                position: 'absolute',
+                top: -6,
+                right: -6,
+                width: 22,
+                height: 22,
+                borderRadius: '50%',
+                background: 'rgba(0,0,0,0.75)',
+                color: '#fff',
+                border: 'none',
+                fontSize: 14,
+                fontWeight: 700,
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: 0,
+              }}
+            >
+              ×
+            </button>
+          </div>
+        )}
+        {bildeFeil && (
+          <div
+            style={{
+              fontFamily: 'var(--font-body)',
+              fontSize: 11,
+              color: 'var(--danger)',
+              marginBottom: 6,
+            }}
+          >
+            {bildeFeil}
+          </div>
+        )}
+
+        {/* Skriv melding — pill. Solid bakgrunn (ikke --bg-elevated som er
+            95% opaque) så eventuelle meldinger som glir bak pillen ikke
+            skinner gjennom. */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            padding: '8px 8px 8px 12px',
+            border: '0.5px solid var(--border)',
+            borderRadius: 999,
+            background: '#282a32',
+            marginBottom: 4,
+          }}
+        >
+          <button
+            type="button"
+            onClick={() => bildeInputRef.current?.click()}
+            aria-label="Legg ved bilde"
+            style={{
+              width: 32,
+              height: 32,
+              borderRadius: '50%',
+              background: 'transparent',
+              border: 'none',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              cursor: 'pointer',
+              color: 'var(--text-secondary)',
+              flexShrink: 0,
+              padding: 0,
+            }}
+          >
+            <Icon name="image" size={18} color="currentColor" strokeWidth={1.8} />
+          </button>
+          <input
+            ref={bildeInputRef}
+            type="file"
+            accept="image/*"
+            onChange={velgBilde}
+            style={{ display: 'none' }}
+          />
+          <input
+            ref={inputRef}
+            type="text"
+            value={tekst}
+            onChange={e => {
+              setTekst(e.target.value)
+              setMentionSøk(beregnMentionSøk(e.target.value))
+            }}
+            onKeyDown={e => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault()
+                handleSend()
+              }
+            }}
+            placeholder={bildePreview ? 'Legg til tekst (valgfritt)…' : 'Skriv en melding…'}
+            maxLength={konfig.charLimit}
+            enterKeyHint="send"
+            autoComplete="off"
+            style={{
+              flex: 1,
+              minWidth: 0,
+              background: 'transparent',
+              border: 'none',
+              outline: 'none',
+              color: 'var(--text-primary)',
+              fontFamily: 'var(--font-body)',
+              fontSize: 13,
+            }}
+          />
+          <button
+            type="button"
+            onClick={handleSend}
+            disabled={(!tekst.trim() && !bildeFil) || sender}
+            style={{
+              width: 32,
+              height: 32,
+              borderRadius: '50%',
+              background: 'var(--accent)',
+              border: 'none',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              cursor: (!tekst.trim() && !bildeFil) || sender ? 'default' : 'pointer',
+              opacity: (!tekst.trim() && !bildeFil) || sender ? 0.4 : 1,
+              flexShrink: 0,
+            }}
+            aria-label="Send melding"
+          >
+            <Icon name="arrowRight" size={14} color="#0a0a0a" strokeWidth={2.5} />
+          </button>
+        </div>
+      </div>
+
+      {lightboxSrc && (
+        <BildeLightbox src={lightboxSrc} onLukk={() => setLightboxSrc(null)} />
+      )}
+    </div>
+  )
+}

--- a/components/chat/ChatV2.tsx
+++ b/components/chat/ChatV2.tsx
@@ -320,6 +320,9 @@ export default function ChatV2({
         display: 'flex',
         flexDirection: 'column',
         height: 'calc(100dvh - var(--top-header-h, 60px))',
+        // position: relative slik at «Ny melding»-pillen (absolutt-posisjonert
+        // lenger ned) plasseres relativt til denne wrapperen, ikke til body.
+        position: 'relative',
       }}
     >
       {/* Indre scroll-container — tar all ledig plass, scroller internt.

--- a/components/chat/hooks/useChatScrollV2.ts
+++ b/components/chat/hooks/useChatScrollV2.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useLayoutEffect, useRef, useCallback } from 'react'
 import { CHAT_NAER_BUNN_TERSKEL_PX } from '@/lib/konstanter'
 import type { ChatMelding } from '../types'
 
@@ -60,6 +60,35 @@ export function useChatScrollV2({
     // containerRef.current kan endre seg, men ref-objektet er stabilt — ok
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [containerRef])
+
+  // Scroll-anchor for prepend (paginering): når eldre meldinger settes inn
+  // øverst, må vi flytte scroll-posisjonen ned med samme høyde som ble lagt
+  // til, så brukeren visuelt forblir på samme melding. Uten dette ender han
+  // på toppen av den nye batchen og sentinel trigger umiddelbar ny fetch =
+  // flikk-loop. Se #210 / Reidars rapport på PR 1.
+  const forsteId = useRef<string | undefined>(meldinger[0]?.id)
+  const prevScrollHeight = useRef<number>(0)
+
+  useLayoutEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+    const nyForsteId = meldinger[0]?.id
+    if (
+      nyForsteId &&
+      forsteId.current &&
+      nyForsteId !== forsteId.current &&
+      container.scrollTop > 0
+    ) {
+      // Prepend: kompenser scroll slik at synlig innhold ikke hopper
+      const diff = container.scrollHeight - prevScrollHeight.current
+      container.scrollTop += diff
+    }
+    forsteId.current = nyForsteId
+    prevScrollHeight.current = container.scrollHeight
+    // meldinger er bevisst brukt som avhengighet (ikke bare lengde) fordi vi
+    // trenger å lese meldinger[0]?.id — vi ser etter id-skifte, ikke bare lengdeendring.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [meldinger])
 
   // Scroll ved mount og ved nye meldinger. Logikk speiler useChatScroll,
   // men opererer på container-scroll i stedet for window.

--- a/components/chat/hooks/useChatScrollV2.ts
+++ b/components/chat/hooks/useChatScrollV2.ts
@@ -1,0 +1,103 @@
+'use client'
+
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { CHAT_NAER_BUNN_TERSKEL_PX } from '@/lib/konstanter'
+import type { ChatMelding } from '../types'
+
+type UseChatScrollV2Props = {
+  /** Ref til scroll-containeren (den indre div med overflow-y: auto). */
+  containerRef: React.RefObject<HTMLDivElement | null>
+  meldinger: ChatMelding[]
+  brukerId: string
+  autoScrollTilBunn: boolean
+}
+
+type UseChatScrollV2Return = {
+  /** Ref satt på en tom div nederst i meldingslisten. */
+  bunnenRef: React.RefObject<HTMLDivElement | null>
+  /** True når det finnes uleste meldinger fra andre og brukeren ikke er nær bunn. */
+  visNyMeldingPille: boolean
+  /** Scroller container til absolutt bunn (smooth). */
+  scrollTilBunn: () => void
+}
+
+export function useChatScrollV2({
+  containerRef,
+  meldinger,
+  brukerId,
+  autoScrollTilBunn,
+}: UseChatScrollV2Props): UseChatScrollV2Return {
+  const bunnenRef = useRef<HTMLDivElement | null>(null)
+  const [visNyMeldingPille, setVisNyMeldingPille] = useState(false)
+
+  // Scroller containeren (ikke window) til absolutt bunn.
+  const scrollTilBunn = useCallback((instant = false) => {
+    const container = containerRef.current
+    if (!container) return
+    container.scrollTo({
+      top: container.scrollHeight,
+      behavior: instant ? 'auto' : 'smooth',
+    })
+  }, [containerRef])
+
+  // Sjekker om containeren er innenfor CHAT_NAER_BUNN_TERSKEL_PX fra bunnen.
+  function erNaerBunn() {
+    const c = containerRef.current
+    if (!c) return true
+    return c.scrollHeight - c.scrollTop - c.clientHeight <= CHAT_NAER_BUNN_TERSKEL_PX
+  }
+
+  // Scroll-lytter på container: skjul pilla når brukeren manuelt scroller
+  // til nær bunn. Passive for ytelse — vi gjør ingen preventDefault her.
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+    function onScroll() {
+      if (erNaerBunn()) setVisNyMeldingPille(false)
+    }
+    container.addEventListener('scroll', onScroll, { passive: true })
+    return () => container.removeEventListener('scroll', onScroll)
+    // containerRef.current kan endre seg, men ref-objektet er stabilt — ok
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [containerRef])
+
+  // Scroll ved mount og ved nye meldinger. Logikk speiler useChatScroll,
+  // men opererer på container-scroll i stedet for window.
+  // INGEN visualViewport — resizes-content håndterer tastaturet.
+  const forrigeLengde = useRef(meldinger.length)
+  const harMountet = useRef(false)
+  useEffect(() => {
+    const lengde = meldinger.length
+    const diff = lengde - forrigeLengde.current
+    forrigeLengde.current = lengde
+
+    if (!harMountet.current) {
+      harMountet.current = true
+      if (autoScrollTilBunn) {
+        // requestAnimationFrame så layout er ferdig før vi måler
+        requestAnimationFrame(() => scrollTilBunn(true))
+      }
+      return
+    }
+
+    if (!autoScrollTilBunn) return
+    if (diff <= 0 || diff > 3) return // paginering eller krympet liste — ikke scroll
+
+    const sisteEgen = meldinger[meldinger.length - 1]?.profil_id === brukerId
+    if (sisteEgen) {
+      // Egen melding — vi forventer å se den vi sendte
+      scrollTilBunn()
+    } else if (erNaerBunn()) {
+      // Annens melding, nær bunn — ikke avbryt lesingen av nylig innhold
+      scrollTilBunn()
+    } else {
+      // Annens melding, brukeren er langt oppe — vis heller pilla
+      setVisNyMeldingPille(true)
+    }
+    // meldinger og brukerId utelates bevisst — samme begrunnelse som i
+    // useChatScroll: vi trigger kun på lengde, ikke hele array-referansen.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [meldinger.length, autoScrollTilBunn, scrollTilBunn])
+
+  return { bunnenRef, visNyMeldingPille, scrollTilBunn }
+}

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -37,6 +37,12 @@ export const R2_PUBLIC_URL = (
 export const GITHUB_REPO = 'reidarei/Herreklubben'
 export const GITHUB_ONSKE_LABEL = 'ønske'
 
+// Kill-switch: sett CHAT_LEGACY_FALLBACK=true i Vercel env for å rulle
+// tilbake til gammel Chat.tsx uten kode-deploy. Fjernes i PR 3 etter
+// at ChatV2 er bekreftet stabil på iPhone. Ingen NEXT_PUBLIC_-prefiks
+// (server-only; vi trenger ikke sende dette til klienten).
+export const CHAT_LEGACY_FALLBACK = process.env.CHAT_LEGACY_FALLBACK === 'true'
+
 // Bygg GitHub Issues-list URL med ønske-label og gitt state.
 export function githubIssuesUrl(params: {
   state: 'open' | 'closed' | 'all'

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 40,
-  "versjon": "V3.1.40"
+  "nummer": 41,
+  "versjon": "V3.1.41"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 42,
-  "versjon": "V3.1.42"
+  "nummer": 43,
+  "versjon": "V3.1.43"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 41,
-  "versjon": "V3.1.41"
+  "nummer": 42,
+  "versjon": "V3.1.42"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 39,
-  "versjon": "V3.1.39"
+  "nummer": 40,
+  "versjon": "V3.1.40"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.42'
+const CACHE_VERSION = 'V3.1.43'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.41'
+const CACHE_VERSION = 'V3.1.42'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.39'
+const CACHE_VERSION = 'V3.1.40'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.40'
+const CACHE_VERSION = 'V3.1.41'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Tredje PR for #210 (etter PR 0 og PR 1). Den store layout-endringen.

## Endring
- **`app/(app)/chat/layout.tsx`** (ny) — viewport `interactiveWidget: 'resizes-content'` kun for /chat-ruten
- **`components/chat/ChatV2.tsx`** (ny, ~1100 linjer) — intern scroll-container, headerSlot-prop, ingen keyboardOffset-juks, "Ny melding"-pille når brukeren leser eldre
- **`components/chat/hooks/useChatScrollV2.ts`** (ny) — container-basert scroll, scroll-anchor for prepend (fikser flikk-loop Reidar fant), ingen visualViewport
- **`lib/config.ts`** — `CHAT_LEGACY_FALLBACK` env-flag (server-only)
- **`app/(app)/chat/page.tsx`** — server-side render: `brukLegacy = CHAT_LEGACY_FALLBACK || ?legacy=1`. Default: ChatV2.

## Produkt-valg (auto, kan korrigeres)
- Nær-bunn-terskel: 150 px (eksisterende konstant)
- Header scroller med innhold (iMessage-aktig)
- "Ny melding"-pille: liten mørk pille "↓ Ny melding" sentrert over input, absolutt-posisjonert i wrapper

## Beslutninger underveis
- **Bug rapportert av Reidar i PR 1 (flikk-loop ved scroll opp):** løst via `useLayoutEffect` i `useChatScrollV2` som måler `scrollHeight` før/etter prepend og kompenserer `scrollTop`
- **Pille-plassering:** koderen flagget at wrapper manglet `position: relative` — rettet før push
- **Reviewer:** rate limit truffet, stoler på Copilot + manuell verifikasjon på iPhone

## Kill-switch
- **Env-flag** `CHAT_LEGACY_FALLBACK=true` i Vercel (server-side, treffer alle med én bryter)
- **URL-param** `?legacy=1` (utvikler-testing, individuell session)
- Default V2 på når flagget er av

## Manuell test på iPhone PWA (Reidar)
1. Åpne `/chat` — siste meldinger nederst, ingen flikk ved load
2. Scroll oppover — eldre meldinger lastes uten flikk-loop (scroll-anchor i action)
3. Tap input — tastatur krymper viewporten, input rett over tastaturet uten JS-juks
4. La andre sende melding mens du leser eldre — "↓ Ny melding"-pille over input. Tap → scroll til bunn
5. Send egen melding — alltid scroll til bunn
6. `/chat?legacy=1` — gammel versjon
7. /samtaler/[id] og andre chat-flater — uendret (overlays-content fortsatt)

## Diff-størrelse
~1330 linjer ny kode i 7 filer. ChatV2 er bevisst kopi av Chat med endringer (parallel change-mønster). PR 3 sletter legacy + env-flag etter 2 ukers stabil drift.