### PR TITLE
Vis liste-modal viser alle svar gruppert (#285)

### DIFF
--- a/app/(app)/arrangementer/[id]/page.tsx
+++ b/app/(app)/arrangementer/[id]/page.tsx
@@ -10,7 +10,7 @@ import RsvpBlokk from '@/components/arrangement/RsvpBlokk'
 import VarsleNuKnapp from './VarsleNuKnapp'
 import Chat from '@/components/chat/Chat'
 import PassListe, { type PassListeDeltaker } from '@/components/arrangement/PassListe'
-import PaameldteListe from '@/components/arrangement/PaameldteListe'
+import PaameldteListe, { type RsvpStatus } from '@/components/arrangement/PaameldteListe'
 import AlbumSeksjon from '@/components/album/AlbumSeksjon'
 import { formaterDato } from '@/lib/dato'
 import { kanAdministrere } from '@/lib/roller'
@@ -500,19 +500,46 @@ export default async function ArrangementDetaljer({
           </>
         )}
 
-        {/* Påmeldt-seksjon.
-            Bygg den filtrerte listen FØR vi tegner — slik at antall-badgen i headeren og
-            antall avatarer i raden alltid stemmer overens (se review-funn til #272). */}
+        {/* Påmeldt-seksjon (#285).
+            Bygg jaListe (avatar-raden) og alleSvar (modalen) FØR vi tegner —
+            slik at antall-badgen i headeren alltid stemmer overens (se #272).
+            alleSvar itererer chatProfiler (alle aktive medlemmer) og slår opp
+            status fra paameldinger — default 'ikke_svart' ved manglende rad. */}
         {(() => {
-          const paameldteMedNavn = jaListe
+          // Slå opp status per profil_id fra paameldinger-lista
+          const statusMap = new Map<string, RsvpStatus>()
+          for (const p of paameldinger) {
+            const s = p.status as RsvpStatus
+            if (s === 'ja' || s === 'kanskje' || s === 'nei') statusMap.set(p.profil_id, s)
+          }
+
+          // jaListeMedNavn: kun ja-folk med navn — driver avatar-raden (uendret)
+          const jaListeMedNavn = jaListe
             .filter(p => p.profiles?.navn)
             .map(p => ({
               profil_id: p.profil_id,
-              navn: p.profiles?.navn ?? '?', // ?? '?' beholdt for type-narrowing — filter over sikrer at den aldri trigger
+              navn: p.profiles?.navn ?? '?', // ?? '?' beholdt for type-narrowing
               bilde_url: p.profiles?.bilde_url ?? null,
               rolle: p.profiles?.rolle ?? null,
+              status: 'ja' as RsvpStatus,
             }));
-          if (paameldteMedNavn.length === 0) return null;
+
+          // alleSvar: alle aktive medlemmer med navn, status default 'ikke_svart'.
+          // Bruker chatProfiler som kilde fordi den allerede er hentet for Chat-komponenten.
+          const alleSvar = (chatProfiler ?? [])
+            .filter(p => p.navn)
+            .map(p => ({
+              profil_id: p.id,
+              navn: p.navn ?? '?', // ?? '?' for type-narrowing — filter over sikrer at den aldri trigger
+              bilde_url: p.bilde_url ?? null,
+              rolle: p.rolle ?? null,
+              status: statusMap.get(p.id) ?? ('ikke_svart' as RsvpStatus),
+            }));
+
+          // Vis seksjonen så lenge det finnes aktive medlemmer (#285).
+          // Tidligere ble seksjonen skjult hvis ingen hadde sagt ja — men det
+          // hindret brukeren i å se hvem som IKKE hadde svart ennå.
+          if (alleSvar.length === 0) return null;
           return (
             <>
               <div
@@ -530,11 +557,11 @@ export default async function ArrangementDetaljer({
                 }}
               >
                 <span>Påmeldt</span>
-                <span style={{ color: 'var(--text-secondary)' }}>{paameldteMedNavn.length}</span>
+                <span style={{ color: 'var(--text-secondary)' }}>{jaListeMedNavn.length}</span>
                 <span style={{ flex: 1, height: '0.5px', background: 'var(--border-subtle)' }} />
               </div>
-              {/* Avatar-rad + modal — klikk åpner alfabetisk liste (#272). */}
-              <PaameldteListe paameldinger={paameldteMedNavn} />
+              {/* Avatar-rad (ja-folk) + modal (alle svar gruppert etter status, #285). */}
+              <PaameldteListe jaListe={jaListeMedNavn} alleSvar={alleSvar} />
             </>
           );
         })()}

--- a/app/(app)/arrangementer/[id]/page.tsx
+++ b/app/(app)/arrangementer/[id]/page.tsx
@@ -70,6 +70,9 @@ export default async function ArrangementDetaljer({
       .eq('arrangement_id', id)
       .order('opprettet', { ascending: false })
       .limit(30),
+    // chatProfiler: alle aktive medlemmer. Navnet kommer fra at den primært
+    // brukes som profil-oppslag for Chat-komponenten, men brukes også til
+    // RSVP-listen (alleSvar) i #285 for å vise hvem som ikke har svart.
     supabase
       .from('profiles')
       .select('id, navn, bilde_url, rolle')

--- a/app/globals.css
+++ b/app/globals.css
@@ -38,6 +38,9 @@
   --danger-alt: #e87060;
   --danger-soft: rgba(200, 90, 80, 0.14);
   --danger-border: rgba(200, 90, 80, 0.34);
+  --warning: #e8a96b;
+  --warning-soft: rgba(230, 160, 100, 0.14);
+  --warning-border: rgba(230, 160, 100, 0.34);
 
   /* Fonter */
   --font-display: var(--font-instrument), Georgia, serif;

--- a/components/arrangement/PaameldteListe.tsx
+++ b/components/arrangement/PaameldteListe.tsx
@@ -276,20 +276,24 @@ export default function PaameldteListe({ jaListe, alleSvar }: Props) {
                 const glyphNavn = STATUS_GLYPH[status]
                 return (
                   <div key={status}>
-                    {/* Sticky gruppe-header — henger igjen ved scroll innen containeren */}
+                    {/* Sticky gruppe-header — henger igjen ved scroll innen containeren.
+                        backgroundColor må være fullt opak slik at 40px avatarer og
+                        24px glyph-slot ikke peeker gjennom (iOS Safari særlig). Økt
+                        bunn-padding gir luft mellom tekst og første avatar under scroll.
+                        boxShadow erstatter borderBottom for å unngå 0.5px-hopp ved
+                        sub-pixel rendering. */}
                     <div
                       style={{
                         position: 'sticky',
                         top: 0,
-                        background: 'var(--bg-elevated)',
-                        padding: '12px 20px 6px',
+                        backgroundColor: 'var(--bg-elevated)',
+                        padding: '10px 20px 8px',
                         fontFamily: 'var(--font-mono)',
                         fontSize: 10,
                         textTransform: 'uppercase',
                         letterSpacing: '1.4px',
                         color: meta.farge,
-                        // Subtil skillelinje under header
-                        borderBottom: '0.5px solid var(--border-subtle)',
+                        boxShadow: '0 1px 0 var(--border-subtle)',
                       }}
                     >
                       {meta.label} ({personer.length})
@@ -300,6 +304,9 @@ export default function PaameldteListe({ jaListe, alleSvar }: Props) {
                         key={p.profil_id}
                         href={`/klubbinfo/medlemmer/${p.profil_id}`}
                         onClick={() => setModalAapen(false)}
+                        // aria-label kombinerer navn + status så skjermlesere får
+                        // formidlet RSVP-svaret — ellers leses bare navnet.
+                        aria-label={`${p.navn}, ${meta.label}`}
                         style={{
                           display: 'flex',
                           alignItems: 'center',
@@ -320,7 +327,8 @@ export default function PaameldteListe({ jaListe, alleSvar }: Props) {
                         >
                           {p.navn}
                         </span>
-                        {/* Status-sirkel med glyph mellom navn og chevron (#285) */}
+                        {/* Naken glyph i fast 24x24 layout-slot mellom navn og chevron
+                            (#285). Ingen bakgrunn/border — bare glyph i meta.farge. */}
                         <span
                           style={{
                             width: 24,
@@ -328,7 +336,6 @@ export default function PaameldteListe({ jaListe, alleSvar }: Props) {
                             display: 'flex',
                             alignItems: 'center',
                             justifyContent: 'center',
-                            borderRadius: '50%',
                             flexShrink: 0,
                             color: meta.farge,
                           }}

--- a/components/arrangement/PaameldteListe.tsx
+++ b/components/arrangement/PaameldteListe.tsx
@@ -1,28 +1,55 @@
 'use client'
 
-// PaameldteListe — viser avatar-rad over påmeldte (status=ja).
-// Hver avatar er en <Link> direkte til medlemsprofilen. Ved siden av står en
-// «Vis liste»-knapp som åpner modal med komplett alfabetisk liste — alltid
-// tilgjengelig uavhengig av antall påmeldte (#280). Tidligere ble knappen
-// kun rendret ved overflow, men det skjulte navnelisten på små arrangementer.
+// PaameldteListe — viser avatar-rad over påmeldte (status=ja) og en «Vis liste»-knapp
+// som åpner modal med ALLE aktive medlemmer gruppert etter RSVP-status (#285).
+// Avatar-raden er uendret — den viser kun ja-folk via jaListe-prop.
+// Modal-innholdet drives av alleSvar-prop som inkluderer ikke-svart.
 
 import { useEffect, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
 import Avatar from '@/components/ui/Avatar'
+import RsvpGlyph from '@/components/arrangement/RsvpGlyph'
+
+export type RsvpStatus = 'ja' | 'kanskje' | 'nei' | 'ikke_svart'
 
 export type PaameldtPerson = {
   profil_id: string
   navn: string
   bilde_url: string | null
   rolle: string | null
+  status: RsvpStatus
 }
 
-// Maks antall avatarer som vises i raden. Resten oppsummeres som "+ N til" og
-// trigger modal-modus. Holdes lokal — vurdert flyttet til lib/konstanter.ts, men
-// brukes kun her og er tett knyttet til layout-valg i denne komponenten.
+type Props = {
+  // jaListe: kun ja-folk — driver avatar-raden og «+ N til»-pillen (uendret)
+  jaListe: PaameldtPerson[]
+  // alleSvar: alle aktive medlemmer med status — driver modalen (#285)
+  alleSvar: PaameldtPerson[]
+}
+
+// Maks antall avatarer som vises i raden. Resten oppsummeres som «+ N til».
+// Holdes lokal — tett knyttet til layout-valg i denne komponenten.
 const MAKS_I_RAD = 6
 
-export default function PaameldteListe({ paameldinger }: { paameldinger: PaameldtPerson[] }) {
+// Rekkefølge og visningsnavn for statusgruppene i modalen.
+// Rekkefølgen her avgjør render-rekkefølgen (ja øverst, ikke_svart nederst).
+const GRUPPE_META: Record<RsvpStatus, { label: string; farge: string }> = {
+  ja: { label: 'Ja', farge: 'var(--success)' },
+  kanskje: { label: 'Kanskje', farge: 'var(--warning)' },
+  nei: { label: 'Nei', farge: 'var(--danger)' },
+  ikke_svart: { label: 'Ikke svart', farge: 'var(--text-tertiary)' },
+}
+const GRUPPE_REKKEFØLGE: RsvpStatus[] = ['ja', 'kanskje', 'nei', 'ikke_svart']
+
+// Glyph som korresponderer til hver RSVP-status — vist i raden ved siden av navn.
+const STATUS_GLYPH: Record<RsvpStatus, React.ComponentProps<typeof RsvpGlyph>['name']> = {
+  ja: 'check',
+  kanskje: 'question',
+  nei: 'x',
+  ikke_svart: 'dash',
+}
+
+export default function PaameldteListe({ jaListe, alleSvar }: Props) {
   const [modalAapen, setModalAapen] = useState(false)
   const dialogRef = useRef<HTMLDivElement>(null)
   const triggerRef = useRef<HTMLElement | null>(null)
@@ -30,12 +57,26 @@ export default function PaameldteListe({ paameldinger }: { paameldinger: Paameld
   // Intl.Collator er raskere enn localeCompare i loop og gir konsistent sortering
   // på tvers av kall. Sekundær-sort på profil_id sikrer stabil rekkefølge ved like navn.
   const collator = useMemo(() => new Intl.Collator('nb'), [])
-  const jaListe = useMemo(() => {
-    return [...paameldinger].sort((a, b) => {
+
+  // jaListeSortert: avatarrad + «+ N til»-pill (kun ja, alfabetisk)
+  const jaListeSortert = useMemo(() => {
+    return [...jaListe].sort((a, b) => {
       const cmp = collator.compare(a.navn, b.navn)
       return cmp !== 0 ? cmp : a.profil_id.localeCompare(b.profil_id)
     })
-  }, [paameldinger, collator])
+  }, [jaListe, collator])
+
+  // grupper: alleSvar gruppert per status, alfabetisk innen hver gruppe
+  const grupper = useMemo(() => {
+    const sorted = [...alleSvar].sort((a, b) => {
+      const cmp = collator.compare(a.navn, b.navn)
+      return cmp !== 0 ? cmp : a.profil_id.localeCompare(b.profil_id)
+    })
+    const map = new Map<RsvpStatus, PaameldtPerson[]>()
+    for (const s of GRUPPE_REKKEFØLGE) map.set(s, [])
+    for (const p of sorted) map.get(p.status)?.push(p)
+    return map
+  }, [alleSvar, collator])
 
   // Escape-tast lukker modalen. body-overflow hindrer scroll bak modalen,
   // særlig viktig på iOS hvor scroll-chain lett lekker gjennom overlay.
@@ -49,21 +90,22 @@ export default function PaameldteListe({ paameldinger }: { paameldinger: Paameld
     document.addEventListener('keydown', onKey)
     const forrigeOverflow = document.body.style.overflow
     document.body.style.overflow = 'hidden'
-    // Lagre forrige fokus og flytt fokus til dialogen
     triggerRef.current = document.activeElement as HTMLElement | null
     dialogRef.current?.focus()
     return () => {
       document.removeEventListener('keydown', onKey)
       document.body.style.overflow = forrigeOverflow
-      // Returnér fokus til triggeren (typisk knappen som åpnet modalen)
       triggerRef.current?.focus?.()
     }
   }, [modalAapen])
 
-  if (jaListe.length === 0) return null
+  // Vises kun hvis det finnes aktive medlemmer (alleSvar.length > 0).
+  // Tidligere ble seksjonen skjult hvis ingen hadde sagt ja — men det ga en
+  // «tom» opplevelse for bruker. Nå vises alltid modalen med «Ikke svart»-gjengen. (#285)
+  if (alleSvar.length === 0) return null
 
-  const synligeAvatarer = jaListe.slice(0, MAKS_I_RAD)
-  const antallSkjult = jaListe.length - MAKS_I_RAD
+  const synligeAvatarer = jaListeSortert.slice(0, MAKS_I_RAD)
+  const antallSkjult = jaListeSortert.length - MAKS_I_RAD
   const harOverflow = antallSkjult > 0
 
   return (
@@ -77,7 +119,7 @@ export default function PaameldteListe({ paameldinger }: { paameldinger: Paameld
           marginBottom: 32,
         }}
       >
-        {/* Avatar-rad: per-avatar Link til medlemsprofil. */}
+        {/* Avatar-rad: per-avatar Link til medlemsprofil. Kun ja-folk. */}
         <div style={{ display: 'flex', alignItems: 'center' }}>
           {synligeAvatarer.map((p, i) => (
             <Link
@@ -100,7 +142,7 @@ export default function PaameldteListe({ paameldinger }: { paameldinger: Paameld
           ))}
         </div>
 
-        {/* «+ N til»-pill kun ved overflow. */}
+        {/* «+ N til»-pill kun ved overflow i ja-listen. */}
         {harOverflow && (
           <span
             style={{
@@ -113,7 +155,7 @@ export default function PaameldteListe({ paameldinger }: { paameldinger: Paameld
           </span>
         )}
 
-        {/* «Vis liste»-knapp alltid synlig — uavhengig av antall (#280). */}
+        {/* «Vis liste»-knapp åpner modal med alle svar — alltid synlig (#280, #285). */}
         <button
           type="button"
           onClick={() => setModalAapen(true)}
@@ -136,7 +178,7 @@ export default function PaameldteListe({ paameldinger }: { paameldinger: Paameld
         </button>
       </div>
 
-      {/* Modal: alfabetisk liste over alle påmeldte. Alltid tilgjengelig via «Vis liste». */}
+      {/* Modal: alle aktive medlemmer gruppert etter RSVP-status (#285). */}
       {modalAapen && (
         // Backdrop — klikk utenfor kortet lukker modalen
         <div
@@ -158,7 +200,7 @@ export default function PaameldteListe({ paameldinger }: { paameldinger: Paameld
             ref={dialogRef}
             role="dialog"
             aria-modal="true"
-            aria-label="Påmeldte"
+            aria-label="Svar fra medlemmer"
             tabIndex={-1}
             onClick={e => e.stopPropagation()}
             style={{
@@ -192,7 +234,7 @@ export default function PaameldteListe({ paameldinger }: { paameldinger: Paameld
                 gap: 12,
               }}
             >
-              <span style={{ flex: 1 }}>Påmeldt ({jaListe.length})</span>
+              <span style={{ flex: 1 }}>Svar ({alleSvar.length})</span>
               <button
                 type="button"
                 onClick={() => setModalAapen(false)}
@@ -223,53 +265,98 @@ export default function PaameldteListe({ paameldinger }: { paameldinger: Paameld
               </button>
             </div>
 
-            {/* Scrollbar liste */}
+            {/* Scrollbar liste — gruppert etter status.
+                Kun ikke-tomme grupper rendres. Gruppe-headeren er sticky
+                innen scroll-containeren så den henger igjen ved scroll. */}
             <div style={{ overflowY: 'auto', flex: 1 }}>
-              {jaListe.map((p, i) => (
-                <Link
-                  key={p.profil_id}
-                  href={`/klubbinfo/medlemmer/${p.profil_id}`}
-                  onClick={() => setModalAapen(false)}
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 12,
-                    padding: '12px 20px',
-                    textDecoration: 'none',
-                    // Skillelinje mellom rader: 0.5px border-subtle (ikke første rad)
-                    borderTop: i > 0 ? '0.5px solid var(--border-subtle)' : 'none',
-                  }}
-                >
-                  <Avatar name={p.navn} size={40} src={p.bilde_url} rolle={p.rolle} />
-                  <span
-                    style={{
-                      flex: 1,
-                      fontFamily: 'var(--font-body)',
-                      fontSize: 15,
-                      color: 'var(--text-primary)',
-                    }}
-                  >
-                    {p.navn}
-                  </span>
-                  {/* Chevron som visuell affordance for at raden er klikkbar */}
-                  <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    fill="none"
-                    aria-hidden="true"
-                    style={{ color: 'var(--text-tertiary)', flexShrink: 0 }}
-                  >
-                    <path
-                      d="M6 4l4 4-4 4"
-                      stroke="currentColor"
-                      strokeWidth="1.5"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                </Link>
-              ))}
+              {GRUPPE_REKKEFØLGE.map(status => {
+                const personer = grupper.get(status) ?? []
+                if (personer.length === 0) return null
+                const meta = GRUPPE_META[status]
+                const glyphNavn = STATUS_GLYPH[status]
+                return (
+                  <div key={status}>
+                    {/* Sticky gruppe-header — henger igjen ved scroll innen containeren */}
+                    <div
+                      style={{
+                        position: 'sticky',
+                        top: 0,
+                        background: 'var(--bg-elevated)',
+                        padding: '12px 20px 6px',
+                        fontFamily: 'var(--font-mono)',
+                        fontSize: 10,
+                        textTransform: 'uppercase',
+                        letterSpacing: '1.4px',
+                        color: meta.farge,
+                        // Subtil skillelinje under header
+                        borderBottom: '0.5px solid var(--border-subtle)',
+                      }}
+                    >
+                      {meta.label} ({personer.length})
+                    </div>
+                    {/* Rader i gruppen */}
+                    {personer.map((p, i) => (
+                      <Link
+                        key={p.profil_id}
+                        href={`/klubbinfo/medlemmer/${p.profil_id}`}
+                        onClick={() => setModalAapen(false)}
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 12,
+                          padding: '12px 20px',
+                          textDecoration: 'none',
+                          borderTop: i > 0 ? '0.5px solid var(--border-subtle)' : 'none',
+                        }}
+                      >
+                        <Avatar name={p.navn} size={40} src={p.bilde_url} rolle={p.rolle} />
+                        <span
+                          style={{
+                            flex: 1,
+                            fontFamily: 'var(--font-body)',
+                            fontSize: 15,
+                            color: 'var(--text-primary)',
+                          }}
+                        >
+                          {p.navn}
+                        </span>
+                        {/* Status-sirkel med glyph mellom navn og chevron (#285) */}
+                        <span
+                          style={{
+                            width: 24,
+                            height: 24,
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            borderRadius: '50%',
+                            flexShrink: 0,
+                            color: meta.farge,
+                          }}
+                        >
+                          <RsvpGlyph name={glyphNavn} color={meta.farge} size={14} />
+                        </span>
+                        {/* Chevron som visuell affordance for at raden er klikkbar */}
+                        <svg
+                          width="16"
+                          height="16"
+                          viewBox="0 0 16 16"
+                          fill="none"
+                          aria-hidden="true"
+                          style={{ color: 'var(--text-tertiary)', flexShrink: 0 }}
+                        >
+                          <path
+                            d="M6 4l4 4-4 4"
+                            stroke="currentColor"
+                            strokeWidth="1.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                        </svg>
+                      </Link>
+                    ))}
+                  </div>
+                )
+              })}
             </div>
           </div>
         </div>

--- a/components/arrangement/RsvpGlyph.tsx
+++ b/components/arrangement/RsvpGlyph.tsx
@@ -13,8 +13,9 @@ export default function RsvpGlyph({
     check: <path d="M5 12l5 5 9-11" />,
     question: <path d="M9 9a3 3 0 116 0c0 2-3 2-3 4M12 18h.01" />,
     x: <path d="M6 6l12 12M18 6L6 18" />,
-    // dash = «ikke svart» — nøytral horisontal strek (#285)
-    dash: <path d="M6 12h12" strokeWidth="2" strokeLinecap="round" />,
+    // dash = «ikke svart» — nøytral horisontal strek (#285).
+    // strokeWidth/strokeLinecap arves fra <svg> — ikke dupliser på path.
+    dash: <path d="M6 12h12" />,
   }
   return (
     <svg

--- a/components/arrangement/RsvpGlyph.tsx
+++ b/components/arrangement/RsvpGlyph.tsx
@@ -1,4 +1,4 @@
-type GlyphNavn = 'check' | 'question' | 'x'
+type GlyphNavn = 'check' | 'question' | 'x' | 'dash'
 
 export default function RsvpGlyph({
   name,
@@ -13,6 +13,8 @@ export default function RsvpGlyph({
     check: <path d="M5 12l5 5 9-11" />,
     question: <path d="M9 9a3 3 0 116 0c0 2-3 2-3 4M12 18h.01" />,
     x: <path d="M6 6l12 12M18 6L6 18" />,
+    // dash = «ikke svart» — nøytral horisontal strek (#285)
+    dash: <path d="M6 12h12" strokeWidth="2" strokeLinecap="round" />,
   }
   return (
     <svg

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 0,
-  "versjon": "V3.2.0"
+  "nummer": 1,
+  "versjon": "V3.2.1"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 1,
-  "versjon": "V3.2.1"
+  "nummer": 2,
+  "versjon": "V3.2.2"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.2.0'
+const CACHE_VERSION = 'V3.2.1'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.2.1'
+const CACHE_VERSION = 'V3.2.2'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
## Sammendrag
- «Vis liste»-modalen viser nå alle aktive medlemmer gruppert etter RSVP-status: Ja (grønn), Kanskje (oransje), Nei (rød), Ikke svart (nøytral).
- Avatar-raden utenfor modalen er uendret — viser fortsatt kun ja-folk.
- Modalen er nå alltid tilgjengelig så lenge minst én aktivt medlem finnes (tidligere skjult når ingen hadde sagt ja).
- Sticky gruppe-header per status med antall, alfabetisk sortering innen hver gruppe.

## Beslutninger underveis
- Ny CSS-variabel `--warning` (varm oransje #e8a96b) introdusert — passet ikke inn i eksisterende success/danger-palette.
- Naken glyph i listen (ikke pill med bakgrunn) — matcher rad-stilen.
- aria-label på rad-Link kommuniserer status til skjermlesere.
- Sticky-header med explicit `backgroundColor` + boxShadow for iOS-Safari-stabilitet.

Lukker #285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)