### PR TITLE
PR 5: Drop paginering, hent alt initial (#210)

### DIFF
--- a/app/(app)/chat/page.tsx
+++ b/app/(app)/chat/page.tsx
@@ -22,12 +22,14 @@ export default async function KlubbChatSide({
     searchParams,
   ])
 
-  const [{ data: siste }, { data: profiler }] = await Promise.all([
+  // Henter ALLE meldinger på initial-load. Klubb-chatten er ~300 meldinger
+  // totalt (~60 KB), så det er trivielt å unngå paginering helt — det fjerner
+  // IntersectionObserver, scroll-anchor og hele bug-klassen (#210 PR 5).
+  const [{ data: alle }, { data: profiler }] = await Promise.all([
     supabase
       .from('klubb_chat')
       .select('id, profil_id, innhold, bilde_url, video_url, opprettet, fra_facebook')
-      .order('opprettet', { ascending: false })
-      .limit(30),
+      .order('opprettet', { ascending: true }),
     supabase.from('profiles').select('id, navn, bilde_url, rolle').eq('aktiv', true),
   ])
 
@@ -36,7 +38,7 @@ export default async function KlubbChatSide({
   markerChatSett().catch(() => {})
 
   const erAdmin = kanAdministrere(profil?.rolle)
-  const initialMeldinger = [...(siste ?? [])].reverse()
+  const initialMeldinger = alle ?? []
 
   // Kill-switch: CHAT_LEGACY_FALLBACK (env) eller ?legacy=1 i URL tvinger
   // gammel Chat.tsx. Fjernes i PR 3 etter at ChatV2 er bekreftet stabil.

--- a/app/(app)/chat/page.tsx
+++ b/app/(app)/chat/page.tsx
@@ -8,8 +8,9 @@ import { markerChatSett } from '@/lib/actions/ulest'
 import { CHAT_LEGACY_FALLBACK } from '@/lib/config'
 
 // Klubb-chat: én felles kronologisk tråd for hele herreklubben.
-// Initial-last er siste 30 meldinger (i desc-rekkefølge fra DB, reversert til
-// ascending for UI). «Vis eldre»-knappen i felleskomponenten henter flere.
+// Henter alle meldinger ved initial-load. Klubb-chatten er ~300 meldinger
+// totalt — paginering er fjernet (#210 PR 5) for å lukke en bug-klasse
+// som kom fra IntersectionObserver + scroll-anchor på iOS Safari.
 export default async function KlubbChatSide({
   searchParams,
 }: {

--- a/components/chat/ChatV2.tsx
+++ b/components/chat/ChatV2.tsx
@@ -72,9 +72,6 @@ export default function ChatV2({
     meldinger,
     reaksjoner,
     reaksjonerPerMelding,
-    harMerEldre,
-    henterEldre,
-    lastEldre,
     send,
     slett,
     redigerMelding,
@@ -83,7 +80,6 @@ export default function ChatV2({
   } = useChatData({ scope, brukerId, initialMeldinger })
 
   // scrollContainerRef peker på den indre scroll-div-en.
-  // Sendes ned til useChatScrollV2 og IntersectionObserver.
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
 
   const { bunnenRef, visNyMeldingPille, scrollTilBunn } = useChatScrollV2({
@@ -111,16 +107,6 @@ export default function ChatV2({
   const [lagrerEdit, setLagrerEdit] = useState(false)
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
-  // Sentinel-div øverst i meldingslisten. IntersectionObserver trigges når
-  // den scrolles inn i scroll-containeren (ikke viewport) — oppgi root
-  // eksplisitt i observer-options, ellers brukes window og sentinel-en
-  // er alltid «synlig» siden containeren er utenfor viewport. Se #210.
-  const toppSentinelRef = useRef<HTMLDivElement>(null)
-  // Gating: vi starter ikke auto-load eldre meldinger før brukeren faktisk
-  // har scrollet. 300ms delay etter mount hindrer at siden laster eldre
-  // meldinger allerede ved initial render på korte chatter.
-  // I ChatV2 lytter vi på container-scroll (ikke window-scroll).
-  const harBrukerScrolletRef = useRef(false)
 
   const profilMap = useRef(
     new Map(profiler.map(p => [p.id, p.navn ?? 'Ukjent'])),
@@ -142,59 +128,9 @@ export default function ChatV2({
     }
   }, [bildePreview])
 
-  // Sett harBrukerScrolletRef etter 300ms, lyt på container-scroll (ikke
-  // window) slik at vi vet at brukeren faktisk har scrollet i chatten.
-  useEffect(() => {
-    const container = scrollContainerRef.current
-    if (!container) return
-    // container er ikke-null her (sjekket over), men TypeScript mister
-    // narrowing inn i setTimeout-callback — eksplisitt capture i lokal const.
-    const el = container
-    const timer = setTimeout(() => {
-      function onScroll() {
-        harBrukerScrolletRef.current = true
-        el.removeEventListener('scroll', onScroll)
-      }
-      el.addEventListener('scroll', onScroll, { passive: true })
-    }, 300)
-    return () => clearTimeout(timer)
-  }, [])
-
-  // IntersectionObserver: kall lastEldre() automatisk når toppSentinelRef
-  // scrolles inn i scroll-containeren. Bevisst minimal `useEffect`-dep
-  // ([harMerEldre]) for å unngå at observer remountes ved hver meldinger-
-  // endring — det er nettopp det som tidligere ga flikk-loop fordi en ny
-  // observer øyeblikkelig fyrer hvis sentinel synes innenfor rootMargin
-  // (#210 PR 3 fant scroll-anchor-bug, PR 4 fant remount-bug).
-  //
-  // For å holde callback'en oppdatert uten å være dep, leser vi siste
-  // lastEldre via ref. Reset av observer skjer KUN når harMerEldre toggles
-  // (true → false når alle gamle meldinger er hentet).
-  const lastEldreRef = useRef(lastEldre)
-  useEffect(() => {
-    lastEldreRef.current = lastEldre
-  }, [lastEldre])
-
-  useEffect(() => {
-    if (!harMerEldre) return
-    const sentinel = toppSentinelRef.current
-    const container = scrollContainerRef.current
-    if (!sentinel || !container) return
-
-    const observer = new IntersectionObserver(
-      entries => {
-        if (!entries[0]?.isIntersecting) return
-        if (!harBrukerScrolletRef.current) return
-        lastEldreRef.current()
-      },
-      {
-        root: container,
-        rootMargin: '200px 0px 0px 0px',
-      },
-    )
-    observer.observe(sentinel)
-    return () => observer.disconnect()
-  }, [harMerEldre])
+  // Paginering ble fjernet i #210 PR 5: vi henter alle meldinger ved
+  // initial-load (~300 i klubb-chatten = ~60 KB). Det fjernet hele klassen
+  // av flikk-bugs som kom fra IntersectionObserver + scroll-anchor + iOS.
 
   async function velgBilde(e: React.ChangeEvent<HTMLInputElement>) {
     const fil = e.target.files?.[0]
@@ -347,37 +283,6 @@ export default function ChatV2({
             sender headerSlot slik at /chat-siden kan kontrollere innholdet
             uten at ChatV2 trenger å vite om breadcrumb / privatmelding-lenke. */}
         {headerSlot}
-
-        {/* Laster eldre — progress-pille mens henting pågår */}
-        {henterEldre && (
-          <div style={{ textAlign: 'center', marginBottom: 14 }}>
-            <span
-              style={{
-                display: 'inline-block',
-                padding: '6px 14px',
-                background: 'transparent',
-                border: '0.5px solid var(--border)',
-                borderRadius: 999,
-                color: 'var(--text-secondary)',
-                fontFamily: 'var(--font-mono)',
-                fontSize: 10,
-                letterSpacing: '1.4px',
-                textTransform: 'uppercase',
-                opacity: 0.5,
-              }}
-            >
-              Henter eldre…
-            </span>
-          </div>
-        )}
-        {/* Usynlig sentinel øverst i meldingslisten. IntersectionObserver
-            (useEffect over) kaller lastEldre() når den scrolles inn.
-            Beholdes mountet hele tiden mens harMerEldre er true — pillen
-            over rendres ved siden av. root er scrollContainerRef slik at
-            vi observerer mot containeren, ikke mot viewporten. */}
-        {harMerEldre && (
-          <div ref={toppSentinelRef} style={{ height: 1 }} />
-        )}
 
         {/* Meldingsliste */}
         <div

--- a/components/chat/hooks/useChatScrollV2.ts
+++ b/components/chat/hooks/useChatScrollV2.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useLayoutEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import { CHAT_NAER_BUNN_TERSKEL_PX } from '@/lib/konstanter'
 import type { ChatMelding } from '../types'
 
@@ -21,6 +21,14 @@ type UseChatScrollV2Return = {
   scrollTilBunn: () => void
 }
 
+/**
+ * Scroll-håndtering for ChatV2. Bevisst minimal: appen henter alle meldinger
+ * ved initial-load (~300 meldinger i klubb-chatten), så vi har ingen
+ * paginering, ingen IntersectionObserver, ingen scroll-anchor — det fjerner
+ * hele bug-klassen vi har patchet flere ganger. Hooken har bare to oppgaver:
+ *   1. Initial scroll til bunn ved mount
+ *   2. Ved nye meldinger: pin til bunn hvis nær, ellers vis pille
+ */
 export function useChatScrollV2({
   containerRef,
   meldinger,
@@ -30,7 +38,6 @@ export function useChatScrollV2({
   const bunnenRef = useRef<HTMLDivElement | null>(null)
   const [visNyMeldingPille, setVisNyMeldingPille] = useState(false)
 
-  // Scroller containeren (ikke window) til absolutt bunn.
   const scrollTilBunn = useCallback((instant = false) => {
     const container = containerRef.current
     if (!container) return
@@ -40,15 +47,13 @@ export function useChatScrollV2({
     })
   }, [containerRef])
 
-  // Sjekker om containeren er innenfor CHAT_NAER_BUNN_TERSKEL_PX fra bunnen.
   function erNaerBunn() {
     const c = containerRef.current
     if (!c) return true
     return c.scrollHeight - c.scrollTop - c.clientHeight <= CHAT_NAER_BUNN_TERSKEL_PX
   }
 
-  // Scroll-lytter på container: skjul pilla når brukeren manuelt scroller
-  // til nær bunn. Passive for ytelse — vi gjør ingen preventDefault her.
+  // Skjul pilla når brukeren manuelt scroller til nær bunn.
   useEffect(() => {
     const container = containerRef.current
     if (!container) return
@@ -57,47 +62,10 @@ export function useChatScrollV2({
     }
     container.addEventListener('scroll', onScroll, { passive: true })
     return () => container.removeEventListener('scroll', onScroll)
-    // containerRef.current kan endre seg, men ref-objektet er stabilt — ok
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [containerRef])
 
-  // Scroll-anchor for prepend (paginering): når eldre meldinger settes inn
-  // øverst, må vi flytte scroll-posisjonen ned med samme høyde som ble lagt
-  // til, så brukeren visuelt forblir på samme melding. Uten dette ender han
-  // på toppen av den nye batchen og sentinel trigger umiddelbar ny fetch =
-  // flikk-loop. Se #210 / Reidars rapport på PR 1.
-  const forsteId = useRef<string | undefined>(meldinger[0]?.id)
-  const prevScrollHeight = useRef<number>(0)
-
-  useLayoutEffect(() => {
-    const container = containerRef.current
-    if (!container) return
-    const nyForsteId = meldinger[0]?.id
-    if (
-      nyForsteId &&
-      forsteId.current &&
-      nyForsteId !== forsteId.current
-    ) {
-      // Prepend: kompenser scroll slik at synlig innhold ikke hopper.
-      // VIKTIG: Vi må kompensere også når scrollTop=0 (brukeren er på topp).
-      // Uten det forblir sentinel synlig etter prepend → IntersectionObserver
-      // trigger umiddelbart → flikk-loop til alt er hentet. Etter
-      // kompensasjon ser brukeren samme melding som før (de nye eldre ligger
-      // over, må scrolle opp for å se dem). Tidligere `scrollTop > 0`-guard
-      // var feil — den hindret nettopp kompensasjonen som lukker loopen.
-      const diff = container.scrollHeight - prevScrollHeight.current
-      if (diff > 0) container.scrollTop += diff
-    }
-    forsteId.current = nyForsteId
-    prevScrollHeight.current = container.scrollHeight
-    // meldinger er bevisst brukt som avhengighet (ikke bare lengde) fordi vi
-    // trenger å lese meldinger[0]?.id — vi ser etter id-skifte, ikke bare lengdeendring.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [meldinger])
-
-  // Scroll ved mount og ved nye meldinger. Logikk speiler useChatScroll,
-  // men opererer på container-scroll i stedet for window.
-  // INGEN visualViewport — resizes-content håndterer tastaturet.
+  // Mount + nye meldinger
   const forrigeLengde = useRef(meldinger.length)
   const harMountet = useRef(false)
   useEffect(() => {
@@ -108,28 +76,22 @@ export function useChatScrollV2({
     if (!harMountet.current) {
       harMountet.current = true
       if (autoScrollTilBunn) {
-        // requestAnimationFrame så layout er ferdig før vi måler
         requestAnimationFrame(() => scrollTilBunn(true))
       }
       return
     }
 
     if (!autoScrollTilBunn) return
-    if (diff <= 0 || diff > 3) return // paginering eller krympet liste — ikke scroll
+    if (diff <= 0) return
 
     const sisteEgen = meldinger[meldinger.length - 1]?.profil_id === brukerId
     if (sisteEgen) {
-      // Egen melding — vi forventer å se den vi sendte
       scrollTilBunn()
     } else if (erNaerBunn()) {
-      // Annens melding, nær bunn — ikke avbryt lesingen av nylig innhold
       scrollTilBunn()
     } else {
-      // Annens melding, brukeren er langt oppe — vis heller pilla
       setVisNyMeldingPille(true)
     }
-    // meldinger og brukerId utelates bevisst — samme begrunnelse som i
-    // useChatScroll: vi trigger kun på lengde, ikke hele array-referansen.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [meldinger.length, autoScrollTilBunn, scrollTilBunn])
 

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 48,
-  "versjon": "V3.1.48"
+  "nummer": 49,
+  "versjon": "V3.1.49"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 47,
-  "versjon": "V3.1.47"
+  "nummer": 48,
+  "versjon": "V3.1.48"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.47'
+const CACHE_VERSION = 'V3.1.48'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.48'
+const CACHE_VERSION = 'V3.1.49'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Etter Reidars påpekning om at chat-paginering fortsatt var uryddig: stripp vekk hele bug-klassen ved å droppe paginering helt.

## Fakta
- Klubb-chatten har 298 meldinger total
- Trivielt under 100 KB komprimert over wire
- Ingen grunn til paginering på denne skalaen

## Endringer
- `/chat/page.tsx`: henter alle meldinger ved initial-load
- `useChatScrollV2`: forenklet — kun mount-scroll + nye-meldinger
- `ChatV2.tsx`: slettet sentinel, IntersectionObserver, scroll-anchor, henter-eldre-pille
- `useChatData` urørt (legacy Chat.tsx bruker den fortsatt)

## Hva forsvinner
Ingen IntersectionObserver, ingen scroll-anchor, ingen lock-refs, ingen prevScrollHeight, ingen forsteId-tracking, ingen harBrukerScrolletRef, ingen 300ms-gating, ingen progress-pille.

## Test
Scroll opp og ned i /chat — skal være helt vanlig native scroll uten flikk.