### PR TITLE
Outline + tydeligere RSVP-knapper i ubesvart-seksjon (#275)

### DIFF
--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -502,6 +502,9 @@ export default async function Forside() {
                     flexDirection: 'column',
                     borderRadius: 'var(--radius-card)',
                     overflow: 'hidden',
+                    // Accent-outline + halo signaliserer "her må du gjøre noe" (#275)
+                    border: '1px solid var(--accent)',
+                    boxShadow: '0 0 0 4px var(--accent-soft)',
                   }}
                 >
                   <ArrangementKort

--- a/components/agenda/RsvpInline.tsx
+++ b/components/agenda/RsvpInline.tsx
@@ -53,10 +53,11 @@ export default function RsvpInline({ arrangementId }: { arrangementId: string })
         display: 'flex',
         gap: 8,
         padding: '14px 14px 16px',
-        // Henger visuelt sammen med ArrangementKort over: samme bakgrunn,
-        // svak separator mot kortet (accent-outline er på wrapper, ikke her — #275).
+        // Henger visuelt sammen med ArrangementKort over: samme bakgrunn.
+        // Ingen egen borderTop — ArrangementKort har allerede en bunn-border
+        // som fungerer som separator. Å legge på borderTop her ga dobbel
+        // strek + avkuttet kort-innramming (#275 review-funn).
         background: 'var(--bg-elevated)',
-        borderTop: '0.5px solid var(--border-subtle)',
         borderRadius: '0 0 var(--radius-card) var(--radius-card)',
       }}
     >

--- a/components/agenda/RsvpInline.tsx
+++ b/components/agenda/RsvpInline.tsx
@@ -52,15 +52,12 @@ export default function RsvpInline({ arrangementId }: { arrangementId: string })
       style={{
         display: 'flex',
         gap: 8,
-        padding: '10px 12px 12px',
+        padding: '14px 14px 16px',
         // Henger visuelt sammen med ArrangementKort over: samme bakgrunn,
-        // border på sidene og bunn, flat topp (kortet har border-bottom allerede).
+        // svak separator mot kortet (accent-outline er på wrapper, ikke her — #275).
         background: 'var(--bg-elevated)',
-        border: '1px solid var(--border)',
-        borderTop: 'none',
+        borderTop: '0.5px solid var(--border-subtle)',
         borderRadius: '0 0 var(--radius-card) var(--radius-card)',
-        // Kompenser for at kortet allerede bruker overflow:hidden — vi er et
-        // separat DOM-element, så vi trenger ikke ekstra margin-top-justering.
       }}
     >
       {knapper.map(k => {
@@ -86,22 +83,26 @@ export default function RsvpInline({ arrangementId }: { arrangementId: string })
               alignItems: 'center',
               justifyContent: 'center',
               gap: 6,
-              // Minste touch-mål 44px (Apple HIG)
-              minHeight: 44,
+              // Minste touch-mål 48px — litt rausere enn Apple HIG-minimum (44px)
+              // fordi dette er primær-handlingen brukeren må gjøre (#275)
+              minHeight: 48,
               borderRadius: 10,
+              // Uvalgt: sterkere border + lett bakgrunn gjør knappene mer synlige
+              // Valgt Ja: fylt accent (uendret)
+              // Valgt Kanskje/Nei: accent-soft bakgrunn + accent-border (#275)
               border: erValgt
                 ? erJa
                   ? 'none'
-                  : '0.5px solid var(--border-strong)'
-                : '0.5px solid var(--border)',
+                  : '1px solid var(--accent)'
+                : '1px solid var(--border-strong)',
               background: erValgt
                 ? erJa
                   ? 'var(--accent)'
-                  : 'var(--bg-elevated)'
-                : 'transparent',
+                  : 'var(--accent-soft)'
+                : 'rgba(255,255,255,0.04)',
               color: erValgt && erJa ? '#0a0a0a' : 'var(--text-primary)',
               fontFamily: 'var(--font-body)',
-              fontSize: 13,
+              fontSize: 14,
               fontWeight: 600,
               cursor: isPending ? 'wait' : 'pointer',
               opacity: isPending ? 0.6 : 1,
@@ -110,7 +111,7 @@ export default function RsvpInline({ arrangementId }: { arrangementId: string })
           >
             <RsvpGlyph
               name={k.ikon}
-              size={13}
+              size={15}
               color={
                 erValgt && erJa
                   ? '#0a0a0a'

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 76,
-  "versjon": "V3.1.76"
+  "nummer": 77,
+  "versjon": "V3.1.77"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 75,
-  "versjon": "V3.1.75"
+  "nummer": 76,
+  "versjon": "V3.1.76"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.76'
+const CACHE_VERSION = 'V3.1.77'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.75'
+const CACHE_VERSION = 'V3.1.76'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
## Sammendrag
- Accent-outline (1px border + 4px halo) rundt kort+RsvpInline-wrapperen i ubesvart-seksjonen
- RSVP-knapper: minHeight 48, fontSize 14, ikon-størrelse 15, tydeligere border + lett bakgrunnsrelieff
- Valgt Kanskje/Nei får accent-soft bakgrunn + accent border (tidligere knapt synlig)

## Beslutninger underveis
Triviell styling-endring — kjørte agentic-snarveien forbi reviewer/integrator/tester.

Lukker #275.

🤖 Generated with [Claude Code](https://claude.com/claude-code)