### PR TITLE
Valgfri hilsen i purre-modal (#267)

### DIFF
--- a/app/(app)/arrangoransvar/PurreKnapp.tsx
+++ b/app/(app)/arrangoransvar/PurreKnapp.tsx
@@ -2,19 +2,39 @@
 
 import { useState, useTransition } from 'react'
 import { purreAnsvarlig } from '@/lib/actions/arrangoransvar'
+import { PURRING_MAKS_LENGDE } from '@/lib/konstanter'
 
-export default function PurreKnapp({ ansvarId }: { ansvarId: string }) {
+export default function PurreKnapp({
+  ansvarId,
+  arrangementNavn,
+}: {
+  ansvarId: string
+  arrangementNavn: string
+}) {
   const [isPending, startTransition] = useTransition()
   const [sendt, setSendt] = useState(false)
   const [feil, setFeil] = useState('')
+  const [modalAapen, setModalAapen] = useState(false)
+  const [melding, setMelding] = useState('')
 
-  function handleKlikk() {
+  function aapneModal() {
     if (sendt || isPending) return
     setFeil('')
+    setMelding('')
+    setModalAapen(true)
+  }
+
+  function lukkModal() {
+    setModalAapen(false)
+  }
+
+  function handleSend() {
     startTransition(async () => {
       try {
-        await purreAnsvarlig(ansvarId)
+        // Sender hilsen kun hvis den ikke er tom etter trimming
+        await purreAnsvarlig(ansvarId, melding.trim() || undefined)
         setSendt(true)
+        setModalAapen(false)
       } catch (err) {
         setFeil(err instanceof Error ? err.message : 'Kunne ikke purre')
       }
@@ -24,39 +44,177 @@ export default function PurreKnapp({ ansvarId }: { ansvarId: string }) {
   const label = sendt ? 'Purret' : isPending ? 'Sender…' : 'Purre'
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'flex-end' }}>
-      <button
-        type="button"
-        onClick={handleKlikk}
-        disabled={sendt || isPending}
-        style={{
-          padding: '6px 12px',
-          borderRadius: 999,
-          background: sendt ? 'transparent' : 'var(--accent-soft)',
-          border: `0.5px solid ${sendt ? 'var(--border)' : 'var(--accent)'}`,
-          color: sendt ? 'var(--text-tertiary)' : 'var(--accent)',
-          fontFamily: 'var(--font-mono)',
-          fontSize: 10,
-          fontWeight: 600,
-          letterSpacing: '1.4px',
-          textTransform: 'uppercase',
-          cursor: sendt || isPending ? 'default' : 'pointer',
-          whiteSpace: 'nowrap',
-        }}
-      >
-        {label}
-      </button>
-      {feil && (
-        <span
+    <>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'flex-end' }}>
+        <button
+          type="button"
+          onClick={aapneModal}
+          disabled={sendt || isPending}
           style={{
-            fontFamily: 'var(--font-body)',
+            padding: '6px 12px',
+            borderRadius: 999,
+            background: sendt ? 'transparent' : 'var(--accent-soft)',
+            border: `0.5px solid ${sendt ? 'var(--border)' : 'var(--accent)'}`,
+            color: sendt ? 'var(--text-tertiary)' : 'var(--accent)',
+            fontFamily: 'var(--font-mono)',
             fontSize: 10,
-            color: 'var(--danger)',
+            fontWeight: 600,
+            letterSpacing: '1.4px',
+            textTransform: 'uppercase',
+            cursor: sendt || isPending ? 'default' : 'pointer',
+            whiteSpace: 'nowrap',
           }}
         >
-          {feil}
-        </span>
+          {label}
+        </button>
+        {feil && (
+          <span
+            style={{
+              fontFamily: 'var(--font-body)',
+              fontSize: 10,
+              color: 'var(--danger)',
+            }}
+          >
+            {feil}
+          </span>
+        )}
+      </div>
+
+      {modalAapen && (
+        // Overlay: klikk utenfor kortet lukker modalen
+        <div
+          onClick={lukkModal}
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(0,0,0,0.5)',
+            zIndex: 100,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '0 20px',
+          }}
+        >
+          {/* Stopp klikk-propagasjon slik at klikk på selve kortet ikke lukker */}
+          <div
+            onClick={e => e.stopPropagation()}
+            style={{
+              width: '100%',
+              maxWidth: 360,
+              background: 'var(--bg-elevated)',
+              border: '0.5px solid var(--border)',
+              borderRadius: 16,
+              padding: 20,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 12,
+            }}
+          >
+            <div
+              style={{
+                fontFamily: 'var(--font-display)',
+                fontSize: 20,
+                fontWeight: 500,
+                letterSpacing: '-0.2px',
+                color: 'var(--text-primary)',
+              }}
+            >
+              Purre på {arrangementNavn}
+            </div>
+
+            <p
+              style={{
+                fontFamily: 'var(--font-body)',
+                fontSize: 13,
+                color: 'var(--text-tertiary)',
+                margin: 0,
+                lineHeight: 1.5,
+              }}
+            >
+              Skriv en valgfri hilsen, eller bare send.
+            </p>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <textarea
+                value={melding}
+                onChange={e => setMelding(e.target.value)}
+                maxLength={PURRING_MAKS_LENGDE}
+                placeholder="Valgfritt: en kort hilsen til arrangøren…"
+                rows={3}
+                style={{
+                  fontFamily: 'var(--font-body)',
+                  fontSize: 14,
+                  color: 'var(--text-primary)',
+                  background: 'var(--bg-base)',
+                  border: '0.5px solid var(--border)',
+                  borderRadius: 10,
+                  padding: '10px 12px',
+                  resize: 'none',
+                  outline: 'none',
+                  width: '100%',
+                  boxSizing: 'border-box',
+                  lineHeight: 1.5,
+                }}
+              />
+              {/* Tegnteller: vises alltid slik at brukeren ser grensen */}
+              <span
+                style={{
+                  fontFamily: 'var(--font-body)',
+                  fontSize: 11,
+                  color: 'var(--text-tertiary)',
+                  alignSelf: 'flex-end',
+                }}
+              >
+                {melding.length}/{PURRING_MAKS_LENGDE}
+              </span>
+            </div>
+
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+              <button
+                type="button"
+                onClick={lukkModal}
+                disabled={isPending}
+                style={{
+                  padding: '8px 16px',
+                  borderRadius: 999,
+                  background: 'transparent',
+                  border: '0.5px solid var(--border)',
+                  color: 'var(--text-secondary)',
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 10,
+                  fontWeight: 600,
+                  letterSpacing: '1.4px',
+                  textTransform: 'uppercase',
+                  cursor: 'pointer',
+                }}
+              >
+                Avbryt
+              </button>
+              <button
+                type="button"
+                onClick={handleSend}
+                disabled={isPending}
+                style={{
+                  padding: '8px 16px',
+                  borderRadius: 999,
+                  background: 'var(--accent)',
+                  border: 'none',
+                  color: '#0a0a0a',
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 10,
+                  fontWeight: 600,
+                  letterSpacing: '1.4px',
+                  textTransform: 'uppercase',
+                  cursor: isPending ? 'default' : 'pointer',
+                  opacity: isPending ? 0.7 : 1,
+                }}
+              >
+                {isPending ? 'Sender…' : 'Send purring'}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
-    </div>
+    </>
   )
 }

--- a/app/(app)/arrangoransvar/PurreKnapp.tsx
+++ b/app/(app)/arrangoransvar/PurreKnapp.tsx
@@ -197,6 +197,23 @@ export default function PurreKnapp({
               </span>
             </div>
 
+            {/* Feilmelding inne i modalen — uten denne ble feil rendret kun
+                utenfor og dermed skjult bak overlayen mens modalen sto åpen. */}
+            {feil && (
+              <p
+                role="alert"
+                style={{
+                  fontFamily: 'var(--font-body)',
+                  fontSize: 13,
+                  color: 'var(--danger)',
+                  margin: 0,
+                  lineHeight: 1.5,
+                }}
+              >
+                {feil}
+              </p>
+            )}
+
             <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
               <button
                 type="button"

--- a/app/(app)/arrangoransvar/PurreKnapp.tsx
+++ b/app/(app)/arrangoransvar/PurreKnapp.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useTransition } from 'react'
+import { useEffect, useRef, useState, useTransition } from 'react'
 import { purreAnsvarlig } from '@/lib/actions/arrangoransvar'
 import { PURRING_MAKS_LENGDE } from '@/lib/konstanter'
 
@@ -16,6 +16,9 @@ export default function PurreKnapp({
   const [feil, setFeil] = useState('')
   const [modalAapen, setModalAapen] = useState(false)
   const [melding, setMelding] = useState('')
+  // Synkron guard mot dobbeltklikk: settes før startTransition rekker å
+  // markere isPending. Uten dette kan to rask-klikk gi to server-kall.
+  const sendingRef = useRef(false)
 
   function aapneModal() {
     if (sendt || isPending) return
@@ -25,10 +28,13 @@ export default function PurreKnapp({
   }
 
   function lukkModal() {
+    if (isPending) return
     setModalAapen(false)
   }
 
   function handleSend() {
+    if (sendingRef.current) return
+    sendingRef.current = true
     startTransition(async () => {
       try {
         // Sender hilsen kun hvis den ikke er tom etter trimming
@@ -37,9 +43,27 @@ export default function PurreKnapp({
         setModalAapen(false)
       } catch (err) {
         setFeil(err instanceof Error ? err.message : 'Kunne ikke purre')
+      } finally {
+        sendingRef.current = false
       }
     })
   }
+
+  // Lukk modalen med Escape og lås body-scroll mens den er åpen.
+  // body-overflow forhindrer scroll-chain bak modalen, særlig på iOS.
+  useEffect(() => {
+    if (!modalAapen) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape' && !isPending) setModalAapen(false)
+    }
+    document.addEventListener('keydown', onKey)
+    const forrigeOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.body.style.overflow = forrigeOverflow
+    }
+  }, [modalAapen, isPending])
 
   const label = sendt ? 'Purret' : isPending ? 'Sender…' : 'Purre'
 
@@ -97,6 +121,9 @@ export default function PurreKnapp({
         >
           {/* Stopp klikk-propagasjon slik at klikk på selve kortet ikke lukker */}
           <div
+            role="dialog"
+            aria-modal="true"
+            aria-label={`Purre på ${arrangementNavn}`}
             onClick={e => e.stopPropagation()}
             style={{
               width: '100%',
@@ -141,6 +168,7 @@ export default function PurreKnapp({
                 maxLength={PURRING_MAKS_LENGDE}
                 placeholder="Valgfritt: en kort hilsen til arrangøren…"
                 rows={3}
+                autoFocus
                 style={{
                   fontFamily: 'var(--font-body)',
                   fontSize: 14,

--- a/app/(app)/arrangoransvar/page.tsx
+++ b/app/(app)/arrangoransvar/page.tsx
@@ -258,7 +258,9 @@ export default async function Arrangoransvar() {
                       />
                     )}
                   </div>
-                  {kanPurres && forsteAnsvarId && <PurreKnapp ansvarId={forsteAnsvarId} />}
+                  {kanPurres && forsteAnsvarId && (
+                    <PurreKnapp ansvarId={forsteAnsvarId} arrangementNavn={navn} />
+                  )}
                 </div>
               )
             })}

--- a/lib/actions/arrangoransvar.ts
+++ b/lib/actions/arrangoransvar.ts
@@ -4,6 +4,7 @@ import { createAdminClient } from '@/lib/supabase/admin'
 import { revalidatePath } from 'next/cache'
 import { sendVarsel } from '@/lib/varsler'
 import { ensureAdmin, ensureInnlogget } from '@/lib/auth'
+import { PURRING_MAKS_LENGDE } from '@/lib/konstanter'
 
 // Slå opp purredato fra arrangementmaler og sett riktig år. Mal-raden
 // har år=2000 som sentinel (kun mnd+dag teller), så vi bytter ut til aar.
@@ -154,10 +155,19 @@ export async function fjernAnsvarlig(ansvarId: string) {
 }
 
 // Purre ansvarlig — kalles av et vanlig medlem. Sender varsel via sendVarsel
-// (som respekterer push_aktiv/epost_aktiv). Dedup unngår purre-spam.
-export async function purreAnsvarlig(ansvarId: string) {
+// (som respekterer push_aktiv/epost_aktiv). hilsen er valgfri fritekst fra
+// den som purrer; uten hilsen brukes standardteksten. Se #267.
+export async function purreAnsvarlig(ansvarId: string, hilsen?: string) {
   const { user } = await ensureInnlogget()
   const admin = createAdminClient()
+
+  // Server-side validering av hilsen-lengde (klienten håndhever maks via
+  // maxLength, men vi validerer også her mot manipulasjon).
+  const trimmetHilsen = hilsen?.trim()
+  if (trimmetHilsen && trimmetHilsen.length > PURRING_MAKS_LENGDE) {
+    throw new Error(`Hilsen kan ikke være lengre enn ${PURRING_MAKS_LENGDE} tegn`)
+  }
+
   const { data: ansvar } = await admin
     .from('arrangoransvar')
     .select('id, aar, arrangement_navn, ansvarlig_id, arrangement_id')
@@ -176,10 +186,14 @@ export async function purreAnsvarlig(ansvarId: string) {
 
   const fraNavn = purrer?.visningsnavn || purrer?.navn || 'En gutt'
 
+  const melding = trimmetHilsen
+    ? `${fraNavn} purrer deg på ${ansvar.arrangement_navn} ${ansvar.aar} og skriver: «${trimmetHilsen}»`
+    : `${fraNavn} purrer deg på ${ansvar.arrangement_navn} ${ansvar.aar}. Få arrangementet inn i kalenderen.`
+
   await sendVarsel({
     mottakere: [ansvar.ansvarlig_id],
     tittel: `Purring: ${ansvar.arrangement_navn}`,
-    melding: `${fraNavn} purrer deg på ${ansvar.arrangement_navn} ${ansvar.aar}. Få arrangementet inn i kalenderen.`,
+    melding,
     url: '/arrangoransvar',
     knappTekst: 'Åpne arrangøransvar',
     type: 'purring_ansvar',

--- a/lib/epost.ts
+++ b/lib/epost.ts
@@ -25,6 +25,19 @@ export async function sendEpost({ til, emne, html }: { til: string; emne: string
 // automatisk for brukere med dark mode (Apple Mail, Gmail, Outlook).
 const AKSENT = '#d4a853'
 
+// Escaper brukerinput før den interpoleres i HTML. Sentral i e-postmalene
+// så vi ikke risikerer at en hilsen som «<a href=…>klikk</a>» rendres som
+// HTML i innboksen. Push- og in-app-varsler bruker ren tekst og trenger
+// ikke escaping — derfor gjøres dette her, ikke i sendVarsel.
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
 export function arrangementEpostHtml({
   tittel,
   tekst,
@@ -36,6 +49,13 @@ export function arrangementEpostHtml({
   url: string
   knappTekst: string
 }) {
+  // Tittel, tekst og knappetekst kan inneholde brukerinput (f.eks. hilsen i
+  // purring) — escapes her. URL-en konstrueres alltid av oss fra trygge kilder
+  // (BASE_URL + varsel-id), men vi escaper attribute-konteksten for sikkerhets skyld.
+  const tittelEsc = escapeHtml(tittel)
+  const tekstEsc = escapeHtml(tekst)
+  const urlEsc = escapeHtml(url)
+  const knappTekstEsc = escapeHtml(knappTekst)
   return `
 <!DOCTYPE html>
 <html lang="no">
@@ -49,11 +69,11 @@ export function arrangementEpostHtml({
       <table width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:480px;">
         <tr><td style="padding:32px;">
           <p style="margin:0 0 4px;font-size:12px;letter-spacing:0.1em;text-transform:uppercase;">Mortensrud Herreklubb</p>
-          <h1 style="margin:0 0 16px;font-size:20px;font-weight:700;">${tittel}</h1>
-          <p style="margin:0 0 24px;font-size:15px;line-height:1.6;">${tekst}</p>
+          <h1 style="margin:0 0 16px;font-size:20px;font-weight:700;">${tittelEsc}</h1>
+          <p style="margin:0 0 24px;font-size:15px;line-height:1.6;white-space:pre-wrap;">${tekstEsc}</p>
           <table cellpadding="0" cellspacing="0" border="0" role="presentation" style="border-collapse:separate;">
             <tr><td bgcolor="${AKSENT}" style="background:${AKSENT};border-radius:8px;">
-              <a href="${url}" style="display:inline-block;padding:12px 24px;color:#0a0a0a;text-decoration:none;font-weight:600;font-size:14px;">${knappTekst}</a>
+              <a href="${urlEsc}" style="display:inline-block;padding:12px 24px;color:#0a0a0a;text-decoration:none;font-weight:600;font-size:14px;">${knappTekstEsc}</a>
             </td></tr>
           </table>
         </td></tr>
@@ -77,6 +97,12 @@ export function velkommenEpostHtml({
 }) {
   const deler = navn.trim().split(/\s+/)
   const etternavn = deler.length > 1 ? deler[deler.length - 1] : deler[0]
+  // Navn settes av admin og er lavrisiko, men vi escaper konsekvent slik at
+  // en bokstavelig «<» i navnet ikke ender opp som markup.
+  const etternavnEsc = escapeHtml(etternavn)
+  const epostEsc = escapeHtml(epost)
+  const passordEsc = escapeHtml(passord)
+  const loggInnUrlEsc = escapeHtml(loggInnUrl)
   return `
 <!DOCTYPE html>
 <html lang="no">
@@ -90,21 +116,21 @@ export function velkommenEpostHtml({
       <table width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:480px;">
         <tr><td style="padding:32px;">
           <p style="margin:0 0 4px;font-size:12px;letter-spacing:0.1em;text-transform:uppercase;">Mortensrud Herreklubb</p>
-          <h1 style="margin:0 0 16px;font-size:22px;font-weight:700;">Velkommen herr ${etternavn}!</h1>
+          <h1 style="margin:0 0 16px;font-size:22px;font-weight:700;">Velkommen herr ${etternavnEsc}!</h1>
           <p style="margin:0 0 24px;font-size:15px;line-height:1.6;">Du er lagt til som medlem i Mortensrud Herreklubb. Under finner du innloggingsinfoen din.</p>
           <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px;">
             <tr><td style="padding:6px 0;">
               <p style="margin:0 0 2px;font-size:11px;letter-spacing:0.08em;text-transform:uppercase;opacity:0.7;">Brukernavn</p>
-              <p style="margin:0;font-size:14px;font-family:Menlo,Consolas,monospace;word-break:break-all;">${epost}</p>
+              <p style="margin:0;font-size:14px;font-family:Menlo,Consolas,monospace;word-break:break-all;">${epostEsc}</p>
             </td></tr>
             <tr><td style="padding:6px 0;">
               <p style="margin:0 0 2px;font-size:11px;letter-spacing:0.08em;text-transform:uppercase;opacity:0.7;">Midlertidig passord</p>
-              <p style="margin:0;font-size:14px;font-family:Menlo,Consolas,monospace;font-weight:700;">${passord}</p>
+              <p style="margin:0;font-size:14px;font-family:Menlo,Consolas,monospace;font-weight:700;">${passordEsc}</p>
             </td></tr>
           </table>
           <table cellpadding="0" cellspacing="0" border="0" role="presentation" style="border-collapse:separate;">
             <tr><td bgcolor="${AKSENT}" style="background:${AKSENT};border-radius:8px;">
-              <a href="${loggInnUrl}" style="display:inline-block;padding:12px 24px;color:#0a0a0a;text-decoration:none;font-weight:600;font-size:14px;">Logg inn</a>
+              <a href="${loggInnUrlEsc}" style="display:inline-block;padding:12px 24px;color:#0a0a0a;text-decoration:none;font-weight:600;font-size:14px;">Logg inn</a>
             </td></tr>
           </table>
           <p style="margin:24px 0 0;font-size:13px;line-height:1.6;opacity:0.7;">Når du er logget inn kan du sette ditt eget passord under <strong>Profil</strong>. Installer gjerne appen på mobilen via «Legg til på Hjem-skjerm».</p>

--- a/lib/konstanter.ts
+++ b/lib/konstanter.ts
@@ -46,6 +46,7 @@ export const MELDING_MAKS_BILDER = 10
 export const CHAT_NAER_BUNN_TERSKEL_PX = 150
 
 // Maks tegn i valgfri hilsen ved purring av arrangøransvarlig.
-// Speiler CHAT_MAKS_LENGDE men er definert separat fordi hilsenen ikke
-// lagres i DB — den går rett inn i sendVarsel-meldingen. Se #267.
+// Tilfeldigvis samme verdi som CHAT_MAKS_LENGDE, men definert separat
+// fordi hilsenen ikke lagres i DB — den går rett inn i sendVarsel-
+// meldingen. De to grensene kan utvikle seg uavhengig. Se #267.
 export const PURRING_MAKS_LENGDE = 500

--- a/lib/konstanter.ts
+++ b/lib/konstanter.ts
@@ -44,3 +44,8 @@ export const MELDING_MAKS_BILDER = 10
 // bunn» i chatten. Under terskelen auto-scroller vi når andres melding
 // kommer inn; over terskelen lar vi ham være i fred. Se #238.
 export const CHAT_NAER_BUNN_TERSKEL_PX = 150
+
+// Maks tegn i valgfri hilsen ved purring av arrangøransvarlig.
+// Speiler CHAT_MAKS_LENGDE men er definert separat fordi hilsenen ikke
+// lagres i DB — den går rett inn i sendVarsel-meldingen. Se #267.
+export const PURRING_MAKS_LENGDE = 500

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 62,
-  "versjon": "V3.1.62"
+  "nummer": 63,
+  "versjon": "V3.1.63"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 61,
-  "versjon": "V3.1.61"
+  "nummer": 62,
+  "versjon": "V3.1.62"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 63,
-  "versjon": "V3.1.63"
+  "nummer": 64,
+  "versjon": "V3.1.64"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.61'
+const CACHE_VERSION = 'V3.1.62'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.63'
+const CACHE_VERSION = 'V3.1.64'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.62'
+const CACHE_VERSION = 'V3.1.63'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
## Sammendrag
- Purre-knappen på `/arrangoransvar` åpner nå en modal med en valgfri hilsen-tekst i stedet for å sende rett.
- Tom melding = uendret purreoppførsel. Tekst = blir med i varselet til arrangøren som «… og skriver: «hilsen»».
- Ny konstant `PURRING_MAKS_LENGDE = 500` med server-side validering.

## Beslutninger underveis
- **Modal vs inline:** valgte modal for tydeligere bevisst send/avbryt.
- **Tegnegrense 500:** speiler chat-grensen, men er separat fordi teksten ikke lagres i DB.
- **Reviewer-funn:** Escape-tast, dobbeltklikk-guard (synkron ref før transition), autofokus, body-scroll-lås, a11y-attributter — alle rettet. Hardkodet `#0a0a0a` beholdt fordi det matcher etablert mønster i resten av kodebasen (egen refactor-sak hvis det skal endres).

Lukker #267.

## Test plan
- [ ] Trykk Purre på et arrangøransvar — modal åpner
- [ ] Send uten tekst — varsel kommer med opprinnelig formulering
- [ ] Send med hilsen — varsel inkluderer hilsenen
- [ ] Escape lukker modal
- [ ] Bakgrunns-scroll låst mens modal er åpen

🤖 Generated with [Claude Code](https://claude.com/claude-code)