### PR TITLE
Flytt Privatmeldinger fra /chat til /profil (#256)

### DIFF
--- a/app/(app)/chat/page.tsx
+++ b/app/(app)/chat/page.tsx
@@ -1,9 +1,7 @@
-import Link from 'next/link'
 import { createServerClient } from '@/lib/supabase/server'
 import { getInnloggetBruker, getProfil } from '@/lib/auth-cache'
 import Chat from '@/components/chat/Chat'
 import ChatAutoScrollScript from '@/components/chat/ChatAutoScrollScript'
-import Icon from '@/components/ui/Icon'
 import { kanAdministrere } from '@/lib/roller'
 import { markerChatSett } from '@/lib/actions/ulest'
 
@@ -17,21 +15,13 @@ export default async function KlubbChatSide() {
     getProfil(),
   ])
 
-  const [{ data: siste }, { data: profiler }, { count: ulestPrivat }] = await Promise.all([
+  const [{ data: siste }, { data: profiler }] = await Promise.all([
     supabase
       .from('klubb_chat')
       .select('id, profil_id, innhold, bilde_url, video_url, opprettet, fra_facebook')
       .order('opprettet', { ascending: false })
       .limit(30),
     supabase.from('profiles').select('id, navn, bilde_url, rolle').eq('aktiv', true),
-    // Antall uleste privatmeldinger til meg. RLS sørger for at vi kun
-    // teller meldinger i samtaler vi deltar i; profil_id != meg ekskluderer
-    // egne sendte meldinger.
-    supabase
-      .from('samtale_chat')
-      .select('id', { count: 'exact', head: true })
-      .eq('lest', false)
-      .neq('profil_id', user!.id),
   ])
 
   // Marker at brukeren nå ser klubb-chat — prikken forsvinner ved neste
@@ -40,7 +30,6 @@ export default async function KlubbChatSide() {
 
   const erAdmin = kanAdministrere(profil?.rolle)
   const initialMeldinger = [...(siste ?? [])].reverse()
-  const ulest = ulestPrivat ?? 0
 
   return (
     <div style={{ padding: '0 20px 20px' }}>
@@ -77,57 +66,6 @@ export default async function KlubbChatSide() {
           Samtalen
         </h1>
       </div>
-
-      {/* Lenke til private samtaler — vises alltid for at funksjonen skal
-          være oppdagbar. Ulest-badge til høyre når det finnes uleste. */}
-      <Link
-        href="/samtaler"
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 12,
-          padding: '12px 14px',
-          marginBottom: 22,
-          background: 'var(--bg-elevated)',
-          border: '0.5px solid var(--border)',
-          borderRadius: 'var(--radius-card)',
-          textDecoration: 'none',
-          color: 'inherit',
-        }}
-      >
-        <Icon name="message" size={18} color="var(--accent)" strokeWidth={1.6} />
-        <span
-          style={{
-            flex: 1,
-            fontFamily: 'var(--font-body)',
-            fontSize: 14,
-            color: 'var(--text-primary)',
-          }}
-        >
-          Privatmeldinger
-        </span>
-        {ulest > 0 && (
-          <span
-            style={{
-              minWidth: 20,
-              height: 20,
-              padding: '0 7px',
-              borderRadius: 999,
-              background: 'var(--accent)',
-              color: '#0a0a0a',
-              fontFamily: 'var(--font-mono)',
-              fontSize: 10,
-              fontWeight: 700,
-              display: 'inline-flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            {ulest}
-          </span>
-        )}
-        <Icon name="chevron" size={14} color="var(--text-tertiary)" />
-      </Link>
 
       <Chat
         scope={{ type: 'klubb' }}

--- a/app/(app)/profil/page.tsx
+++ b/app/(app)/profil/page.tsx
@@ -3,6 +3,7 @@ import { createServerClient } from '@/lib/supabase/server'
 import { getInnloggetBruker } from '@/lib/auth-cache'
 import { norskAar } from '@/lib/dato'
 import Avatar from '@/components/ui/Avatar'
+import Icon from '@/components/ui/Icon'
 import SectionLabel from '@/components/ui/SectionLabel'
 import VarslerInnstillinger from '@/components/VarslerInnstillinger'
 import VarslerListe from '@/components/profil/VarslerListe'
@@ -24,6 +25,7 @@ export default async function Profil() {
     { data: varsler },
     { count: antallUlesteVarsler },
     { data: passInfo },
+    { count: ulestPrivat },
   ] = await Promise.all([
     supabase
       .from('profiles')
@@ -71,10 +73,19 @@ export default async function Profil() {
       .select('nummer, utloper')
       .eq('profil_id', user!.id)
       .maybeSingle(),
+    // Antall uleste privatmeldinger til meg. RLS sørger for at vi kun
+    // teller meldinger i samtaler vi deltar i; profil_id != meg ekskluderer
+    // egne sendte meldinger. Flyttes hit fra /chat (#256).
+    supabase
+      .from('samtale_chat')
+      .select('id', { count: 'exact', head: true })
+      .eq('lest', false)
+      .neq('profil_id', user!.id),
   ])
 
   const navn = profil?.navn ?? 'Ukjent'
   const rolle = tittelFor(profil?.rolle)
+  const ulest = ulestPrivat ?? 0
 
   return (
     <div style={{ padding: '0 20px 20px' }}>
@@ -228,6 +239,57 @@ export default async function Profil() {
           ))}
         </div>
       </div>
+
+      {/* Privatmeldinger — flyttes hit fra /chat (#256) slik at lenken
+          er tilgjengelig fra profil-siden, ikke fra klubb-chat. */}
+      <Link
+        href="/samtaler"
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          padding: '12px 14px',
+          marginBottom: 22,
+          background: 'var(--bg-elevated)',
+          border: '0.5px solid var(--border)',
+          borderRadius: 'var(--radius-card)',
+          textDecoration: 'none',
+          color: 'inherit',
+        }}
+      >
+        <Icon name="message" size={18} color="var(--accent)" strokeWidth={1.6} />
+        <span
+          style={{
+            flex: 1,
+            fontFamily: 'var(--font-body)',
+            fontSize: 14,
+            color: 'var(--text-primary)',
+          }}
+        >
+          Privatmeldinger
+        </span>
+        {ulest > 0 && (
+          <span
+            style={{
+              minWidth: 20,
+              height: 20,
+              padding: '0 7px',
+              borderRadius: 999,
+              background: 'var(--accent)',
+              color: '#0a0a0a',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 10,
+              fontWeight: 700,
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            {ulest}
+          </span>
+        )}
+        <Icon name="chevron" size={14} color="var(--text-tertiary)" />
+      </Link>
 
       {/* Arrangøransvar */}
       {ansvar && ansvar.length > 0 && (

--- a/components/TopHeader.tsx
+++ b/components/TopHeader.tsx
@@ -5,7 +5,6 @@ import { usePathname } from 'next/navigation'
 import { type CSSProperties, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import Avatar from '@/components/ui/Avatar'
 import { harGulGloed } from '@/lib/roller'
-import { CHAT_TAB_PREFIKSER } from '@/lib/navigasjon'
 
 type Tab = {
   href: string
@@ -17,7 +16,8 @@ type Tab = {
 
 const TABS: Tab[] = [
   { href: '/', label: 'Agenda', nokkel: 'agenda', prefikser: ['/poll', '/arrangementer', '/meldinger'] },
-  { href: '/chat', label: 'Chat', nokkel: 'chat', prefikser: [...CHAT_TAB_PREFIKSER] },
+  // /samtaler aktiverer IKKE chat-tabben visuelt. Privatmeldinger åpnes fra profil-siden (#256). CHAT_TAB_PREFIKSER i lib/navigasjon.ts beholdes for pull-to-refresh-deaktivering.
+  { href: '/chat', label: 'Chat', nokkel: 'chat', prefikser: ['/chat'] },
   { href: '/klubbinfo', label: 'Klubb', nokkel: 'klubb', prefikser: ['/klubbinfo', '/kaaringer', '/album'] },
 ]
 

--- a/lib/actions/samtaler.ts
+++ b/lib/actions/samtaler.ts
@@ -2,6 +2,7 @@
 
 import { createServerClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
+import { revalidatePath } from 'next/cache'
 
 /**
  * Finn eller opprett samtalen mellom innlogget bruker og motpart.
@@ -60,6 +61,9 @@ export async function markerSamtaleLest(samtaleId: string) {
     .eq('samtale_id', samtaleId)
     .neq('profil_id', user.id)
     .eq('lest', false)
+
+  // Oppdater ulest-tellingen som nå vises på profil-siden (#256)
+  revalidatePath('/profil')
 }
 
 // Send/oppdater/slett private meldinger går via sendChatMelding /

--- a/lib/navigasjon.ts
+++ b/lib/navigasjon.ts
@@ -1,6 +1,7 @@
-// Én sannhet for Chat-tab'ens omfang — brukes av både TopHeader (for å
-// markere taben aktiv) og DraNedForOppdater (for å deaktivere pull-to-refresh
-// på chat-ruter). Se #231 for bakgrunn.
+// Én sannhet for Chat-tab'ens omfang — brukes av DraNedForOppdater (for å
+// deaktivere pull-to-refresh på chat-ruter). TopHeader bruker ikke lenger
+// denne listen etter #256 — /samtaler aktiverer ikke chat-tabben visuelt.
+// Se #231 for bakgrunn.
 
 export const CHAT_TAB_PREFIKSER = ['/chat', '/samtaler'] as const
 

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 52,
-  "versjon": "V3.1.52"
+  "nummer": 53,
+  "versjon": "V3.1.53"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.52'
+const CACHE_VERSION = 'V3.1.53'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Lukker #256. Ortogonal forbedring tatt ut av #210-arbeidet (ble revertert i #255 sammen med chat-arkitekturen, gjøres på nytt som egen PR).

## Endring
- Privatmeldinger-lenke flyttet fra /chat-headeren til /profil-siden (med ulest-badge)
- TopHeader: /samtaler aktiverer ikke lenger chat-tabben visuelt
- `markerSamtaleLest` revalidatererer /profil så badge ikke blir stale
- `CHAT_TAB_PREFIKSER` beholdt for pull-to-refresh-deaktivering

## Effekt
Når brukeren går fra profilen til Privatmeldinger, blir han ikke villedet om at han er på 'Chat'-tabben. Privatmeldinger ligger nå i sin egen brukers-sone (profil), som matcher hvordan Slack/Messenger skiller DM fra kanaler.