### PR TITLE
Modal med navneliste over påmeldte (#272)

### DIFF
--- a/app/(app)/arrangementer/[id]/page.tsx
+++ b/app/(app)/arrangementer/[id]/page.tsx
@@ -521,15 +521,17 @@ export default async function ArrangementDetaljer({
               <span style={{ color: 'var(--text-secondary)' }}>{jaListe.length}</span>
               <span style={{ flex: 1, height: '0.5px', background: 'var(--border-subtle)' }} />
             </div>
-            {/* Avatar-rad + modal — klikk åpner alfabetisk liste (#272) */}
+            {/* Avatar-rad + modal — klikk åpner alfabetisk liste (#272).
+                Filtrér ut rader uten navn FØR map så vi ikke sender placeholder-navn videre. */}
             <PaameldteListe
-              paameldinger={jaListe.map(p => ({
-                profil_id: p.profil_id,
-                status: 'ja' as const,
-                navn: p.profiles?.navn ?? '?',
-                bilde_url: p.profiles?.bilde_url ?? null,
-                rolle: p.profiles?.rolle ?? null,
-              }))}
+              paameldinger={jaListe
+                .filter(p => p.profiles?.navn)
+                .map(p => ({
+                  profil_id: p.profil_id,
+                  navn: p.profiles?.navn ?? '?', // ?? '?' beholdt for type-narrowing — filter over sikrer at den aldri trigger
+                  bilde_url: p.profiles?.bilde_url ?? null,
+                  rolle: p.profiles?.rolle ?? null,
+                }))}
             />
           </>
         )}

--- a/app/(app)/arrangementer/[id]/page.tsx
+++ b/app/(app)/arrangementer/[id]/page.tsx
@@ -500,41 +500,44 @@ export default async function ArrangementDetaljer({
           </>
         )}
 
-        {/* Påmeldt-seksjon */}
-        {jaListe.length > 0 && (
-          <>
-            <div
-              style={{
-                fontFamily: 'var(--font-mono)',
-                fontSize: 10,
-                color: 'var(--text-tertiary)',
-                letterSpacing: '2px',
-                textTransform: 'uppercase',
-                marginBottom: 14,
-                display: 'flex',
-                alignItems: 'center',
-                gap: 10,
-                fontWeight: 600,
-              }}
-            >
-              <span>Påmeldt</span>
-              <span style={{ color: 'var(--text-secondary)' }}>{jaListe.length}</span>
-              <span style={{ flex: 1, height: '0.5px', background: 'var(--border-subtle)' }} />
-            </div>
-            {/* Avatar-rad + modal — klikk åpner alfabetisk liste (#272).
-                Filtrér ut rader uten navn FØR map så vi ikke sender placeholder-navn videre. */}
-            <PaameldteListe
-              paameldinger={jaListe
-                .filter(p => p.profiles?.navn)
-                .map(p => ({
-                  profil_id: p.profil_id,
-                  navn: p.profiles?.navn ?? '?', // ?? '?' beholdt for type-narrowing — filter over sikrer at den aldri trigger
-                  bilde_url: p.profiles?.bilde_url ?? null,
-                  rolle: p.profiles?.rolle ?? null,
-                }))}
-            />
-          </>
-        )}
+        {/* Påmeldt-seksjon.
+            Bygg den filtrerte listen FØR vi tegner — slik at antall-badgen i headeren og
+            antall avatarer i raden alltid stemmer overens (se review-funn til #272). */}
+        {(() => {
+          const paameldteMedNavn = jaListe
+            .filter(p => p.profiles?.navn)
+            .map(p => ({
+              profil_id: p.profil_id,
+              navn: p.profiles?.navn ?? '?', // ?? '?' beholdt for type-narrowing — filter over sikrer at den aldri trigger
+              bilde_url: p.profiles?.bilde_url ?? null,
+              rolle: p.profiles?.rolle ?? null,
+            }));
+          if (paameldteMedNavn.length === 0) return null;
+          return (
+            <>
+              <div
+                style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 10,
+                  color: 'var(--text-tertiary)',
+                  letterSpacing: '2px',
+                  textTransform: 'uppercase',
+                  marginBottom: 14,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 10,
+                  fontWeight: 600,
+                }}
+              >
+                <span>Påmeldt</span>
+                <span style={{ color: 'var(--text-secondary)' }}>{paameldteMedNavn.length}</span>
+                <span style={{ flex: 1, height: '0.5px', background: 'var(--border-subtle)' }} />
+              </div>
+              {/* Avatar-rad + modal — klikk åpner alfabetisk liste (#272). */}
+              <PaameldteListe paameldinger={paameldteMedNavn} />
+            </>
+          );
+        })()}
 
         {/* Pass-info for deltakere — kun for arrangør på kommende tur */}
         {visPassListe && passDeltakere.length > 0 && (

--- a/app/(app)/arrangementer/[id]/page.tsx
+++ b/app/(app)/arrangementer/[id]/page.tsx
@@ -4,13 +4,13 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import Image from 'next/image'
 import Icon from '@/components/ui/Icon'
-import Avatar from '@/components/ui/Avatar'
 import Placeholder from '@/components/ui/Placeholder'
 import SladdetFelt from '@/components/SladdetFelt'
 import RsvpBlokk from '@/components/arrangement/RsvpBlokk'
 import VarsleNuKnapp from './VarsleNuKnapp'
 import Chat from '@/components/chat/Chat'
 import PassListe, { type PassListeDeltaker } from '@/components/arrangement/PassListe'
+import PaameldteListe from '@/components/arrangement/PaameldteListe'
 import AlbumSeksjon from '@/components/album/AlbumSeksjon'
 import { formaterDato } from '@/lib/dato'
 import { kanAdministrere } from '@/lib/roller'
@@ -521,48 +521,16 @@ export default async function ArrangementDetaljer({
               <span style={{ color: 'var(--text-secondary)' }}>{jaListe.length}</span>
               <span style={{ flex: 1, height: '0.5px', background: 'var(--border-subtle)' }} />
             </div>
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                marginBottom: 32,
-                flexWrap: 'wrap',
-              }}
-            >
-              {jaListe.slice(0, 7).map((p, i) => (
-                <Link
-                  key={p.profil_id}
-                  href={`/klubbinfo/medlemmer/${p.profil_id}`}
-                  style={{
-                    marginLeft: i === 0 ? 0 : -8,
-                    zIndex: 20 - i,
-                    border: '2px solid var(--bg)',
-                    borderRadius: '50%',
-                    position: 'relative',
-                    textDecoration: 'none',
-                  }}
-                >
-                  <Avatar
-                    name={p.profiles?.navn ?? '?'}
-                    size={32}
-                    src={p.profiles?.bilde_url}
-                    rolle={p.profiles?.rolle}
-                  />
-                </Link>
-              ))}
-              {jaListe.length > 7 && (
-                <span
-                  style={{
-                    marginLeft: 12,
-                    fontFamily: 'var(--font-body)',
-                    fontSize: 13,
-                    color: 'var(--text-secondary)',
-                  }}
-                >
-                  + {jaListe.length - 7} til
-                </span>
-              )}
-            </div>
+            {/* Avatar-rad + modal — klikk åpner alfabetisk liste (#272) */}
+            <PaameldteListe
+              paameldinger={jaListe.map(p => ({
+                profil_id: p.profil_id,
+                status: 'ja' as const,
+                navn: p.profiles?.navn ?? '?',
+                bilde_url: p.profiles?.bilde_url ?? null,
+                rolle: p.profiles?.rolle ?? null,
+              }))}
+            />
           </>
         )}
 

--- a/components/arrangement/PaameldteListe.tsx
+++ b/components/arrangement/PaameldteListe.tsx
@@ -1,0 +1,216 @@
+'use client'
+
+// PaameldteListe — klikk på avatar-raden åpner modal med alfabetisk navneliste.
+// Erstatter inline avatar-rad i arrangementer/[id]/page.tsx (#272).
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import Avatar from '@/components/ui/Avatar'
+
+export type PaameldtPerson = {
+  profil_id: string
+  status: 'ja' | 'kanskje' | 'nei'
+  navn: string
+  bilde_url: string | null
+  rolle: string | null
+}
+
+// Maks antall avatarer som vises i raden. Resten oppsummeres som "+ N til".
+const MAKS_I_RAD = 6
+
+export default function PaameldteListe({ paameldinger }: { paameldinger: PaameldtPerson[] }) {
+  const [modalAapen, setModalAapen] = useState(false)
+
+  // Filtrér til kun ja-svar, sortér alfabetisk — samme subset som vises i UI.
+  const jaListe = [...paameldinger]
+    .filter(p => p.status === 'ja')
+    .sort((a, b) => a.navn.localeCompare(b.navn, 'nb'))
+
+  // Escape-tast lukker modalen. body-overflow hindrer scroll bak modalen,
+  // særlig viktig på iOS hvor scroll-chain lett lekker gjennom overlay.
+  useEffect(() => {
+    if (!modalAapen) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setModalAapen(false)
+    }
+    document.addEventListener('keydown', onKey)
+    const forrigeOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.body.style.overflow = forrigeOverflow
+    }
+  }, [modalAapen])
+
+  if (jaListe.length === 0) return null
+
+  const synligeAvatarer = jaListe.slice(0, MAKS_I_RAD)
+  const antallSkjult = jaListe.length - MAKS_I_RAD
+
+  return (
+    <>
+      {/* Klikk på raden åpner modal — hele flaten er interaktiv */}
+      <button
+        type="button"
+        onClick={() => setModalAapen(true)}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          background: 'none',
+          border: 'none',
+          padding: 0,
+          cursor: 'pointer',
+          marginBottom: 32,
+        }}
+      >
+        {/* Stablet avatar-rad med negativ margin for overlapp */}
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          {synligeAvatarer.map((p, i) => (
+            <div
+              key={p.profil_id}
+              style={{
+                marginLeft: i === 0 ? 0 : -12,
+                zIndex: MAKS_I_RAD - i,
+                border: '3px solid var(--bg)',
+                borderRadius: '50%',
+                position: 'relative',
+                flexShrink: 0,
+              }}
+            >
+              <Avatar name={p.navn} size={44} src={p.bilde_url} rolle={p.rolle} />
+            </div>
+          ))}
+        </div>
+
+        {/* "+ N til" hvis flere enn MAKS_I_RAD er påmeldt */}
+        {antallSkjult > 0 && (
+          <span
+            style={{
+              fontFamily: 'var(--font-body)',
+              fontSize: 13,
+              color: 'var(--text-secondary)',
+            }}
+          >
+            + {antallSkjult} til
+          </span>
+        )}
+
+        {/* Ekstra affordance — synlig oppfordring til å trykke */}
+        <span
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 10,
+            color: 'var(--text-tertiary)',
+            letterSpacing: '1px',
+            marginLeft: 4,
+          }}
+        >
+          Se alle
+        </span>
+      </button>
+
+      {/* Modal: alfabetisk liste over alle påmeldte */}
+      {modalAapen && (
+        // Backdrop — klikk utenfor kortet lukker modalen
+        <div
+          onClick={() => setModalAapen(false)}
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(0,0,0,0.5)',
+            zIndex: 100,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '0 20px',
+          }}
+        >
+          {/* Stopp propagasjon så klikk på selve kortet ikke lukker */}
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Påmeldte"
+            onClick={e => e.stopPropagation()}
+            style={{
+              width: '100%',
+              maxWidth: 360,
+              maxHeight: '80vh',
+              background: 'var(--bg-elevated)',
+              border: '0.5px solid var(--border)',
+              borderRadius: 16,
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+            }}
+          >
+            {/* Modal-header */}
+            <div
+              style={{
+                padding: '18px 20px 14px',
+                fontFamily: 'var(--font-display)',
+                fontSize: 20,
+                fontWeight: 500,
+                letterSpacing: '-0.2px',
+                color: 'var(--text-primary)',
+                borderBottom: '0.5px solid var(--border-subtle)',
+                flexShrink: 0,
+              }}
+            >
+              Påmeldt ({jaListe.length})
+            </div>
+
+            {/* Scrollbar liste */}
+            <div style={{ overflowY: 'auto', flex: 1 }}>
+              {jaListe.map((p, i) => (
+                <Link
+                  key={p.profil_id}
+                  href={`/klubbinfo/medlemmer/${p.profil_id}`}
+                  onClick={() => setModalAapen(false)}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 12,
+                    padding: '12px 20px',
+                    textDecoration: 'none',
+                    // Skillelinje mellom rader: 0.5px border-subtle (ikke første rad)
+                    borderTop: i > 0 ? '0.5px solid var(--border-subtle)' : 'none',
+                  }}
+                >
+                  <Avatar name={p.navn} size={40} src={p.bilde_url} rolle={p.rolle} />
+                  <span
+                    style={{
+                      flex: 1,
+                      fontFamily: 'var(--font-body)',
+                      fontSize: 15,
+                      color: 'var(--text-primary)',
+                    }}
+                  >
+                    {p.navn}
+                  </span>
+                  {/* Chevron som visuell affordance for at raden er klikkbar */}
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    aria-hidden="true"
+                    style={{ color: 'var(--text-tertiary)', flexShrink: 0 }}
+                  >
+                    <path
+                      d="M6 4l4 4-4 4"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/components/arrangement/PaameldteListe.tsx
+++ b/components/arrangement/PaameldteListe.tsx
@@ -200,7 +200,9 @@ export default function PaameldteListe({ paameldinger }: { paameldinger: Paameld
               outline: 'none',
             }}
           >
-            {/* Modal-header */}
+            {/* Modal-header med eksplisitt Lukk-knapp.
+                Escape og klikk-utenfor lukker også, men en synlig knapp er nødvendig
+                for tastaturbrukere og touch-brukere som ikke kjenner gesten. */}
             <div
               style={{
                 padding: '18px 20px 14px',
@@ -211,9 +213,40 @@ export default function PaameldteListe({ paameldinger }: { paameldinger: Paameld
                 color: 'var(--text-primary)',
                 borderBottom: '0.5px solid var(--border-subtle)',
                 flexShrink: 0,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 12,
               }}
             >
-              Påmeldt ({jaListe.length})
+              <span style={{ flex: 1 }}>Påmeldt ({jaListe.length})</span>
+              <button
+                type="button"
+                onClick={() => setModalAapen(false)}
+                aria-label="Lukk"
+                style={{
+                  width: 32,
+                  height: 32,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  background: 'transparent',
+                  border: 'none',
+                  borderRadius: 8,
+                  cursor: 'pointer',
+                  color: 'var(--text-secondary)',
+                  flexShrink: 0,
+                  padding: 0,
+                }}
+              >
+                <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+                  <path
+                    d="M4 4l10 10M14 4L4 14"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              </button>
             </div>
 
             {/* Scrollbar liste */}

--- a/components/arrangement/PaameldteListe.tsx
+++ b/components/arrangement/PaameldteListe.tsx
@@ -1,33 +1,46 @@
 'use client'
 
-// PaameldteListe — klikk på avatar-raden åpner modal med alfabetisk navneliste.
-// Erstatter inline avatar-rad i arrangementer/[id]/page.tsx (#272).
+// PaameldteListe — viser avatar-rad over påmeldte (status=ja).
+// Hvis alle får plass i raden: hver avatar er en <Link> direkte til medlemsprofilen
+// (samme oppførsel som før #272). Hvis det er overflow ("+ N til"), blir hele raden
+// én knapp som åpner modal med komplett alfabetisk liste — det er først DA modal-
+// affordansen gir mening. Brukeren skal aldri få en modal med kun én oppføring.
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
 import Avatar from '@/components/ui/Avatar'
 
 export type PaameldtPerson = {
   profil_id: string
-  status: 'ja' | 'kanskje' | 'nei'
   navn: string
   bilde_url: string | null
   rolle: string | null
 }
 
-// Maks antall avatarer som vises i raden. Resten oppsummeres som "+ N til".
+// Maks antall avatarer som vises i raden. Resten oppsummeres som "+ N til" og
+// trigger modal-modus. Holdes lokal — vurdert flyttet til lib/konstanter.ts, men
+// brukes kun her og er tett knyttet til layout-valg i denne komponenten.
 const MAKS_I_RAD = 6
 
 export default function PaameldteListe({ paameldinger }: { paameldinger: PaameldtPerson[] }) {
   const [modalAapen, setModalAapen] = useState(false)
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLElement | null>(null)
 
-  // Filtrér til kun ja-svar, sortér alfabetisk — samme subset som vises i UI.
-  const jaListe = [...paameldinger]
-    .filter(p => p.status === 'ja')
-    .sort((a, b) => a.navn.localeCompare(b.navn, 'nb'))
+  // Intl.Collator er raskere enn localeCompare i loop og gir konsistent sortering
+  // på tvers av kall. Sekundær-sort på profil_id sikrer stabil rekkefølge ved like navn.
+  const collator = useMemo(() => new Intl.Collator('nb'), [])
+  const jaListe = useMemo(() => {
+    return [...paameldinger].sort((a, b) => {
+      const cmp = collator.compare(a.navn, b.navn)
+      return cmp !== 0 ? cmp : a.profil_id.localeCompare(b.profil_id)
+    })
+  }, [paameldinger, collator])
 
   // Escape-tast lukker modalen. body-overflow hindrer scroll bak modalen,
   // særlig viktig på iOS hvor scroll-chain lett lekker gjennom overlay.
+  // Fokus flyttes inn i dialogen ved åpning og tilbake til triggeren ved lukking,
+  // i tråd med WAI-ARIA modal-mønster.
   useEffect(() => {
     if (!modalAapen) return
     function onKey(e: KeyboardEvent) {
@@ -36,9 +49,14 @@ export default function PaameldteListe({ paameldinger }: { paameldinger: Paameld
     document.addEventListener('keydown', onKey)
     const forrigeOverflow = document.body.style.overflow
     document.body.style.overflow = 'hidden'
+    // Lagre forrige fokus og flytt fokus til dialogen
+    triggerRef.current = document.activeElement as HTMLElement | null
+    dialogRef.current?.focus()
     return () => {
       document.removeEventListener('keydown', onKey)
       document.body.style.overflow = forrigeOverflow
+      // Returnér fokus til triggeren (typisk knappen som åpnet modalen)
+      triggerRef.current?.focus?.()
     }
   }, [modalAapen])
 
@@ -46,29 +64,16 @@ export default function PaameldteListe({ paameldinger }: { paameldinger: Paameld
 
   const synligeAvatarer = jaListe.slice(0, MAKS_I_RAD)
   const antallSkjult = jaListe.length - MAKS_I_RAD
+  const harOverflow = antallSkjult > 0
 
-  return (
-    <>
-      {/* Klikk på raden åpner modal — hele flaten er interaktiv */}
-      <button
-        type="button"
-        onClick={() => setModalAapen(true)}
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 10,
-          background: 'none',
-          border: 'none',
-          padding: 0,
-          cursor: 'pointer',
-          marginBottom: 32,
-        }}
-      >
-        {/* Stablet avatar-rad med negativ margin for overlapp */}
-        <div style={{ display: 'flex', alignItems: 'center' }}>
-          {synligeAvatarer.map((p, i) => (
+  // Hjelper: render selve avatar-stabelen. Brukes både som lenker (uten overflow)
+  // og som ikke-interaktive elementer inni knappen (med overflow).
+  function renderAvatarRad(somLenker: boolean) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        {synligeAvatarer.map((p, i) => {
+          const innhold = (
             <div
-              key={p.profil_id}
               style={{
                 marginLeft: i === 0 ? 0 : -12,
                 zIndex: MAKS_I_RAD - i,
@@ -80,11 +85,60 @@ export default function PaameldteListe({ paameldinger }: { paameldinger: Paameld
             >
               <Avatar name={p.navn} size={44} src={p.bilde_url} rolle={p.rolle} />
             </div>
-          ))}
-        </div>
+          )
+          if (somLenker) {
+            return (
+              <Link
+                key={p.profil_id}
+                href={`/klubbinfo/medlemmer/${p.profil_id}`}
+                aria-label={p.navn}
+                style={{ display: 'block', textDecoration: 'none' }}
+              >
+                {innhold}
+              </Link>
+            )
+          }
+          return <div key={p.profil_id}>{innhold}</div>
+        })}
+      </div>
+    )
+  }
 
-        {/* "+ N til" hvis flere enn MAKS_I_RAD er påmeldt */}
-        {antallSkjult > 0 && (
+  return (
+    <>
+      {!harOverflow ? (
+        // Liten liste: per-avatar lenker direkte til profil, ingen modal.
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            flexWrap: 'wrap',
+            marginBottom: 32,
+          }}
+        >
+          {renderAvatarRad(true)}
+        </div>
+      ) : (
+        // Overflow: hele raden er én knapp som åpner modalen.
+        <button
+          type="button"
+          onClick={() => setModalAapen(true)}
+          aria-label={`Se alle ${jaListe.length} påmeldte`}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            flexWrap: 'wrap',
+            background: 'none',
+            border: 'none',
+            padding: 0,
+            cursor: 'pointer',
+            marginBottom: 32,
+            minHeight: 48, // klikk-mål-minimum
+          }}
+        >
+          {renderAvatarRad(false)}
           <span
             style={{
               fontFamily: 'var(--font-body)',
@@ -94,23 +148,21 @@ export default function PaameldteListe({ paameldinger }: { paameldinger: Paameld
           >
             + {antallSkjult} til
           </span>
-        )}
+          <span
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 10,
+              color: 'var(--text-tertiary)',
+              letterSpacing: '1px',
+              marginLeft: 4,
+            }}
+          >
+            Se alle
+          </span>
+        </button>
+      )}
 
-        {/* Ekstra affordance — synlig oppfordring til å trykke */}
-        <span
-          style={{
-            fontFamily: 'var(--font-mono)',
-            fontSize: 10,
-            color: 'var(--text-tertiary)',
-            letterSpacing: '1px',
-            marginLeft: 4,
-          }}
-        >
-          Se alle
-        </span>
-      </button>
-
-      {/* Modal: alfabetisk liste over alle påmeldte */}
+      {/* Modal: alfabetisk liste over alle påmeldte. Kun tilgjengelig når overflow finnes. */}
       {modalAapen && (
         // Backdrop — klikk utenfor kortet lukker modalen
         <div
@@ -126,11 +178,14 @@ export default function PaameldteListe({ paameldinger }: { paameldinger: Paameld
             padding: '0 20px',
           }}
         >
-          {/* Stopp propagasjon så klikk på selve kortet ikke lukker */}
+          {/* Stopp propagasjon så klikk på selve kortet ikke lukker. tabIndex=-1
+              gjør at .focus() kan flyttes hit programmatisk uten å gjøre kortet tab-bart. */}
           <div
+            ref={dialogRef}
             role="dialog"
             aria-modal="true"
             aria-label="Påmeldte"
+            tabIndex={-1}
             onClick={e => e.stopPropagation()}
             style={{
               width: '100%',
@@ -142,6 +197,7 @@ export default function PaameldteListe({ paameldinger }: { paameldinger: Paameld
               display: 'flex',
               flexDirection: 'column',
               overflow: 'hidden',
+              outline: 'none',
             }}
           >
             {/* Modal-header */}

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 72,
-  "versjon": "V3.1.72"
+  "nummer": 73,
+  "versjon": "V3.1.73"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 70,
-  "versjon": "V3.1.70"
+  "nummer": 71,
+  "versjon": "V3.1.71"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 71,
-  "versjon": "V3.1.71"
+  "nummer": 72,
+  "versjon": "V3.1.72"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.70'
+const CACHE_VERSION = 'V3.1.71'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.72'
+const CACHE_VERSION = 'V3.1.73'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.71'
+const CACHE_VERSION = 'V3.1.72'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
## Sammendrag
- Stablet avatar-rad på arrangement-detaljsiden viser nå større avatarer (32 → 44 px).
- Når listen er kort nok til at alle synes: per-avatar `<Link>` til medlemsprofil som før.
- Når «+ N til»-overflow finnes: hele raden er én knapp som åpner modal med alfabetisk navneliste. Klikk på navn navigerer til medlemsprofilen.

## Beslutninger underveis
- Per-avatar-lenke beholdt når alle synes (ingen modal-affordans i det tilfellet) — unngår "modal med kun én person".
- Filtrer ut rader uten navn før map til komponenten (i stedet for `?? '?'`-placeholder).
- Modal følger mønsteret fra `PurreKnapp` (Escape, body-scroll-lås, klikk-utenfor, role=dialog).
- Focus-management: dialog mottar fokus ved åpning, returneres til triggeren ved lukking.
- Sortering via `Intl.Collator('nb')` i `useMemo` med sekundærsort på `profil_id` for stabilitet.

Lukker #272.

## Test plan
- [ ] Arrangement med ≤6 påmeldte: alle avatarer synlige, hver er en lenke til profil
- [ ] Arrangement med >6 påmeldte: hele raden klikkbar, modal åpner med alle navn alfabetisk
- [ ] Escape lukker modal, fokus returneres til triggeren
- [ ] Klikk på navn i modal navigerer til medlemsprofil

🤖 Generated with [Claude Code](https://claude.com/claude-code)