### PR TITLE
PR 6: Viewport-høyde + robust mount-scroll (#210)

### DIFF
--- a/components/chat/ChatV2.tsx
+++ b/components/chat/ChatV2.tsx
@@ -260,7 +260,11 @@ export default function ChatV2({
       style={{
         display: 'flex',
         flexDirection: 'column',
-        height: 'calc(100dvh - var(--top-header-h, 60px))',
+        // 100dvh minus TopHeader (--top-header-h) OG safe-area-inset-top
+        // (notch på iPhone). Tidligere trakk vi bare fra --top-header-h
+        // og endte ~47px under viewport-bunn på iPhone Pro — input-pillen
+        // forsvant utenfor skjermen.
+        height: 'calc(100dvh - var(--top-header-h, 60px) - env(safe-area-inset-top))',
         // position: relative slik at «Ny melding»-pillen (absolutt-posisjonert
         // lenger ned) plasseres relativt til denne wrapperen, ikke til body.
         position: 'relative',

--- a/components/chat/hooks/useChatScrollV2.ts
+++ b/components/chat/hooks/useChatScrollV2.ts
@@ -39,13 +39,15 @@ export function useChatScrollV2({
   const [visNyMeldingPille, setVisNyMeldingPille] = useState(false)
 
   const scrollTilBunn = useCallback((instant = false) => {
-    const container = containerRef.current
-    if (!container) return
-    container.scrollTo({
-      top: container.scrollHeight,
+    // bunnenRef.scrollIntoView er mer robust enn scrollTo(scrollHeight):
+    // scrollHeight er ustabil mens bilder/video laster, så vi kunne lande
+    // "midt i" chatten. scrollIntoView mot en faktisk DOM-node finner alltid
+    // den nye bunnen, også når layout endrer seg rett etter mount.
+    bunnenRef.current?.scrollIntoView({
+      block: 'end',
       behavior: instant ? 'auto' : 'smooth',
     })
-  }, [containerRef])
+  }, [])
 
   function erNaerBunn() {
     const c = containerRef.current
@@ -76,7 +78,17 @@ export function useChatScrollV2({
     if (!harMountet.current) {
       harMountet.current = true
       if (autoScrollTilBunn) {
-        requestAnimationFrame(() => scrollTilBunn(true))
+        // Scroll til bunn i flere bølger: rett etter mount (instant), så etter
+        // 100ms og 500ms for å fange opp at bilder/video kan endre layout-
+        // høyden mens vi er i ferd med å rendre. Instant så brukeren ikke
+        // ser et hopp fra topp til bunn.
+        scrollTilBunn(true)
+        const t1 = setTimeout(() => scrollTilBunn(true), 100)
+        const t2 = setTimeout(() => scrollTilBunn(true), 500)
+        return () => {
+          clearTimeout(t1)
+          clearTimeout(t2)
+        }
       }
       return
     }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 49,
-  "versjon": "V3.1.49"
+  "nummer": 50,
+  "versjon": "V3.1.50"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.49'
+const CACHE_VERSION = 'V3.1.50'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Adresserer to bugs Reidar fant etter PR 5:

1. **Input-pille for langt ned/delvis skjult** — ChatV2 trakk bare fra `--top-header-h` (60px), men på iPhone har TopHeader `paddingTop: env(safe-area-inset-top)` (~47px notch). Containeren ble 47px for høy → input forsvant under viewport-bunn. Nå: `100dvh - --top-header-h - env(safe-area-inset-top)`.

2. **Lander midt i chatten ved mount** — `scrollTo(scrollHeight)` ble målt før bilder/video stabiliserte layout, så scrollHeight var for lite ved første kall. Nå: `bunnenRef.scrollIntoView()` (følger DOM-node, ikke beregnet pixel) + flere bølger (0/100/500ms) for å fange sen layout-endring.