### PR TITLE
Modal med valgfri hilsen på varsle-knapp (#282)

### DIFF
--- a/app/(app)/arrangementer/[id]/VarsleNuKnapp.tsx
+++ b/app/(app)/arrangementer/[id]/VarsleNuKnapp.tsx
@@ -21,6 +21,15 @@ export default function VarsleNuKnapp({
   // Synkron guard mot dobbeltklikk: settes før startTransition rekker å
   // markere isPending. Uten dette kan to raske klikk gi to server-kall.
   const sendingRef = useRef(false)
+  // Ref på utløser-knappen for focus-retur når modalen lukkes. Sentralt
+  // håndtert i useEffect-cleanup nedenfor slik at alle lukke-veier
+  // (Escape, overlay-klikk, Avbryt-knapp, suksess) treffes samtidig.
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  // Holder siste isPending-verdi tilgjengelig inne i onKey uten å måtte
+  // legge isPending i useEffect-deps (som ville trigget cleanup ved hver
+  // pending-endring og dermed feilaktig focus-retur mens modalen er åpen).
+  const isPendingRef = useRef(isPending)
+  isPendingRef.current = isPending
 
   function aapneModal() {
     if (sendt || isPending) return
@@ -51,21 +60,30 @@ export default function VarsleNuKnapp({
     })
   }
 
-  // Lukk modalen med Escape og lås body-scroll mens den er åpen.
-  // body-overflow forhindrer scroll-chain bak modalen, særlig på iOS.
+  // Lukk modalen med Escape, lås body-scroll mens den er åpen, og returner
+  // fokus til utløser-knappen ved lukking. Sentral cleanup dekker alle
+  // lukke-veier (Escape, overlay, Avbryt, suksess) i én slag.
   useEffect(() => {
     if (!modalAapen) return
     function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape' && !isPending) setModalAapen(false)
+      if (e.key === 'Escape' && !isPendingRef.current) setModalAapen(false)
     }
     document.addEventListener('keydown', onKey)
     const forrigeOverflow = document.body.style.overflow
     document.body.style.overflow = 'hidden'
+    // Snapshot trigger ved effekt-start — trigger-knappen forblir mounted
+    // gjennom modalens levetid, så referansen er stabil. Snapshotting
+    // tilfredsstiller react-hooks/exhaustive-deps-linteren.
+    const triggerNode = triggerRef.current
     return () => {
       document.removeEventListener('keydown', onKey)
       document.body.style.overflow = forrigeOverflow
+      // Focus-retur til trigger — viktig for tastatur- og skjermleser-
+      // brukere som ellers mister fokus til <body> etter at modalen
+      // forsvinner fra DOM.
+      triggerNode?.focus()
     }
-  }, [modalAapen, isPending])
+  }, [modalAapen])
 
   const tekst = sendt ? 'Varslet' : isPending ? 'Sender…' : 'Varsle'
   const len = melding.length
@@ -73,6 +91,8 @@ export default function VarsleNuKnapp({
   return (
     <>
       <button
+        ref={triggerRef}
+        type="button"
         onClick={aapneModal}
         disabled={sendt || isPending}
         style={{

--- a/app/(app)/arrangementer/[id]/VarsleNuKnapp.tsx
+++ b/app/(app)/arrangementer/[id]/VarsleNuKnapp.tsx
@@ -1,57 +1,259 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useRef, useState, useTransition } from 'react'
 import { varslOmArrangement } from '@/lib/actions/arrangementer'
+import { VARSLE_MAKS_LENGDE } from '@/lib/konstanter'
 
-export default function VarsleNuKnapp({ arrangementId }: { arrangementId: string }) {
-  const [status, setStatus] = useState<'idle' | 'sender' | 'ok' | 'feil'>('idle')
+// Speil av PurreKnapp.tsx (#267 + integrator-funn) — modal med valgfri
+// hilsen før varselet sendes. Se #282 for bakgrunn.
+export default function VarsleNuKnapp({
+  arrangementId,
+  arrangementTittel,
+}: {
+  arrangementId: string
+  arrangementTittel: string
+}) {
+  const [isPending, startTransition] = useTransition()
+  const [sendt, setSendt] = useState(false)
+  const [feil, setFeil] = useState('')
+  const [modalAapen, setModalAapen] = useState(false)
+  const [melding, setMelding] = useState('')
+  // Synkron guard mot dobbeltklikk: settes før startTransition rekker å
+  // markere isPending. Uten dette kan to raske klikk gi to server-kall.
+  const sendingRef = useRef(false)
 
-  async function handleVarsle() {
-    setStatus('sender')
-    try {
-      await varslOmArrangement(arrangementId)
-      setStatus('ok')
-      setTimeout(() => setStatus('idle'), 3000)
-    } catch {
-      setStatus('feil')
-      setTimeout(() => setStatus('idle'), 3000)
-    }
+  function aapneModal() {
+    if (sendt || isPending) return
+    setFeil('')
+    setMelding('')
+    setModalAapen(true)
   }
 
-  const tekst =
-    status === 'sender'
-      ? 'Sender…'
-      : status === 'ok'
-      ? 'Varslet'
-      : status === 'feil'
-      ? 'Feil'
-      : 'Varsle'
+  function lukkModal() {
+    if (isPending) return
+    setModalAapen(false)
+  }
+
+  function handleSend() {
+    if (sendingRef.current) return
+    sendingRef.current = true
+    startTransition(async () => {
+      try {
+        // Sender hilsen kun hvis den ikke er tom etter trimming
+        await varslOmArrangement(arrangementId, melding.trim() || undefined)
+        setSendt(true)
+        setModalAapen(false)
+      } catch (err) {
+        setFeil(err instanceof Error ? err.message : 'Kunne ikke sende varsel')
+      } finally {
+        sendingRef.current = false
+      }
+    })
+  }
+
+  // Lukk modalen med Escape og lås body-scroll mens den er åpen.
+  // body-overflow forhindrer scroll-chain bak modalen, særlig på iOS.
+  useEffect(() => {
+    if (!modalAapen) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape' && !isPending) setModalAapen(false)
+    }
+    document.addEventListener('keydown', onKey)
+    const forrigeOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.body.style.overflow = forrigeOverflow
+    }
+  }, [modalAapen, isPending])
+
+  const tekst = sendt ? 'Varslet' : isPending ? 'Sender…' : 'Varsle'
+  const len = melding.length
 
   return (
-    <button
-      onClick={handleVarsle}
-      disabled={status === 'sender'}
-      style={{
-        padding: '8px 14px',
-        borderRadius: 999,
-        background: 'rgba(10,10,12,0.6)',
-        backdropFilter: 'blur(16px)',
-        WebkitBackdropFilter: 'blur(16px)',
-        border: '0.5px solid var(--border)',
-        color:
-          status === 'ok'
-            ? 'var(--success)'
-            : status === 'feil'
-            ? 'var(--danger)'
-            : 'var(--text-primary)',
-        fontFamily: 'var(--font-body)',
-        fontSize: 12,
-        fontWeight: 500,
-        cursor: status === 'sender' ? 'default' : 'pointer',
-        opacity: status === 'sender' ? 0.6 : 1,
-      }}
-    >
-      {tekst}
-    </button>
+    <>
+      <button
+        onClick={aapneModal}
+        disabled={sendt || isPending}
+        style={{
+          padding: '8px 14px',
+          borderRadius: 999,
+          background: 'rgba(10,10,12,0.6)',
+          backdropFilter: 'blur(16px)',
+          WebkitBackdropFilter: 'blur(16px)',
+          border: '0.5px solid var(--border)',
+          color:
+            sendt
+              ? 'var(--success)'
+              : isPending
+              ? 'var(--text-secondary)'
+              : 'var(--text-primary)',
+          fontFamily: 'var(--font-body)',
+          fontSize: 12,
+          fontWeight: 500,
+          cursor: sendt || isPending ? 'default' : 'pointer',
+          opacity: isPending ? 0.6 : 1,
+        }}
+      >
+        {tekst}
+      </button>
+
+      {modalAapen && (
+        // Overlay: klikk utenfor kortet lukker modalen
+        <div
+          onClick={lukkModal}
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(0,0,0,0.5)',
+            zIndex: 100,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '0 20px',
+          }}
+        >
+          {/* Stopp klikk-propagasjon slik at klikk på selve kortet ikke lukker */}
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label={`Varsle om ${arrangementTittel}`}
+            onClick={e => e.stopPropagation()}
+            style={{
+              width: '100%',
+              maxWidth: 360,
+              background: 'var(--bg-elevated)',
+              border: '0.5px solid var(--border)',
+              borderRadius: 16,
+              padding: 20,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 12,
+            }}
+          >
+            <div
+              style={{
+                fontFamily: 'var(--font-display)',
+                fontSize: 20,
+                fontWeight: 500,
+                letterSpacing: '-0.2px',
+                color: 'var(--text-primary)',
+              }}
+            >
+              Varsle om {arrangementTittel}
+            </div>
+
+            <p
+              style={{
+                fontFamily: 'var(--font-body)',
+                fontSize: 13,
+                color: 'var(--text-tertiary)',
+                margin: 0,
+                lineHeight: 1.5,
+              }}
+            >
+              Skriv en valgfri hilsen, eller bare send.
+            </p>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <textarea
+                value={melding}
+                onChange={e => setMelding(e.target.value)}
+                maxLength={VARSLE_MAKS_LENGDE}
+                placeholder="Valgfritt: en kort hilsen til gutta…"
+                rows={3}
+                autoFocus
+                style={{
+                  fontFamily: 'var(--font-body)',
+                  fontSize: 14,
+                  color: 'var(--text-primary)',
+                  background: 'var(--bg-base)',
+                  border: '0.5px solid var(--border)',
+                  borderRadius: 10,
+                  padding: '10px 12px',
+                  resize: 'none',
+                  outline: 'none',
+                  width: '100%',
+                  boxSizing: 'border-box',
+                  lineHeight: 1.5,
+                }}
+              />
+              {/* Tegnteller: vises alltid slik at brukeren ser grensen */}
+              <span
+                style={{
+                  fontFamily: 'var(--font-body)',
+                  fontSize: 11,
+                  color: 'var(--text-tertiary)',
+                  alignSelf: 'flex-end',
+                }}
+              >
+                {len}/{VARSLE_MAKS_LENGDE}
+              </span>
+            </div>
+
+            {/* Feilmelding inne i modalen — uten denne ble feil rendret kun
+                utenfor og dermed skjult bak overlayen mens modalen sto åpen. */}
+            {feil && (
+              <p
+                role="alert"
+                style={{
+                  fontFamily: 'var(--font-body)',
+                  fontSize: 13,
+                  color: 'var(--danger)',
+                  margin: 0,
+                  lineHeight: 1.5,
+                }}
+              >
+                {feil}
+              </p>
+            )}
+
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+              <button
+                type="button"
+                onClick={lukkModal}
+                disabled={isPending}
+                style={{
+                  padding: '8px 16px',
+                  borderRadius: 999,
+                  background: 'transparent',
+                  border: '0.5px solid var(--border)',
+                  color: 'var(--text-secondary)',
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 10,
+                  fontWeight: 600,
+                  letterSpacing: '1.4px',
+                  textTransform: 'uppercase',
+                  cursor: 'pointer',
+                }}
+              >
+                Avbryt
+              </button>
+              <button
+                type="button"
+                onClick={handleSend}
+                disabled={isPending}
+                style={{
+                  padding: '8px 16px',
+                  borderRadius: 999,
+                  background: 'var(--accent)',
+                  border: 'none',
+                  color: '#0a0a0a',
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 10,
+                  fontWeight: 600,
+                  letterSpacing: '1.4px',
+                  textTransform: 'uppercase',
+                  cursor: isPending ? 'default' : 'pointer',
+                  opacity: isPending ? 0.7 : 1,
+                }}
+              >
+                {isPending ? 'Sender…' : 'Send varsel'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   )
 }

--- a/app/(app)/arrangementer/[id]/page.tsx
+++ b/app/(app)/arrangementer/[id]/page.tsx
@@ -268,7 +268,7 @@ export default async function ArrangementDetaljer({
             gap: 8,
           }}
         >
-          {kanRedigere && <VarsleNuKnapp arrangementId={id} />}
+          {kanRedigere && <VarsleNuKnapp arrangementId={id} arrangementTittel={arr.tittel} />}
           {kanRedigere && (
             <Link
               href={`/arrangementer/${id}/rediger`}

--- a/lib/actions/arrangementer.ts
+++ b/lib/actions/arrangementer.ts
@@ -8,6 +8,7 @@ import { getProfil } from '@/lib/auth-cache'
 import { kanAdministrere } from '@/lib/roller'
 import { naa } from '@/lib/dato'
 import { r2StiFraUrl, slettR2 } from '@/lib/r2'
+import { VARSLE_MAKS_LENGDE } from '@/lib/konstanter'
 
 export type ArrangementInput = {
   type: 'moete' | 'tur'
@@ -170,10 +171,18 @@ export async function oppdaterArrangement(id: string, data: Partial<ArrangementI
   revalidatePath('/arrangoransvar')
 }
 
-export async function varslOmArrangement(arrangementId: string) {
+// hilsen er valgfri fri tekst fra avsender — valideres server-side mot
+// VARSLE_MAKS_LENGDE slik at klient-maxLength aldri er eneste sperre. Se #282.
+export async function varslOmArrangement(arrangementId: string, hilsen?: string) {
   const supabase = await createServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) throw new Error('Ikke innlogget')
+
+  const trimmetHilsen = hilsen?.trim()
+
+  if (trimmetHilsen && trimmetHilsen.length > VARSLE_MAKS_LENGDE) {
+    throw new Error(`Hilsen kan ikke være lengre enn ${VARSLE_MAKS_LENGDE} tegn`)
+  }
 
   const { data: arrangement } = await supabase
     .from('arrangementer')
@@ -189,11 +198,25 @@ export async function varslOmArrangement(arrangementId: string) {
   const erOpprettet = arrangement.opprettet_av === user.id
   if (!erAdmin && !erOpprettet) throw new Error('Ikke tilgang')
 
-  // Send én oppdatert-varsling til alle
+  // Hent avsenders visningsnavn hvis hilsen er oppgitt — samme mønster
+  // som purreAnsvarlig i lib/actions/arrangoransvar.ts
+  let fraNavn: string | undefined
+  if (trimmetHilsen) {
+    const { data: avsender } = await supabase
+      .from('profiles')
+      .select('navn, visningsnavn')
+      .eq('id', user.id)
+      .single()
+    fraNavn = avsender?.visningsnavn || avsender?.navn || 'En gutt'
+  }
+
+  // Send én oppdatert-varsling til alle — med eller uten hilsen
   await sendOppdatertVarsler({
     arrangementId: arrangement.id,
     tittel: arrangement.tittel,
     startTidspunkt: arrangement.start_tidspunkt,
+    fraNavn,
+    hilsen: trimmetHilsen,
   })
 
   revalidatePath(`/arrangementer/${arrangementId}`)

--- a/lib/konstanter.ts
+++ b/lib/konstanter.ts
@@ -50,3 +50,8 @@ export const CHAT_NAER_BUNN_TERSKEL_PX = 150
 // fordi hilsenen ikke lagres i DB — den går rett inn i sendVarsel-
 // meldingen. De to grensene kan utvikle seg uavhengig. Se #267.
 export const PURRING_MAKS_LENGDE = 500
+
+// Maks tegn i valgfri hilsen ved varsling om arrangement.
+// Tilfeldigvis samme verdi som PURRING_MAKS_LENGDE — semantisk separat
+// så de to grensene kan utvikle seg uavhengig. Se #282.
+export const VARSLE_MAKS_LENGDE = 500

--- a/lib/varsler.ts
+++ b/lib/varsler.ts
@@ -285,6 +285,11 @@ export async function sendOppdatertVarsler({
 }) {
   const dato = formaterDatoKlokke(startTidspunkt)
   const trimmet = hilsen?.trim()
+  // Defensiv: hilsen uten avsender ville falle stille tilbake til standardteksten
+  // og forvirre fremtidige kallere. Krev at de oppgis sammen.
+  if (trimmet && !fraNavn) {
+    throw new Error('fraNavn må oppgis sammen med hilsen')
+  }
   // Med hilsen: personlig melding med avsender og tekst.
   // Uten hilsen: standard stille oppdateringsmelding (bakoverkompatibel).
   const melding = trimmet && fraNavn

--- a/lib/varsler.ts
+++ b/lib/varsler.ts
@@ -271,15 +271,28 @@ export async function sendOppdatertVarsler({
   arrangementId,
   tittel,
   startTidspunkt,
+  fraNavn,
+  hilsen,
 }: {
   arrangementId: string
   tittel: string
   startTidspunkt: string
+  // Valgfri avsender og hilsen — satt når admin/arrangør varsler manuelt
+  // via VarsleNuKnapp-modalen (#282). Uten disse to beholdes dagens
+  // stille «Arrangement oppdatert»-melding.
+  fraNavn?: string
+  hilsen?: string
 }) {
   const dato = formaterDatoKlokke(startTidspunkt)
+  const trimmet = hilsen?.trim()
+  // Med hilsen: personlig melding med avsender og tekst.
+  // Uten hilsen: standard stille oppdateringsmelding (bakoverkompatibel).
+  const melding = trimmet && fraNavn
+    ? `${fraNavn} varsler om ${tittel} (${dato}) og skriver: «${trimmet}»`
+    : `${tittel} — ${dato}`
   await sendVarsel({
     tittel: 'Arrangement oppdatert',
-    melding: `${tittel} — ${dato}`,
+    melding,
     url: `${BASE_URL}/arrangementer/${arrangementId}`,
     type: 'oppdatert',
     arrangementId,

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 80,
-  "versjon": "V3.1.80"
+  "nummer": 81,
+  "versjon": "V3.1.81"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 79,
-  "versjon": "V3.1.79"
+  "nummer": 80,
+  "versjon": "V3.1.80"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 81,
-  "versjon": "V3.1.81"
+  "nummer": 82,
+  "versjon": "V3.1.82"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.81'
+const CACHE_VERSION = 'V3.1.82'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.79'
+const CACHE_VERSION = 'V3.1.80'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.1.80'
+const CACHE_VERSION = 'V3.1.81'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
## Sammendrag
- «Varsle»-knappen på arrangement-detaljsiden åpner nå en modal med valgfri hilsen-tekst i stedet for å sende rett.
- Tom melding = uendret varseloppførsel (`{tittel} — {dato}`). Tekst = «{avsender} varsler om {tittel} ({dato}) og skriver: «{hilsen}»».
- Direkte parallell til #267-mønsteret for purreknappen.

## Beslutninger underveis
- Egen konstant `VARSLE_MAKS_LENGDE = 500` (semantisk separat fra `PURRING_MAKS_LENGDE`).
- Avsendernavn bare hentet når hilsen finnes — bevarer eksisterende push-tekst eksakt for de som vil varsle stille.
- Defensiv throw hvis fremtidig kaller sender hilsen uten fraNavn.

Lukker #282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)