### PR TITLE
Purring varsler alle medansvarlige (#268)

### DIFF
--- a/lib/actions/arrangoransvar.ts
+++ b/lib/actions/arrangoransvar.ts
@@ -175,8 +175,20 @@ export async function purreAnsvarlig(ansvarId: string, hilsen?: string) {
     .maybeSingle()
 
   if (!ansvar) throw new Error('Fant ikke ansvar')
-  if (!ansvar.ansvarlig_id) throw new Error('Ingen ansvarlig å purre på')
   if (ansvar.arrangement_id) throw new Error('Arrangementet er allerede lagt inn')
+
+  // Hent ALLE søsken-rader med samme (aar, arrangement_navn) som har en
+  // ansvarlig_id — purring på arrangement-nivå treffer alle medansvarlige,
+  // ikke bare den raden man klikket på. Se #268 og Policy: Arrangøransvar-kobling.
+  const { data: soeskenRader } = await admin
+    .from('arrangoransvar')
+    .select('ansvarlig_id')
+    .eq('aar', ansvar.aar)
+    .eq('arrangement_navn', ansvar.arrangement_navn)
+    .not('ansvarlig_id', 'is', null)
+
+  const mottakere = (soeskenRader ?? []).map(r => r.ansvarlig_id as string)
+  if (mottakere.length === 0) throw new Error('Ingen ansvarlig å purre på')
 
   const { data: purrer } = await admin
     .from('profiles')
@@ -191,7 +203,7 @@ export async function purreAnsvarlig(ansvarId: string, hilsen?: string) {
     : `${fraNavn} purrer deg på ${ansvar.arrangement_navn} ${ansvar.aar}. Få arrangementet inn i kalenderen.`
 
   await sendVarsel({
-    mottakere: [ansvar.ansvarlig_id],
+    mottakere,
     tittel: `Purring: ${ansvar.arrangement_navn}`,
     melding,
     url: '/arrangoransvar',

--- a/lib/actions/arrangoransvar.ts
+++ b/lib/actions/arrangoransvar.ts
@@ -183,7 +183,7 @@ export async function purreAnsvarlig(ansvarId: string, hilsen?: string) {
   // arrangement_id is null: purring gir bare mening når arrangementet ikke
   // er opprettet. Eksplisitt filter beskytter også mot race med koble() som
   // kan fylle arrangement_id mellom guard-sjekken over og denne spørringen.
-  const { data: soeskenRader } = await admin
+  const { data: soeskenRader, error: soeskenFeil } = await admin
     .from('arrangoransvar')
     .select('ansvarlig_id')
     .eq('aar', ansvar.aar)
@@ -191,9 +191,21 @@ export async function purreAnsvarlig(ansvarId: string, hilsen?: string) {
     .is('arrangement_id', null)
     .not('ansvarlig_id', 'is', null)
 
+  // Skill DB-feil fra tom mottakerliste — ellers ville en spørringsfeil
+  // bli feiltolket som «ingen ansvarlig å purre på» og villede brukeren.
+  if (soeskenFeil) throw new Error(`Kunne ikke hente medansvarlige: ${soeskenFeil.message}`)
+
   // Defensiv dedup: sendVarsel dedup'er også internt, men vi gjør det
   // eksplisitt her slik at koden er selvforklarende på kall-stedet.
-  const mottakere = [...new Set((soeskenRader ?? []).map(r => r.ansvarlig_id as string))]
+  // Typesikkert filter på null framfor `as string` — ansvarlig_id er nullable
+  // i skjemaet selv om .not('is', null) i praksis luker dem ut.
+  const mottakere = [
+    ...new Set(
+      (soeskenRader ?? [])
+        .map(r => r.ansvarlig_id)
+        .filter((id): id is string => !!id)
+    ),
+  ]
   if (mottakere.length === 0) throw new Error('Ingen ansvarlig å purre på')
 
   const { data: purrer } = await admin

--- a/lib/actions/arrangoransvar.ts
+++ b/lib/actions/arrangoransvar.ts
@@ -180,14 +180,20 @@ export async function purreAnsvarlig(ansvarId: string, hilsen?: string) {
   // Hent ALLE søsken-rader med samme (aar, arrangement_navn) som har en
   // ansvarlig_id — purring på arrangement-nivå treffer alle medansvarlige,
   // ikke bare den raden man klikket på. Se #268 og Policy: Arrangøransvar-kobling.
+  // arrangement_id is null: purring gir bare mening når arrangementet ikke
+  // er opprettet. Eksplisitt filter beskytter også mot race med koble() som
+  // kan fylle arrangement_id mellom guard-sjekken over og denne spørringen.
   const { data: soeskenRader } = await admin
     .from('arrangoransvar')
     .select('ansvarlig_id')
     .eq('aar', ansvar.aar)
     .eq('arrangement_navn', ansvar.arrangement_navn)
+    .is('arrangement_id', null)
     .not('ansvarlig_id', 'is', null)
 
-  const mottakere = (soeskenRader ?? []).map(r => r.ansvarlig_id as string)
+  // Defensiv dedup: sendVarsel dedup'er også internt, men vi gjør det
+  // eksplisitt her slik at koden er selvforklarende på kall-stedet.
+  const mottakere = [...new Set((soeskenRader ?? []).map(r => r.ansvarlig_id as string))]
   if (mottakere.length === 0) throw new Error('Ingen ansvarlig å purre på')
 
   const { data: purrer } = await admin

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 64,
-  "versjon": "V3.1.64"
+  "nummer": 65,
+  "versjon": "V3.1.65"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 66,
-  "versjon": "V3.1.66"
+  "nummer": 67,
+  "versjon": "V3.1.67"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 65,
-  "versjon": "V3.1.65"
+  "nummer": 66,
+  "versjon": "V3.1.66"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.65'
+const CACHE_VERSION = 'V3.1.66'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.66'
+const CACHE_VERSION = 'V3.1.67'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.64'
+const CACHE_VERSION = 'V3.1.65'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
## Sammendrag
- `purreAnsvarlig` slo bare opp én rad og varslet kun den ene `ansvarlig_id`-en. Når flere personer var ansvarlige for samme arrangement (delte `aar` + `arrangement_navn`), gikk varselet kun til første rad.
- Henter nå alle søsken-rader med samme `(aar, arrangement_navn)` og `arrangement_id is null`, deduplikerer mottakerlisten og sender ett samlet `sendVarsel`-kall.

## Beslutninger underveis
- Defensiv `[...new Set(...)]` på mottakerlisten selv om `sendVarsel` deduper internt — gjør koden selvforklarende.
- Eksplisitt `.is('arrangement_id', null)`-filter på søsken-spørringen som race-beskyttelse mot `koble()`.
- Autorisasjons-modell uendret: alle innloggede medlemmer kan purre, UI skjuler knappen fra de som selv er medansvarlige.
- Følger Policy: Arrangøransvar-kobling — operasjoner på arrangement-nivå treffer alle søsken-rader.

Lukker #268.

## Test plan
- [ ] Trykk Purre på et arrangement med flere ansvarlige — alle får varsel
- [ ] Trykk Purre på arrangement med én ansvarlig — fungerer som før
- [ ] Tom mottakerliste gir riktig feilmelding

🤖 Generated with [Claude Code](https://claude.com/claude-code)