### PR TITLE
PR 4: Observer remount-fix + samtaler ut av chat-tab (#210)

### DIFF
--- a/components/TopHeader.tsx
+++ b/components/TopHeader.tsx
@@ -5,7 +5,6 @@ import { usePathname } from 'next/navigation'
 import { type CSSProperties, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import Avatar from '@/components/ui/Avatar'
 import { harGulGloed } from '@/lib/roller'
-import { CHAT_TAB_PREFIKSER } from '@/lib/navigasjon'
 
 type Tab = {
   href: string
@@ -17,7 +16,10 @@ type Tab = {
 
 const TABS: Tab[] = [
   { href: '/', label: 'Agenda', nokkel: 'agenda', prefikser: ['/poll', '/arrangementer', '/meldinger'] },
-  { href: '/chat', label: 'Chat', nokkel: 'chat', prefikser: [...CHAT_TAB_PREFIKSER] },
+  // /samtaler aktiverer IKKE chat-tabben visuelt. Privatmeldinger åpnes fra
+  // profil-siden (#210 PR 4). Pull-to-refresh-deaktivering styres fortsatt
+  // av CHAT_TAB_PREFIKSER i lib/navigasjon.ts som beholder begge.
+  { href: '/chat', label: 'Chat', nokkel: 'chat', prefikser: ['/chat'] },
   { href: '/klubbinfo', label: 'Klubb', nokkel: 'klubb', prefikser: ['/klubbinfo', '/kaaringer', '/album'] },
 ]
 

--- a/components/chat/ChatV2.tsx
+++ b/components/chat/ChatV2.tsx
@@ -5,7 +5,7 @@
 // Erstatter Chat.tsx på /chat-ruten når CHAT_LEGACY_FALLBACK=false (default).
 // Se issue #210 for bakgrunn og PR 2 for denne implementasjonen.
 
-import { Fragment, useState, useEffect, useRef, useCallback, type ReactNode } from 'react'
+import { Fragment, useState, useEffect, useRef, type ReactNode } from 'react'
 import { type ChatScope as ChatScopeKonfig } from '@/lib/chat-konfig'
 import { formaterDato, erSammeNorskeDag, formaterDatoSkille } from '@/lib/dato'
 import Avatar from '@/components/ui/Avatar'

--- a/components/chat/ChatV2.tsx
+++ b/components/chat/ChatV2.tsx
@@ -161,15 +161,18 @@ export default function ChatV2({
   }, [])
 
   // IntersectionObserver: kall lastEldre() automatisk når toppSentinelRef
-  // scrolles inn i scroll-containeren (root = containerRef.current).
-  // 200px forhåndsmargin trigger hentingen litt før sentinelen er fullt
-  // synlig — seamless paginering. Aktiv bare når harMerEldre === true og
-  // brukeren har scrollet (harBrukerScrolletRef).
-  // lastEldre() er idempotent via intern ref-lock, så observer-callback
-  // kan kalle den direkte uten ekstra guards her.
-  const lastEldreCallback = useCallback(() => {
-    if (!harBrukerScrolletRef.current) return
-    lastEldre()
+  // scrolles inn i scroll-containeren. Bevisst minimal `useEffect`-dep
+  // ([harMerEldre]) for å unngå at observer remountes ved hver meldinger-
+  // endring — det er nettopp det som tidligere ga flikk-loop fordi en ny
+  // observer øyeblikkelig fyrer hvis sentinel synes innenfor rootMargin
+  // (#210 PR 3 fant scroll-anchor-bug, PR 4 fant remount-bug).
+  //
+  // For å holde callback'en oppdatert uten å være dep, leser vi siste
+  // lastEldre via ref. Reset av observer skjer KUN når harMerEldre toggles
+  // (true → false når alle gamle meldinger er hentet).
+  const lastEldreRef = useRef(lastEldre)
+  useEffect(() => {
+    lastEldreRef.current = lastEldre
   }, [lastEldre])
 
   useEffect(() => {
@@ -180,7 +183,9 @@ export default function ChatV2({
 
     const observer = new IntersectionObserver(
       entries => {
-        if (entries[0]?.isIntersecting) lastEldreCallback()
+        if (!entries[0]?.isIntersecting) return
+        if (!harBrukerScrolletRef.current) return
+        lastEldreRef.current()
       },
       {
         root: container,
@@ -189,7 +194,7 @@ export default function ChatV2({
     )
     observer.observe(sentinel)
     return () => observer.disconnect()
-  }, [harMerEldre, lastEldreCallback])
+  }, [harMerEldre])
 
   async function velgBilde(e: React.ChangeEvent<HTMLInputElement>) {
     const fil = e.target.files?.[0]

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 45,
-  "versjon": "V3.1.45"
+  "nummer": 46,
+  "versjon": "V3.1.46"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 46,
-  "versjon": "V3.1.46"
+  "nummer": 47,
+  "versjon": "V3.1.47"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.45'
+const CACHE_VERSION = 'V3.1.46'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.46'
+const CACHE_VERSION = 'V3.1.47'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Adresserer to bugs:

1. **Scroll-anchor flikk** — IntersectionObserver-useEffect hadde `lastEldreCallback` som dep, som skiftet ved hver meldinger-endring. Hver remount lagde ny observer som umiddelbart fyrte hvis sentinel var innenfor rootMargin. Nå: kun `[harMerEldre]` som dep, `lastEldre` via ref.

2. **/samtaler aktiverte chat-tabben** — fjernet fra TopHeaders Chat-tab-prefikser. Pull-to-refresh-deaktivering beholdt via CHAT_TAB_PREFIKSER i navigasjon.ts.

## Test
- Scroll til topp av /chat — ingen flikk
- Gå på Privatmeldinger fra profil — chat-tabben i TopHeader skal IKKE være highlighta