### PR TITLE
PR 3: Fiks scroll-anchor flikk + flytt privatmeldinger til profil (#210)

### DIFF
--- a/app/(app)/chat/page.tsx
+++ b/app/(app)/chat/page.tsx
@@ -1,10 +1,8 @@
-import Link from 'next/link'
 import { createServerClient } from '@/lib/supabase/server'
 import { getInnloggetBruker, getProfil } from '@/lib/auth-cache'
 import Chat from '@/components/chat/Chat'
 import ChatV2 from '@/components/chat/ChatV2'
 import ChatAutoScrollScript from '@/components/chat/ChatAutoScrollScript'
-import Icon from '@/components/ui/Icon'
 import { kanAdministrere } from '@/lib/roller'
 import { markerChatSett } from '@/lib/actions/ulest'
 import { CHAT_LEGACY_FALLBACK } from '@/lib/config'
@@ -24,21 +22,13 @@ export default async function KlubbChatSide({
     searchParams,
   ])
 
-  const [{ data: siste }, { data: profiler }, { count: ulestPrivat }] = await Promise.all([
+  const [{ data: siste }, { data: profiler }] = await Promise.all([
     supabase
       .from('klubb_chat')
       .select('id, profil_id, innhold, bilde_url, video_url, opprettet, fra_facebook')
       .order('opprettet', { ascending: false })
       .limit(30),
     supabase.from('profiles').select('id, navn, bilde_url, rolle').eq('aktiv', true),
-    // Antall uleste privatmeldinger til meg. RLS sørger for at vi kun
-    // teller meldinger i samtaler vi deltar i; profil_id != meg ekskluderer
-    // egne sendte meldinger.
-    supabase
-      .from('samtale_chat')
-      .select('id', { count: 'exact', head: true })
-      .eq('lest', false)
-      .neq('profil_id', user!.id),
   ])
 
   // Marker at brukeren nå ser klubb-chat — prikken forsvinner ved neste
@@ -47,7 +37,6 @@ export default async function KlubbChatSide({
 
   const erAdmin = kanAdministrere(profil?.rolle)
   const initialMeldinger = [...(siste ?? [])].reverse()
-  const ulest = ulestPrivat ?? 0
 
   // Kill-switch: CHAT_LEGACY_FALLBACK (env) eller ?legacy=1 i URL tvinger
   // gammel Chat.tsx. Fjernes i PR 3 etter at ChatV2 er bekreftet stabil.
@@ -87,57 +76,6 @@ export default async function KlubbChatSide({
       >
         Samtalen
       </h1>
-
-      {/* Lenke til private samtaler — vises alltid for at funksjonen skal
-          være oppdagbar. Ulest-badge til høyre når det finnes uleste. */}
-      <Link
-        href="/samtaler"
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 12,
-          padding: '12px 14px',
-          marginTop: 22,
-          background: 'var(--bg-elevated)',
-          border: '0.5px solid var(--border)',
-          borderRadius: 'var(--radius-card)',
-          textDecoration: 'none',
-          color: 'inherit',
-        }}
-      >
-        <Icon name="message" size={18} color="var(--accent)" strokeWidth={1.6} />
-        <span
-          style={{
-            flex: 1,
-            fontFamily: 'var(--font-body)',
-            fontSize: 14,
-            color: 'var(--text-primary)',
-          }}
-        >
-          Privatmeldinger
-        </span>
-        {ulest > 0 && (
-          <span
-            style={{
-              minWidth: 20,
-              height: 20,
-              padding: '0 7px',
-              borderRadius: 999,
-              background: 'var(--accent)',
-              color: '#0a0a0a',
-              fontFamily: 'var(--font-mono)',
-              fontSize: 10,
-              fontWeight: 700,
-              display: 'inline-flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            {ulest}
-          </span>
-        )}
-        <Icon name="chevron" size={14} color="var(--text-tertiary)" />
-      </Link>
     </div>
   )
 

--- a/app/(app)/profil/page.tsx
+++ b/app/(app)/profil/page.tsx
@@ -3,6 +3,7 @@ import { createServerClient } from '@/lib/supabase/server'
 import { getInnloggetBruker } from '@/lib/auth-cache'
 import { norskAar } from '@/lib/dato'
 import Avatar from '@/components/ui/Avatar'
+import Icon from '@/components/ui/Icon'
 import SectionLabel from '@/components/ui/SectionLabel'
 import VarslerInnstillinger from '@/components/VarslerInnstillinger'
 import VarslerListe from '@/components/profil/VarslerListe'
@@ -24,6 +25,7 @@ export default async function Profil() {
     { data: varsler },
     { count: antallUlesteVarsler },
     { data: passInfo },
+    { count: ulestPrivat },
   ] = await Promise.all([
     supabase
       .from('profiles')
@@ -71,7 +73,16 @@ export default async function Profil() {
       .select('nummer, utloper')
       .eq('profil_id', user!.id)
       .maybeSingle(),
+    // Antall uleste privatmeldinger til meg. Brukes på privatmeldinger-lenken
+    // øverst i profil-siden (flyttet hit fra /chat-headeren, #210).
+    supabase
+      .from('samtale_chat')
+      .select('id', { count: 'exact', head: true })
+      .eq('lest', false)
+      .neq('profil_id', user!.id),
   ])
+
+  const ulest = ulestPrivat ?? 0
 
   const navn = profil?.navn ?? 'Ukjent'
   const rolle = tittelFor(profil?.rolle)
@@ -228,6 +239,56 @@ export default async function Profil() {
           ))}
         </div>
       </div>
+
+      {/* Privatmeldinger — flyttet hit fra /chat-headeren (#210 PR 3) */}
+      <Link
+        href="/samtaler"
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          padding: '12px 14px',
+          marginBottom: 24,
+          background: 'var(--bg-elevated)',
+          border: '0.5px solid var(--border)',
+          borderRadius: 'var(--radius-card)',
+          textDecoration: 'none',
+          color: 'inherit',
+        }}
+      >
+        <Icon name="message" size={18} color="var(--accent)" strokeWidth={1.6} />
+        <span
+          style={{
+            flex: 1,
+            fontFamily: 'var(--font-body)',
+            fontSize: 14,
+            color: 'var(--text-primary)',
+          }}
+        >
+          Privatmeldinger
+        </span>
+        {ulest > 0 && (
+          <span
+            style={{
+              minWidth: 20,
+              height: 20,
+              padding: '0 7px',
+              borderRadius: 999,
+              background: 'var(--accent)',
+              color: '#0a0a0a',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 10,
+              fontWeight: 700,
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            {ulest}
+          </span>
+        )}
+        <Icon name="chevron" size={14} color="var(--text-tertiary)" />
+      </Link>
 
       {/* Arrangøransvar */}
       {ansvar && ansvar.length > 0 && (

--- a/components/chat/hooks/useChatScrollV2.ts
+++ b/components/chat/hooks/useChatScrollV2.ts
@@ -76,12 +76,17 @@ export function useChatScrollV2({
     if (
       nyForsteId &&
       forsteId.current &&
-      nyForsteId !== forsteId.current &&
-      container.scrollTop > 0
+      nyForsteId !== forsteId.current
     ) {
-      // Prepend: kompenser scroll slik at synlig innhold ikke hopper
+      // Prepend: kompenser scroll slik at synlig innhold ikke hopper.
+      // VIKTIG: Vi må kompensere også når scrollTop=0 (brukeren er på topp).
+      // Uten det forblir sentinel synlig etter prepend → IntersectionObserver
+      // trigger umiddelbart → flikk-loop til alt er hentet. Etter
+      // kompensasjon ser brukeren samme melding som før (de nye eldre ligger
+      // over, må scrolle opp for å se dem). Tidligere `scrollTop > 0`-guard
+      // var feil — den hindret nettopp kompensasjonen som lukker loopen.
       const diff = container.scrollHeight - prevScrollHeight.current
-      container.scrollTop += diff
+      if (diff > 0) container.scrollTop += diff
     }
     forsteId.current = nyForsteId
     prevScrollHeight.current = container.scrollHeight

--- a/lib/actions/samtaler.ts
+++ b/lib/actions/samtaler.ts
@@ -2,6 +2,7 @@
 
 import { createServerClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
+import { revalidatePath } from 'next/cache'
 
 /**
  * Finn eller opprett samtalen mellom innlogget bruker og motpart.
@@ -60,6 +61,10 @@ export async function markerSamtaleLest(samtaleId: string) {
     .eq('samtale_id', samtaleId)
     .neq('profil_id', user.id)
     .eq('lest', false)
+
+  // Profil-siden viser uleste-badge på Privatmeldinger-lenken (#210 PR 3).
+  // Uten revalidate vil tilbakenavigasjon til /profil vise gammel telling.
+  revalidatePath('/profil')
 }
 
 // Send/oppdater/slett private meldinger går via sendChatMelding /

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 43,
-  "versjon": "V3.1.43"
+  "nummer": 44,
+  "versjon": "V3.1.44"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 44,
-  "versjon": "V3.1.44"
+  "nummer": 45,
+  "versjon": "V3.1.45"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.44'
+const CACHE_VERSION = 'V3.1.45'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.43'
+const CACHE_VERSION = 'V3.1.44'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Lukker #210 (sammen med PR 0/1/2). Adresserer flikk-bugen Reidar fant i PR 2.

## Endring
- **`useChatScrollV2.ts`** — fjernet `scrollTop > 0`-guard fra prepend-kompensasjonen. Det var nettopp tilstanden vi måtte håndtere: når brukeren scroller til topp (scrollTop=0) og eldre meldinger prepended-es, må vi kompensere ned, ellers forblir sentinel synlig → IntersectionObserver trigger igjen → flikk-loop til alt er hentet.
- **`/profil/page.tsx`** — Privatmeldinger-lenken (med ulest-badge) flyttet hit, rett etter stat-blokken
- **`/chat/page.tsx`** — Privatmeldinger-Link + ulest-query fjernet fra headerSlot. /chat er nå ren chat-flate.

## Hvorfor flytte privatmeldinger?
Reidars hypotese var at headeren med privatmeldinger-knappen kunne forstyrre scroll-modellen siden /chat ikke var ren chat. Den hypotesen stemte ikke helt — selve flikket var pga den feilaktige `scrollTop > 0`-guarden — men flyttingen gir en renere chat-flate uten distraksjon. Privatmeldinger er nå tilgjengelig fra profilen (én tap fra TopHeader-avataren).

## Manuell test
1. Scroll til toppen av /chat — eldre meldinger skal lastes én batch av gangen uten flikk-loop
2. Profil-siden viser Privatmeldinger-lenke med ulest-badge
3. /chat har ingen Privatmeldinger-knapp lenger, kun "Klubbchat / Samtalen"-header

## Cleanup (ikke i denne PR)
Legacy `Chat.tsx` + `CHAT_LEGACY_FALLBACK` env-flag + `?legacy=1` URL-param står fortsatt — slettes i egen PR når Reidar har bekreftet at scroll-anchor faktisk virker.