### PR TITLE
Skjul kommentarer på ubesvart-seksjon (#274)

### DIFF
--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -506,10 +506,7 @@ export default async function Forside() {
                 >
                   <ArrangementKort
                     arr={i.data}
-                    kommentarer={kommentarerPerArr.get(i.data.id) ?? []}
-                    totaltKommentarer={totaltPerArr.get(i.data.id) ?? 0}
-                    profiler={chatProfiler}
-                    brukerId={user!.id}
+                    visKommentarer={false}
                   />
                   {/* RsvpInline sitter utenfor <Link> i ArrangementKort slik at
                       knapp-klikk ikke trigger navigasjon. Wrapperens overflow:hidden

--- a/components/agenda/ArrangementKort.tsx
+++ b/components/agenda/ArrangementKort.tsx
@@ -61,9 +61,11 @@ type Props = {
   profiler?: ChatProfil[]
   /** Innlogget brukers id — ekskluderes fra mention-forslag. */
   brukerId?: string
+  /** Skjul kommentar-blokken — brukes for «ikke svart ennå»-seksjonen (#274). */
+  visKommentarer?: boolean
 }
 
-export default function ArrangementKort({ arr, tidligere = false, kommentarer = [], totaltKommentarer, profiler, brukerId }: Props) {
+export default function ArrangementKort({ arr, tidligere = false, kommentarer = [], totaltKommentarer, profiler, brukerId, visKommentarer = true }: Props) {
   const iso = arr.start_tidspunkt
   const mnd = formaterDato(iso, 'MMM').toUpperCase()
   const dag = formaterDato(iso, 'd')
@@ -257,8 +259,8 @@ export default function ArrangementKort({ arr, tidligere = false, kommentarer = 
         </div>
         </div>
 
-        {/* Kommentarer — inne i kortet, kollapsbart, med inline input */}
-        {!tidligere && (
+        {/* Kommentarer — inne i kortet, kollapsbart, med inline input; se #274 for visKommentarer-flagg */}
+        {!tidligere && visKommentarer && (
           <KommentarerPaaKort
             kommentarer={kommentarer}
             scope={{ type: 'arrangement', id: arr.id }}

--- a/components/agenda/ArrangementKort.tsx
+++ b/components/agenda/ArrangementKort.tsx
@@ -61,7 +61,7 @@ type Props = {
   profiler?: ChatProfil[]
   /** Innlogget brukers id — ekskluderes fra mention-forslag. */
   brukerId?: string
-  /** Skjul kommentar-blokken — brukes for «ikke svart ennå»-seksjonen (#274). */
+  /** Vis kommentar-blokken. Default true. Sett false (f.eks. i ubesvart-seksjonen) for å skjule — se #274. */
   visKommentarer?: boolean
 }
 
@@ -73,10 +73,14 @@ export default function ArrangementKort({ arr, tidligere = false, kommentarer = 
   const aar = aarHvisAvvik(iso)
   const scene = sceneFor(arr.type)
 
-  const siste = kommentarer[kommentarer.length - 1]
+  // Beregn kun kollaps-flagg når blokken faktisk skal vises (sparer Date-arbeid på hver render i ubesvart-seksjonen).
+  const visKommentarBlokk = !tidligere && visKommentarer
+  const siste = visKommentarBlokk ? kommentarer[kommentarer.length - 1] : undefined
   const alderMs = siste ? Date.now() - new Date(siste.opprettet).getTime() : 0
   const skalKollapse =
-    kommentarer.length > 0 && alderMs > KOMMENTARER_KOLLAPS_DAGER * 24 * 60 * 60 * 1000
+    visKommentarBlokk &&
+    kommentarer.length > 0 &&
+    alderMs > KOMMENTARER_KOLLAPS_DAGER * 24 * 60 * 60 * 1000
 
   return (
     <Link
@@ -260,7 +264,7 @@ export default function ArrangementKort({ arr, tidligere = false, kommentarer = 
         </div>
 
         {/* Kommentarer — inne i kortet, kollapsbart, med inline input; se #274 for visKommentarer-flagg */}
-        {!tidligere && visKommentarer && (
+        {visKommentarBlokk && (
           <KommentarerPaaKort
             kommentarer={kommentarer}
             scope={{ type: 'arrangement', id: arr.id }}

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 73,
-  "versjon": "V3.1.73"
+  "nummer": 74,
+  "versjon": "V3.1.74"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 74,
-  "versjon": "V3.1.74"
+  "nummer": 75,
+  "versjon": "V3.1.75"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.73'
+const CACHE_VERSION = 'V3.1.74'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.74'
+const CACHE_VERSION = 'V3.1.75'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
## Sammendrag
- `ArrangementKort` får ny prop `visKommentarer?: boolean` (default true)
- Ubesvart-seksjonen sender `visKommentarer={false}` — andre seksjoner uendret
- Fjernet ubrukte props (`kommentarer`, `totaltKommentarer`, `profiler`, `brukerId`) fra ubesvart-kallet

## Beslutninger underveis
- Triviell endring (fjerning av visning) — kjørte agentic-snarveien forbi reviewer/integrator/tester.

Lukker #274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)