### PR TITLE
«Ikke svart»-seksjon på agendaen med inline RSVP (#271)

### DIFF
--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -14,6 +14,7 @@ import InnspillKnapp from '@/components/agenda/InnspillKnapp'
 import PollKort from '@/components/agenda/PollKort'
 import MeldingKort from '@/components/agenda/MeldingKort'
 import NyFAB from '@/components/agenda/NyFAB'
+import RsvpInline from '@/components/agenda/RsvpInline'
 import type { KommentarKortData } from '@/components/agenda/KommentarerPaaKort'
 import {
   byggAgenda,
@@ -413,7 +414,7 @@ export default async function Forside() {
     bilde_url: a.bilde_url ?? coverPerArrangement.get(a.id) ?? null,
   }))
 
-  const { meldinger, idag, kommende, tidligere } = byggAgenda({
+  const { ubesvarte, meldinger, idag, kommende, tidligere } = byggAgenda({
     arrangementer: arrangementerBerikt,
     ansvar: (ansvar ?? []) as unknown as UtkastRaad[],
     profilerMedBursdag: (profilerMedBursdag ?? []) as ProfilMedBursdag[],
@@ -478,6 +479,48 @@ export default async function Forside() {
       </header>
 
       <PushPaaminnelse />
+
+      {/* Ubesvarte fremtidige arrangementer — vises øverst som påminnelse (#271).
+          Hvert kort er en vanlig <Link> med en RsvpInline-rad rett under.
+          RsvpInline ligger *utenfor* <Link> for å unngå nested-button-i-link-feil.
+          Arrangementet forsvinner herfra (og dukker opp i Kommende/I kveld) så
+          snart revalidatePath('/') kjøres etter at svaret er lagret. */}
+      {ubesvarte.length > 0 && (
+        <section style={{ marginBottom: 28 }}>
+          <SectionLabel>Ikke svart ennå</SectionLabel>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            {ubesvarte.map(i => {
+              if (i.kind !== 'arrangement') return null
+              return (
+                // Wrapper med overflow:hidden klipper bort bunnavrunding på kortet
+                // og lar RsvpInline fylle ut bunnen — de to elementene ser da ut
+                // som ett sammenhengende kort (#271).
+                <div
+                  key={i.data.id}
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    borderRadius: 'var(--radius-card)',
+                    overflow: 'hidden',
+                  }}
+                >
+                  <ArrangementKort
+                    arr={i.data}
+                    kommentarer={kommentarerPerArr.get(i.data.id) ?? []}
+                    totaltKommentarer={totaltPerArr.get(i.data.id) ?? 0}
+                    profiler={chatProfiler}
+                    brukerId={user!.id}
+                  />
+                  {/* RsvpInline sitter utenfor <Link> i ArrangementKort slik at
+                      knapp-klikk ikke trigger navigasjon. Wrapperens overflow:hidden
+                      sørger for at bunnavrundingen kuttes riktig. */}
+                  <RsvpInline arrangementId={i.data.id} />
+                </div>
+              )
+            })}
+          </div>
+        </section>
+      )}
 
       {/* Levende meldinger — fjerde element-type, øverst på agenda */}
       {meldinger.length > 0 && (

--- a/components/agenda/RsvpInline.tsx
+++ b/components/agenda/RsvpInline.tsx
@@ -9,6 +9,7 @@
 import { useState, useTransition } from 'react'
 import { oppdaterPaamelding } from '@/lib/actions/paameldinger'
 import RsvpGlyph from '@/components/arrangement/RsvpGlyph'
+import Toast from '@/components/ui/Toast'
 
 type Status = 'ja' | 'kanskje' | 'nei'
 
@@ -24,8 +25,9 @@ const knapper: Array<{
 
 export default function RsvpInline({ arrangementId }: { arrangementId: string }) {
   // Optimistic state: sett lokalt med én gang, server-kall i bakgrunnen.
-  // Ved feil rulleres tilbake til null (visningen er da uendret).
+  // Ved feil rulleres tilbake til forrige verdi og vi viser toast.
   const [valgt, setValgt] = useState<Status | null>(null)
+  const [feilMelding, setFeilMelding] = useState<string | null>(null)
   const [isPending, startTransition] = useTransition()
 
   function velg(status: Status) {
@@ -38,11 +40,14 @@ export default function RsvpInline({ arrangementId }: { arrangementId: string })
         // forsvinner fra ubesvart-seksjonen etter at serveren svarer.
       } catch {
         setValgt(forrige) // rull tilbake ved feil
+        setFeilMelding('Fikk ikke lagra — prøv igjen')
       }
     })
   }
 
   return (
+    <>
+    <Toast melding={feilMelding} onSkjul={() => setFeilMelding(null)} />
     <div
       style={{
         display: 'flex',
@@ -66,14 +71,15 @@ export default function RsvpInline({ arrangementId }: { arrangementId: string })
             key={k.id}
             disabled={isPending}
             onClick={e => {
-              // Stopp klikket fra å nå <Link>-wrapper-en rundt kortet (#271).
-              // preventDefault+stopPropagation er nødvendig fordi React
-              // bubbler syntetiske hendelser opp til Next.js sin Link-handler.
+              // defensiv: hvis noen senere wrapper RsvpInline inni <Link>,
+              // unngår vi utilsiktet navigasjon.
               e.preventDefault()
               e.stopPropagation()
               velg(k.id)
             }}
             aria-label={k.label}
+            aria-pressed={erValgt}
+            aria-busy={isPending}
             style={{
               flex: 1,
               display: 'flex',
@@ -120,5 +126,6 @@ export default function RsvpInline({ arrangementId }: { arrangementId: string })
         )
       })}
     </div>
+    </>
   )
 }

--- a/components/agenda/RsvpInline.tsx
+++ b/components/agenda/RsvpInline.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+// Inline RSVP-knapper for ubesvart-seksjonen på agendaen (#271).
+// Kompakt tre-knapper-rad: Ja / Kanskje / Nei.
+// Komponenten sitter *utenfor* <Link>-wrapperen i page.tsx, så klikk
+// på knappene navigerer ikke til arrangementet (se kommentar under).
+// useTransition gir optimistic pending-state uten ekstra setState.
+
+import { useState, useTransition } from 'react'
+import { oppdaterPaamelding } from '@/lib/actions/paameldinger'
+import RsvpGlyph from '@/components/arrangement/RsvpGlyph'
+
+type Status = 'ja' | 'kanskje' | 'nei'
+
+const knapper: Array<{
+  id: Status
+  label: string
+  ikon: 'check' | 'question' | 'x'
+}> = [
+  { id: 'ja', label: 'Ja', ikon: 'check' },
+  { id: 'kanskje', label: 'Kanskje', ikon: 'question' },
+  { id: 'nei', label: 'Nei', ikon: 'x' },
+]
+
+export default function RsvpInline({ arrangementId }: { arrangementId: string }) {
+  // Optimistic state: sett lokalt med én gang, server-kall i bakgrunnen.
+  // Ved feil rulleres tilbake til null (visningen er da uendret).
+  const [valgt, setValgt] = useState<Status | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  function velg(status: Status) {
+    const forrige = valgt
+    setValgt(status) // optimistisk
+    startTransition(async () => {
+      try {
+        await oppdaterPaamelding(arrangementId, status)
+        // revalidatePath('/') i server action sørger for at arrangementet
+        // forsvinner fra ubesvart-seksjonen etter at serveren svarer.
+      } catch {
+        setValgt(forrige) // rull tilbake ved feil
+      }
+    })
+  }
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        gap: 8,
+        padding: '10px 12px 12px',
+        // Henger visuelt sammen med ArrangementKort over: samme bakgrunn,
+        // border på sidene og bunn, flat topp (kortet har border-bottom allerede).
+        background: 'var(--bg-elevated)',
+        border: '1px solid var(--border)',
+        borderTop: 'none',
+        borderRadius: '0 0 var(--radius-card) var(--radius-card)',
+        // Kompenser for at kortet allerede bruker overflow:hidden — vi er et
+        // separat DOM-element, så vi trenger ikke ekstra margin-top-justering.
+      }}
+    >
+      {knapper.map(k => {
+        const erValgt = valgt === k.id
+        const erJa = k.id === 'ja'
+        return (
+          <button
+            key={k.id}
+            disabled={isPending}
+            onClick={e => {
+              // Stopp klikket fra å nå <Link>-wrapper-en rundt kortet (#271).
+              // preventDefault+stopPropagation er nødvendig fordi React
+              // bubbler syntetiske hendelser opp til Next.js sin Link-handler.
+              e.preventDefault()
+              e.stopPropagation()
+              velg(k.id)
+            }}
+            aria-label={k.label}
+            style={{
+              flex: 1,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 6,
+              // Minste touch-mål 44px (Apple HIG)
+              minHeight: 44,
+              borderRadius: 10,
+              border: erValgt
+                ? erJa
+                  ? 'none'
+                  : '0.5px solid var(--border-strong)'
+                : '0.5px solid var(--border)',
+              background: erValgt
+                ? erJa
+                  ? 'var(--accent)'
+                  : 'var(--bg-elevated)'
+                : 'transparent',
+              color: erValgt && erJa ? '#0a0a0a' : 'var(--text-primary)',
+              fontFamily: 'var(--font-body)',
+              fontSize: 13,
+              fontWeight: 600,
+              cursor: isPending ? 'wait' : 'pointer',
+              opacity: isPending ? 0.6 : 1,
+              transition: 'background 0.12s, border 0.12s, opacity 0.12s',
+            }}
+          >
+            <RsvpGlyph
+              name={k.ikon}
+              size={13}
+              color={
+                erValgt && erJa
+                  ? '#0a0a0a'
+                  : k.id === 'ja'
+                  ? 'var(--accent)'
+                  : k.id === 'kanskje'
+                  ? 'var(--text-secondary)'
+                  : 'var(--text-tertiary)'
+              }
+            />
+            {k.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -5,7 +5,7 @@
 // Bevisst enkel — vi har ikke behov for kø, varianter eller global state ennå.
 // Hvis vi senere trenger toast flere steder, vurder Context-provider i (app)/layout.
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 
 export default function Toast({
@@ -22,18 +22,26 @@ export default function Toast({
   // createPortal krever document — bare tilgjengelig etter mount på klient.
   useEffect(() => setMounted(true), [])
 
+  // Hold onSkjul i ref slik at timeouten ikke nullstilles hver gang parent
+  // re-rendrer med en ny inline-callback (vanlig mønster i RsvpInline m.fl.).
+  // Uten dette resettes setTimeout på hver render og toasten forsvinner aldri.
+  const onSkjulRef = useRef(onSkjul)
+  useEffect(() => {
+    onSkjulRef.current = onSkjul
+  }, [onSkjul])
+
   useEffect(() => {
     if (!melding) return
-    const t = setTimeout(onSkjul, varighet)
+    const t = setTimeout(() => onSkjulRef.current(), varighet)
     return () => clearTimeout(t)
-  }, [melding, varighet, onSkjul])
+  }, [melding, varighet])
 
   if (!mounted || !melding) return null
 
   return createPortal(
     <div
-      role="status"
-      aria-live="polite"
+      role="alert"
+      aria-live="assertive"
       style={{
         position: 'fixed',
         left: '50%',

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+// Minimal toast: én melding av gangen, auto-fjerner seg etter `varighet` ms.
+// Portal til document.body slik at sticky-headere / fixed-elementer ikke skjuler den.
+// Bevisst enkel — vi har ikke behov for kø, varianter eller global state ennå.
+// Hvis vi senere trenger toast flere steder, vurder Context-provider i (app)/layout.
+
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+export default function Toast({
+  melding,
+  varighet = 3000,
+  onSkjul,
+}: {
+  melding: string | null
+  varighet?: number
+  onSkjul: () => void
+}) {
+  const [mounted, setMounted] = useState(false)
+
+  // createPortal krever document — bare tilgjengelig etter mount på klient.
+  useEffect(() => setMounted(true), [])
+
+  useEffect(() => {
+    if (!melding) return
+    const t = setTimeout(onSkjul, varighet)
+    return () => clearTimeout(t)
+  }, [melding, varighet, onSkjul])
+
+  if (!mounted || !melding) return null
+
+  return createPortal(
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        position: 'fixed',
+        left: '50%',
+        bottom: 24,
+        transform: 'translateX(-50%)',
+        // Over sticky-header (~50) og modaler (vi har ingen z=2000+ i dag)
+        zIndex: 9999,
+        background: 'var(--accent-soft)',
+        border: '1px solid var(--accent)',
+        color: 'var(--text-primary)',
+        padding: '10px 16px',
+        borderRadius: 10,
+        fontFamily: 'var(--font-body)',
+        fontSize: 14,
+        fontWeight: 500,
+        boxShadow: '0 4px 16px rgba(0,0,0,0.18)',
+        maxWidth: 'calc(100vw - 32px)',
+        textAlign: 'center',
+      }}
+    >
+      {melding}
+    </div>,
+    document.body,
+  )
+}

--- a/lib/actions/arrangementer.ts
+++ b/lib/actions/arrangementer.ts
@@ -80,6 +80,18 @@ export async function opprettArrangement(data: ArrangementInput) {
 
   if (error) throw new Error(error.message)
 
+  // Oppretteren har implisitt sagt Ja — sett påmelding automatisk så
+  // arrangementet ikke dukker opp i hans egen «Ikke svart»-seksjon (#271).
+  // Best-effort: hvis det feiler stopper vi ikke opprettelsen.
+  await supabase
+    .from('paameldinger')
+    .insert({
+      arrangement_id: arrangement.id,
+      profil_id: user.id,
+      status: 'ja',
+      oppdatert: naa(),
+    })
+
   await koble(supabase, arrangement.id, data.mal_navn, data.aar)
 
   revalidatePath('/')

--- a/lib/actions/arrangementer.ts
+++ b/lib/actions/arrangementer.ts
@@ -82,15 +82,23 @@ export async function opprettArrangement(data: ArrangementInput) {
 
   // Oppretteren har implisitt sagt Ja — sett påmelding automatisk så
   // arrangementet ikke dukker opp i hans egen «Ikke svart»-seksjon (#271).
-  // Best-effort: hvis det feiler stopper vi ikke opprettelsen.
-  await supabase
+  // Upsert er idempotent og takler PK-konflikt (arrangement_id, profil_id) rent.
+  // Best-effort: vi logger feil men kaster ikke — opprettelsen skal gå gjennom
+  // selv om auto-RSVP glipper. Tidligere swallowing skjulte ekte RLS-glipp.
+  const { error: rsvpError } = await supabase
     .from('paameldinger')
-    .insert({
-      arrangement_id: arrangement.id,
-      profil_id: user.id,
-      status: 'ja',
-      oppdatert: naa(),
-    })
+    .upsert(
+      {
+        arrangement_id: arrangement.id,
+        profil_id: user.id,
+        status: 'ja',
+        oppdatert: naa(),
+      },
+      { onConflict: 'arrangement_id,profil_id' },
+    )
+  if (rsvpError) {
+    console.error('[opprettArrangement] auto-RSVP feilet:', rsvpError)
+  }
 
   await koble(supabase, arrangement.id, data.mal_navn, data.aar)
 

--- a/lib/agenda-sortering.ts
+++ b/lib/agenda-sortering.ts
@@ -470,8 +470,9 @@ export function byggAgenda(input: {
   // (ikke som highlight) — brukeren skal svare, ikke «glede seg» til kvelden.
   const ubesvarte: AgendaItem[] = arrangementer
     .filter(a => {
-      // Bare fremtidige (eller dagens) arrangementer er relevante
-      if (a.start_tidspunkt < nowIso && !erSammeNorskeDag(a.start_tidspunkt, naa)) return false
+      // Kun arrangementer som ennå ikke har startet — etter start_tidspunkt
+      // er det for sent å si Ja, så da forsvinner det fra «Ikke svart».
+      if (a.start_tidspunkt < nowIso) return false
       // Ubesvart = ingen rad i paameldinger for meg, eller status er null
       const min = a.paameldinger.find(p => p.profil_id === meg)
       return !min || !min.status

--- a/lib/agenda-sortering.ts
+++ b/lib/agenda-sortering.ts
@@ -167,6 +167,10 @@ export type TidligereItem =
   | { kind: 'melding'; sortIso: string; data: MeldingKortData }
 
 export type Agenda = {
+  // Ubesvarte fremtidige arrangementer — øverst, over «I kveld» (#271).
+  // Et arrangement er ubesvart når innlogget bruker ikke har status i paameldinger.
+  // Disse ekskluderes fra idag/kommende for å unngå duplikat.
+  ubesvarte: AgendaItem[]
   // Levende meldinger — øverst på agenda, sortert etter sist_aktivitet
   meldinger: AgendaItem[]
   idag: AgendaItem[]
@@ -458,8 +462,35 @@ export function byggAgenda(input: {
   // Samlet kandidat-liste for «I kveld» + «Kommende». Arrangementer tas kun
   // med hvis de enten er i fremtiden eller samme norske dag (dekker kveld
   // som begynner før midnatt UTC men går over i neste UTC-dag).
+  //
+  // Ubesvarte fremtidige arrangementer (#271): arrangement der innlogget bruker
+  // (meg) ikke har noen rad i paameldinger. Disse plasseres i en egen seksjon
+  // øverst og ekskluderes fra idag/kommende for å unngå duplikat.
+  // «I kveld»-arrangementer som er ubesvart, vises likevel i ubesvart-seksjonen
+  // (ikke som highlight) — brukeren skal svare, ikke «glede seg» til kvelden.
+  const ubesvarte: AgendaItem[] = arrangementer
+    .filter(a => {
+      // Bare fremtidige (eller dagens) arrangementer er relevante
+      if (a.start_tidspunkt < nowIso && !erSammeNorskeDag(a.start_tidspunkt, naa)) return false
+      // Ubesvart = ingen rad i paameldinger for meg, eller status er null
+      const min = a.paameldinger.find(p => p.profil_id === meg)
+      return !min || !min.status
+    })
+    .sort((a, b) => a.start_tidspunkt.localeCompare(b.start_tidspunkt))
+    .map(a => ({
+      kind: 'arrangement' as const,
+      sortIso: a.start_tidspunkt,
+      data: tilKort(a, meg),
+    }))
+
+  // Sett med id-er som allerede er i ubesvart — ekskluderes fra idag/kommende
+  const ubesvarteIds = new Set(ubesvarte.map(i => i.data.id))
+
   const arrItems: AgendaItem[] = arrangementer
-    .filter(a => a.start_tidspunkt >= nowIso || erSammeNorskeDag(a.start_tidspunkt, naa))
+    .filter(a => {
+      if (ubesvarteIds.has(a.id)) return false // allerede i ubesvart
+      return a.start_tidspunkt >= nowIso || erSammeNorskeDag(a.start_tidspunkt, naa)
+    })
     .map(a => {
       const erIdag = erSammeNorskeDag(a.start_tidspunkt, naa)
       // I kveld → highlight-variant, ellers kompakt kort
@@ -533,5 +564,5 @@ export function byggAgenda(input: {
       return a.sortIso.localeCompare(b.sortIso)
     })
 
-  return { meldinger, idag, kommende, tidligere }
+  return { ubesvarte, meldinger, idag, kommende, tidligere }
 }

--- a/lib/agenda-sortering.ts
+++ b/lib/agenda-sortering.ts
@@ -473,9 +473,11 @@ export function byggAgenda(input: {
       // Kun arrangementer som ennå ikke har startet — etter start_tidspunkt
       // er det for sent å si Ja, så da forsvinner det fra «Ikke svart».
       if (a.start_tidspunkt < nowIso) return false
-      // Ubesvart = ingen rad i paameldinger for meg, eller status er null
+      // Ubesvart = ingen rad i paameldinger for meg. DB-kolonnen status er
+      // NOT NULL, så !min.status ville maskert evt. ugyldige rader heller enn
+      // å rapportere dem — vi sjekker kun rad-eksistens her.
       const min = a.paameldinger.find(p => p.profil_id === meg)
-      return !min || !min.status
+      return !min
     })
     .sort((a, b) => a.start_tidspunkt.localeCompare(b.start_tidspunkt))
     .map(a => ({

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 68,
-  "versjon": "V3.1.68"
+  "nummer": 69,
+  "versjon": "V3.1.69"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 69,
-  "versjon": "V3.1.69"
+  "nummer": 70,
+  "versjon": "V3.1.70"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 67,
-  "versjon": "V3.1.67"
+  "nummer": 68,
+  "versjon": "V3.1.68"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.67'
+const CACHE_VERSION = 'V3.1.68'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.68'
+const CACHE_VERSION = 'V3.1.69'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.69'
+const CACHE_VERSION = 'V3.1.70'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
## Sammendrag
- Ny «Ikke svart ennå»-seksjon øverst i agendaen lister fremtidige arrangement der innlogget bruker ikke har svart Ja/Kanskje/Nei.
- Hvert kort i seksjonen har inline RSVP-knapper. Når man svarer, forsvinner kortet og dukker opp i normal seksjon med eksisterende utseende.
- Et ubesvart arrangement vises kun ett sted (ekskludert fra `idag`/`kommende`-partisjonene).
- Oppretter av et arrangement settes automatisk til `ja` så hans egne arrangement ikke havner i hans ubesvart-seksjon.

## Beslutninger underveis
- **Avgrensning «fremtidige»:** filteret er `start_tidspunkt >= nowIso` — arrangementer forsvinner ved starttid (du kan ikke si Ja på en tur som allerede har begynt).
- **Toast-infrastruktur:** ny `components/ui/Toast.tsx` portal-rendret til `document.body`, brukt lokalt fra `RsvpInline` ved feil. Ingen global Context-provider — premature for ett bruksområde.
- **RsvpInline plassert utenfor kort-Link-en:** unngår `<button>` nestet i `<a>` (ugyldig HTML).
- **`useTransition` + lokal state** for optimistic update; ekte `useOptimistic` ble vurdert men dropper fordi kortet uansett forsvinner ved revalidatePath.

Lukker #271.

## Test plan
- [ ] Logg inn, sjekk at fremtidige arrangement du ikke har svart på ligger øverst med Ja/Kanskje/Nei-knapper
- [ ] Svar Ja på et kort — kortet forsvinner fra «Ikke svart»-seksjonen og dukker opp i Kommende/I kveld med normal styling
- [ ] Opprett et nytt arrangement — det skal IKKE dukke opp i din egen «Ikke svart»-seksjon
- [ ] Verifiser at arrangement som har startet ikke ligger igjen i seksjonen

🤖 Generated with [Claude Code](https://claude.com/claude-code)