### PR TITLE
Purre disse-knapp i Ikke svart-gruppen (#287)

### DIFF
--- a/app/(app)/arrangementer/[id]/page.tsx
+++ b/app/(app)/arrangementer/[id]/page.tsx
@@ -563,8 +563,15 @@ export default async function ArrangementDetaljer({
                 <span style={{ color: 'var(--text-secondary)' }}>{jaListeMedNavn.length}</span>
                 <span style={{ flex: 1, height: '0.5px', background: 'var(--border-subtle)' }} />
               </div>
-              {/* Avatar-rad (ja-folk) + modal (alle svar gruppert etter status, #285). */}
-              <PaameldteListe jaListe={jaListeMedNavn} alleSvar={alleSvar} />
+              {/* Avatar-rad (ja-folk) + modal (alle svar gruppert etter status, #285).
+                  kanPurre=kanRedigere slik at kun admin/oppretter ser «Purre disse». (#287) */}
+              <PaameldteListe
+                jaListe={jaListeMedNavn}
+                alleSvar={alleSvar}
+                arrangementId={id}
+                arrangementTittel={arr.tittel}
+                kanPurre={kanRedigere}
+              />
             </>
           );
         })()}

--- a/components/arrangement/PaameldteListe.tsx
+++ b/components/arrangement/PaameldteListe.tsx
@@ -4,11 +4,14 @@
 // som åpner modal med ALLE aktive medlemmer gruppert etter RSVP-status (#285).
 // Avatar-raden er uendret — den viser kun ja-folk via jaListe-prop.
 // Modal-innholdet drives av alleSvar-prop som inkluderer ikke-svart.
+// «Purre disse»-pill i «Ikke svart»-gruppe-headeren for admin/oppretter (#287).
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState, useTransition } from 'react'
 import Link from 'next/link'
 import Avatar from '@/components/ui/Avatar'
 import RsvpGlyph from '@/components/arrangement/RsvpGlyph'
+import { purreUtenSvar } from '@/lib/actions/arrangementer'
+import { PURRING_MAKS_LENGDE } from '@/lib/konstanter'
 
 export type RsvpStatus = 'ja' | 'kanskje' | 'nei' | 'ikke_svart'
 
@@ -25,6 +28,11 @@ type Props = {
   jaListe: PaameldtPerson[]
   // alleSvar: alle aktive medlemmer med status — driver modalen (#285)
   alleSvar: PaameldtPerson[]
+  // Arrangement-info og tilgangssjekk for «Purre disse»-knappen (#287)
+  arrangementId: string
+  arrangementTittel: string
+  // kanPurre: true for admin og oppretter — vises ikke for vanlige medlemmer
+  kanPurre: boolean
 }
 
 // Maks antall avatarer som vises i raden. Resten oppsummeres som «+ N til».
@@ -49,10 +57,22 @@ const STATUS_GLYPH: Record<RsvpStatus, React.ComponentProps<typeof RsvpGlyph>['n
   ikke_svart: 'dash',
 }
 
-export default function PaameldteListe({ jaListe, alleSvar }: Props) {
+export default function PaameldteListe({ jaListe, alleSvar, arrangementId, arrangementTittel, kanPurre }: Props) {
   const [modalAapen, setModalAapen] = useState(false)
   const dialogRef = useRef<HTMLDivElement>(null)
   const triggerRef = useRef<HTMLElement | null>(null)
+
+  // Purre-modal state — søsken til hovedmodalen slik at de aldri er åpne
+  // samtidig. Lukk hoved → åpne purre ved klikk på «Purre disse». (#287)
+  const [purreModalAapen, setPurreModalAapen] = useState(false)
+  const [purreMelding, setPurreMelding] = useState('')
+  const [purrePending, startPurreTransition] = useTransition()
+  const [purreSendt, setPurreSendt] = useState(false)
+  const [purreFeil, setPurreFeil] = useState('')
+  // Synkron guard mot dobbelklikk — settes før useTransition rekker å markere pending.
+  const purreSendingRef = useRef(false)
+  // Focus-retur: snapshot av trigger-knappen ved åpning av purre-modal.
+  const purreTriggerRef = useRef<HTMLElement | null>(null)
 
   // Intl.Collator er raskere enn localeCompare i loop og gir konsistent sortering
   // på tvers av kall. Sekundær-sort på profil_id sikrer stabil rekkefølge ved like navn.
@@ -98,6 +118,53 @@ export default function PaameldteListe({ jaListe, alleSvar }: Props) {
       triggerRef.current?.focus?.()
     }
   }, [modalAapen])
+
+  // Samme fokus/scroll-lock-mønster for purre-modalen. (#287)
+  useEffect(() => {
+    if (!purreModalAapen) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape' && !purrePending) setPurreModalAapen(false)
+    }
+    document.addEventListener('keydown', onKey)
+    const forrigeOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    const triggerNode = purreTriggerRef.current
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.body.style.overflow = forrigeOverflow
+      triggerNode?.focus?.()
+    }
+  }, [purreModalAapen, purrePending])
+
+  function aapnePurreModal() {
+    // Lukk hoved-modalen først, åpne purre-modalen direkte. (#287)
+    purreTriggerRef.current = document.activeElement as HTMLElement | null
+    setModalAapen(false)
+    setPurreFeil('')
+    setPurreMelding('')
+    setPurreModalAapen(true)
+  }
+
+  function lukkPurreModal() {
+    if (purrePending) return
+    setPurreModalAapen(false)
+  }
+
+  function handlePurreSend() {
+    if (purreSendingRef.current) return
+    purreSendingRef.current = true
+    startPurreTransition(async () => {
+      try {
+        await purreUtenSvar(arrangementId, purreMelding.trim() || undefined)
+        setPurreSendt(true)
+        setPurreModalAapen(false)
+      } catch (err) {
+        setPurreFeil(err instanceof Error ? err.message : 'Kunne ikke sende purring')
+      } finally {
+        purreSendingRef.current = false
+      }
+    })
+  }
 
   // Vises kun hvis det finnes aktive medlemmer (alleSvar.length > 0).
   // Tidligere ble seksjonen skjult hvis ingen hadde sagt ja — men det ga en
@@ -294,9 +361,36 @@ export default function PaameldteListe({ jaListe, alleSvar }: Props) {
                         letterSpacing: '1.4px',
                         color: meta.farge,
                         boxShadow: '0 1px 0 var(--border-subtle)',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 8,
                       }}
                     >
-                      {meta.label} ({personer.length})
+                      <span style={{ flex: 1 }}>{meta.label} ({personer.length})</span>
+                      {/* «Purre disse»-pill: kun synlig for admin/oppretter når gruppen ikke er tom.
+                          Manuell purring ignorerer cron-bryteren purring_aktiv — admin vet hva han gjør. (#287) */}
+                      {status === 'ikke_svart' && kanPurre && (
+                        <button
+                          type="button"
+                          onClick={aapnePurreModal}
+                          disabled={purreSendt}
+                          style={{
+                            fontFamily: 'var(--font-mono)',
+                            fontSize: 10,
+                            letterSpacing: '1.2px',
+                            textTransform: 'uppercase',
+                            color: purreSendt ? 'var(--success)' : 'var(--accent)',
+                            background: 'var(--accent-soft)',
+                            border: '0.5px solid var(--accent)',
+                            borderRadius: 999,
+                            padding: '4px 10px',
+                            cursor: purreSendt ? 'default' : 'pointer',
+                            flexShrink: 0,
+                          }}
+                        >
+                          {purreSendt ? 'Purret' : 'Purre disse'}
+                        </button>
+                      )}
                     </div>
                     {/* Rader i gruppen */}
                     {personer.map((p, i) => (
@@ -364,6 +458,160 @@ export default function PaameldteListe({ jaListe, alleSvar }: Props) {
                   </div>
                 )
               })}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Purre-modal — søsken til hoved-modalen, aldri åpne samtidig. (#287)
+          Samme overlay- og dialog-mønster som VarsleNuKnapp og PurreKnapp. */}
+      {purreModalAapen && (
+        <div
+          onClick={lukkPurreModal}
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(0,0,0,0.5)',
+            zIndex: 100,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '0 20px',
+          }}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label={`Purre de som ikke har svart på ${arrangementTittel}`}
+            onClick={e => e.stopPropagation()}
+            style={{
+              width: '100%',
+              maxWidth: 360,
+              background: 'var(--bg-elevated)',
+              border: '0.5px solid var(--border)',
+              borderRadius: 16,
+              padding: 20,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 12,
+            }}
+          >
+            <div
+              style={{
+                fontFamily: 'var(--font-display)',
+                fontSize: 20,
+                fontWeight: 500,
+                letterSpacing: '-0.2px',
+                color: 'var(--text-primary)',
+              }}
+            >
+              Purre disse
+            </div>
+
+            <p
+              style={{
+                fontFamily: 'var(--font-body)',
+                fontSize: 13,
+                color: 'var(--text-tertiary)',
+                margin: 0,
+                lineHeight: 1.5,
+              }}
+            >
+              Skriv en valgfri hilsen til de som ikke har svart på {arrangementTittel}, eller bare send.
+            </p>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <textarea
+                value={purreMelding}
+                onChange={e => setPurreMelding(e.target.value)}
+                maxLength={PURRING_MAKS_LENGDE}
+                placeholder="Valgfritt: en hilsen til gutta…"
+                rows={3}
+                autoFocus
+                style={{
+                  fontFamily: 'var(--font-body)',
+                  fontSize: 14,
+                  color: 'var(--text-primary)',
+                  background: 'var(--bg-base)',
+                  border: '0.5px solid var(--border)',
+                  borderRadius: 10,
+                  padding: '10px 12px',
+                  resize: 'none',
+                  outline: 'none',
+                  width: '100%',
+                  boxSizing: 'border-box',
+                  lineHeight: 1.5,
+                }}
+              />
+              <span
+                style={{
+                  fontFamily: 'var(--font-body)',
+                  fontSize: 11,
+                  color: 'var(--text-tertiary)',
+                  alignSelf: 'flex-end',
+                }}
+              >
+                {purreMelding.length}/{PURRING_MAKS_LENGDE}
+              </span>
+            </div>
+
+            {purreFeil && (
+              <p
+                role="alert"
+                style={{
+                  fontFamily: 'var(--font-body)',
+                  fontSize: 13,
+                  color: 'var(--danger)',
+                  margin: 0,
+                  lineHeight: 1.5,
+                }}
+              >
+                {purreFeil}
+              </p>
+            )}
+
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+              <button
+                type="button"
+                onClick={lukkPurreModal}
+                disabled={purrePending}
+                style={{
+                  padding: '8px 16px',
+                  borderRadius: 999,
+                  background: 'transparent',
+                  border: '0.5px solid var(--border)',
+                  color: 'var(--text-secondary)',
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 10,
+                  fontWeight: 600,
+                  letterSpacing: '1.4px',
+                  textTransform: 'uppercase',
+                  cursor: 'pointer',
+                }}
+              >
+                Avbryt
+              </button>
+              <button
+                type="button"
+                onClick={handlePurreSend}
+                disabled={purrePending}
+                style={{
+                  padding: '8px 16px',
+                  borderRadius: 999,
+                  background: 'var(--accent)',
+                  border: 'none',
+                  color: '#0a0a0a',
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 10,
+                  fontWeight: 600,
+                  letterSpacing: '1.4px',
+                  textTransform: 'uppercase',
+                  cursor: purrePending ? 'default' : 'pointer',
+                  opacity: purrePending ? 0.7 : 1,
+                }}
+              >
+                {purrePending ? 'Sender…' : 'Send purring'}
+              </button>
             </div>
           </div>
         </div>

--- a/components/arrangement/PaameldteListe.tsx
+++ b/components/arrangement/PaameldteListe.tsx
@@ -120,10 +120,16 @@ export default function PaameldteListe({ jaListe, alleSvar, arrangementId, arran
   }, [modalAapen])
 
   // Samme fokus/scroll-lock-mønster for purre-modalen. (#287)
+  // Effekten avhenger KUN av purreModalAapen — ikke purrePending. Hvis vi
+  // hadde lagt pending i dep-listen ville cleanup kjørt midt under sending
+  // (når useTransition flipper pending), restore body-overflow og forsøkt
+  // focus-retur mens modalen fortsatt er åpen. Escape-gating gjøres derfor
+  // via purreSendingRef (synkron flagg), samme mønster som VarsleNuKnapp
+  // etter #282-fiksen.
   useEffect(() => {
     if (!purreModalAapen) return
     function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape' && !purrePending) setPurreModalAapen(false)
+      if (e.key === 'Escape' && !purreSendingRef.current) setPurreModalAapen(false)
     }
     document.addEventListener('keydown', onKey)
     const forrigeOverflow = document.body.style.overflow
@@ -144,7 +150,7 @@ export default function PaameldteListe({ jaListe, alleSvar, arrangementId, arran
         document.body.focus?.()
       }
     }
-  }, [purreModalAapen, purrePending])
+  }, [purreModalAapen])
 
   function aapnePurreModal() {
     // Lukk hoved-modalen først, åpne purre-modalen direkte. (#287)
@@ -385,10 +391,17 @@ export default function PaameldteListe({ jaListe, alleSvar, arrangementId, arran
                           over), men eksplisitt sjekk leser tydeligere enn implisitt avhengighet. (#287)
                           Manuell purring ignorerer cron-bryteren purring_aktiv — admin vet hva han gjør. */}
                       {status === 'ikke_svart' && kanPurre && personer.length > 0 && (
+                        // Pillen disables KUN under aktiv sending (purrePending).
+                        // Etter sending viser vi «Purret» som tekst-state i en kort
+                        // periode, men pillen er klikkbar igjen — admin kan åpne
+                        // modalen og purre på nytt (aapnePurreModal nullstiller
+                        // purreSendt). Tidligere ble pillen permanent disabled
+                        // etter første sending, så admin var låst ute fra å sende
+                        // ny purring uten å laste siden på nytt.
                         <button
                           type="button"
                           onClick={aapnePurreModal}
-                          disabled={purreSendt}
+                          disabled={purrePending}
                           style={{
                             fontFamily: 'var(--font-mono)',
                             fontSize: 10,
@@ -399,7 +412,7 @@ export default function PaameldteListe({ jaListe, alleSvar, arrangementId, arran
                             border: '0.5px solid var(--accent)',
                             borderRadius: 999,
                             padding: '4px 10px',
-                            cursor: purreSendt ? 'default' : 'pointer',
+                            cursor: purrePending ? 'default' : 'pointer',
                             flexShrink: 0,
                           }}
                         >

--- a/components/arrangement/PaameldteListe.tsx
+++ b/components/arrangement/PaameldteListe.tsx
@@ -132,7 +132,17 @@ export default function PaameldteListe({ jaListe, alleSvar, arrangementId, arran
     return () => {
       document.removeEventListener('keydown', onKey)
       document.body.style.overflow = forrigeOverflow
-      triggerNode?.focus?.()
+      // Focus-retur: trigger-knappen for purre-modalen er pillen INNE i
+      // hoved-modalen, som lukkes samtidig som purre-modalen åpnes. Når purre
+      // lukkes er den DOM-noden derfor borte. Fall tilbake til hoved-modalens
+      // trigger (avatar-raden/«Vis liste»), og til body som siste utvei. (#287)
+      if (triggerNode && document.body.contains(triggerNode)) {
+        triggerNode.focus?.()
+      } else if (triggerRef.current && document.body.contains(triggerRef.current)) {
+        triggerRef.current.focus?.()
+      } else {
+        document.body.focus?.()
+      }
     }
   }, [purreModalAapen, purrePending])
 
@@ -142,6 +152,9 @@ export default function PaameldteListe({ jaListe, alleSvar, arrangementId, arran
     setModalAapen(false)
     setPurreFeil('')
     setPurreMelding('')
+    // Reset «Purret»-tilstanden så admin kan purre igjen senere i økten —
+    // folk svarer over tid, og det er legitimt å purre flere ganger. (#287)
+    setPurreSendt(false)
     setPurreModalAapen(true)
   }
 
@@ -368,8 +381,10 @@ export default function PaameldteListe({ jaListe, alleSvar, arrangementId, arran
                     >
                       <span style={{ flex: 1 }}>{meta.label} ({personer.length})</span>
                       {/* «Purre disse»-pill: kun synlig for admin/oppretter når gruppen ikke er tom.
-                          Manuell purring ignorerer cron-bryteren purring_aktiv — admin vet hva han gjør. (#287) */}
-                      {status === 'ikke_svart' && kanPurre && (
+                          personer.length>0 er strengt tatt overflødig (tomme grupper filtreres bort
+                          over), men eksplisitt sjekk leser tydeligere enn implisitt avhengighet. (#287)
+                          Manuell purring ignorerer cron-bryteren purring_aktiv — admin vet hva han gjør. */}
+                      {status === 'ikke_svart' && kanPurre && personer.length > 0 && (
                         <button
                           type="button"
                           onClick={aapnePurreModal}

--- a/lib/actions/arrangementer.ts
+++ b/lib/actions/arrangementer.ts
@@ -3,12 +3,12 @@
 import { createServerClient } from '@/lib/supabase/server'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
-import { sendNyttArrangementVarsler, sendOppdatertVarsler } from '@/lib/varsler'
+import { sendNyttArrangementVarsler, sendOppdatertVarsler, sendPurringVarsler } from '@/lib/varsler'
 import { getProfil } from '@/lib/auth-cache'
 import { kanAdministrere } from '@/lib/roller'
 import { naa } from '@/lib/dato'
 import { r2StiFraUrl, slettR2 } from '@/lib/r2'
-import { VARSLE_MAKS_LENGDE } from '@/lib/konstanter'
+import { VARSLE_MAKS_LENGDE, PURRING_MAKS_LENGDE } from '@/lib/konstanter'
 
 export type ArrangementInput = {
   type: 'moete' | 'tur'
@@ -220,4 +220,73 @@ export async function varslOmArrangement(arrangementId: string, hilsen?: string)
   })
 
   revalidatePath(`/arrangementer/${arrangementId}`)
+}
+
+// Manuell purring til alle som ikke har svart — trigges av admin/oppretter fra
+// «Vis liste»-modalen via «Purre disse»-knappen. Ignorerer purring_aktiv-bryteren
+// siden dette er en bevisst admin-handling, ikke en cron-jobb. Se #287.
+export async function purreUtenSvar(arrangementId: string, hilsen?: string) {
+  const supabase = await createServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error('Ikke innlogget')
+
+  const trimmetHilsen = hilsen?.trim()
+
+  if (trimmetHilsen && trimmetHilsen.length > PURRING_MAKS_LENGDE) {
+    throw new Error(`Hilsen kan ikke være lengre enn ${PURRING_MAKS_LENGDE} tegn`)
+  }
+
+  const { data: arrangement } = await supabase
+    .from('arrangementer')
+    .select('id, tittel, start_tidspunkt, opprettet_av')
+    .eq('id', arrangementId)
+    .single()
+
+  if (!arrangement) throw new Error('Arrangement ikke funnet')
+
+  // Kun admin eller oppretter kan purre — samme mønster som varslOmArrangement.
+  const profil = await getProfil()
+  const erAdmin = kanAdministrere(profil?.rolle)
+  const erOpprettet = arrangement.opprettet_av === user.id
+  if (!erAdmin && !erOpprettet) throw new Error('Ikke tilgang')
+
+  // Beregn hvem som ikke har svart ennå — hent alle aktive profiler minus de
+  // som har en paameldinger-rad for dette arrangementet.
+  const [{ data: paameldinger }, { data: alleProfiler }] = await Promise.all([
+    supabase
+      .from('paameldinger')
+      .select('profil_id')
+      .eq('arrangement_id', arrangementId),
+    supabase
+      .from('profiles')
+      .select('id')
+      .eq('aktiv', true),
+  ])
+
+  const harSvart = new Set((paameldinger ?? []).map(p => p.profil_id))
+  const utenSvar = (alleProfiler ?? [])
+    .map(p => p.id)
+    .filter(id => !harSvart.has(id))
+
+  if (utenSvar.length === 0) return
+
+  // Hent avsenders visningsnavn hvis hilsen er oppgitt
+  let fraNavn: string | undefined
+  if (trimmetHilsen) {
+    const { data: avsender } = await supabase
+      .from('profiles')
+      .select('navn, visningsnavn')
+      .eq('id', user.id)
+      .single()
+    fraNavn = avsender?.visningsnavn || avsender?.navn || 'En gutt'
+  }
+
+  await sendPurringVarsler({
+    arrangementId: arrangement.id,
+    tittel: arrangement.tittel,
+    startTidspunkt: arrangement.start_tidspunkt,
+    mottakere: utenSvar,
+    fraNavn,
+    hilsen: trimmetHilsen,
+  })
 }

--- a/lib/actions/arrangementer.ts
+++ b/lib/actions/arrangementer.ts
@@ -9,6 +9,7 @@ import { kanAdministrere } from '@/lib/roller'
 import { naa } from '@/lib/dato'
 import { r2StiFraUrl, slettR2 } from '@/lib/r2'
 import { VARSLE_MAKS_LENGDE, PURRING_MAKS_LENGDE } from '@/lib/konstanter'
+import { ensureInnlogget } from '@/lib/auth'
 
 export type ArrangementInput = {
   type: 'moete' | 'tur'
@@ -226,9 +227,7 @@ export async function varslOmArrangement(arrangementId: string, hilsen?: string)
 // «Vis liste»-modalen via «Purre disse»-knappen. Ignorerer purring_aktiv-bryteren
 // siden dette er en bevisst admin-handling, ikke en cron-jobb. Se #287.
 export async function purreUtenSvar(arrangementId: string, hilsen?: string) {
-  const supabase = await createServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error('Ikke innlogget')
+  const { supabase, user } = await ensureInnlogget()
 
   const trimmetHilsen = hilsen?.trim()
 
@@ -250,26 +249,6 @@ export async function purreUtenSvar(arrangementId: string, hilsen?: string) {
   const erOpprettet = arrangement.opprettet_av === user.id
   if (!erAdmin && !erOpprettet) throw new Error('Ikke tilgang')
 
-  // Beregn hvem som ikke har svart ennå — hent alle aktive profiler minus de
-  // som har en paameldinger-rad for dette arrangementet.
-  const [{ data: paameldinger }, { data: alleProfiler }] = await Promise.all([
-    supabase
-      .from('paameldinger')
-      .select('profil_id')
-      .eq('arrangement_id', arrangementId),
-    supabase
-      .from('profiles')
-      .select('id')
-      .eq('aktiv', true),
-  ])
-
-  const harSvart = new Set((paameldinger ?? []).map(p => p.profil_id))
-  const utenSvar = (alleProfiler ?? [])
-    .map(p => p.id)
-    .filter(id => !harSvart.has(id))
-
-  if (utenSvar.length === 0) return
-
   // Hent avsenders visningsnavn hvis hilsen er oppgitt
   let fraNavn: string | undefined
   if (trimmetHilsen) {
@@ -281,12 +260,20 @@ export async function purreUtenSvar(arrangementId: string, hilsen?: string) {
     fraNavn = avsender?.visningsnavn || avsender?.navn || 'En gutt'
   }
 
+  // Vi sender IKKE en pre-beregnet mottakerliste — sendPurringVarsler beregner
+  // utenSvar selv så tett opp mot utsendingen som mulig. Det lukker et TOCTOU-vindu
+  // hvor noen rekker å svare mellom beregning her og utsending der. Vi signaliserer
+  // bare at dette er en manuell admin-handling som skal ignorere cron-bryteren. (#287)
   await sendPurringVarsler({
     arrangementId: arrangement.id,
     tittel: arrangement.tittel,
     startTidspunkt: arrangement.start_tidspunkt,
-    mottakere: utenSvar,
     fraNavn,
     hilsen: trimmetHilsen,
+    ignorerAktivBryter: true,
   })
+
+  // Refresh siden så «Ikke svart»-listen oppdateres hvis noen svarte
+  // i mellomtiden (eller cron har kjørt mellom åpning og sending).
+  revalidatePath(`/arrangementer/${arrangementId}`)
 }

--- a/lib/varsler.ts
+++ b/lib/varsler.ts
@@ -456,35 +456,71 @@ export async function sendPurringVarsler({
   arrangementId,
   tittel,
   startTidspunkt,
+  fraNavn,
+  hilsen,
+  mottakere,
 }: {
   arrangementId: string
   tittel: string
   startTidspunkt: string
+  // Valgfri avsender og hilsen — satt ved manuell purring fra admin/oppretter (#287).
+  // Når disse er oppgitt brukes personlig meldingstekst og purring_aktiv-sjekken hoppes over.
+  fraNavn?: string
+  hilsen?: string
+  // Hvis oppgitt: brukes som mottakerliste direkte — beregning av utenSvar hoppes over.
+  // Brukt av purreUtenSvar() som selv beregner hvem som ikke har svart. (#287)
+  mottakere?: string[]
 }) {
-  if (!(await erVarselAktiv('purring_aktiv'))) return
+  const trimmetHilsen = hilsen?.trim()
+
+  // Defensiv guard: hilsen uten avsender ville gitt en forvirrende melding.
+  if (trimmetHilsen && !fraNavn) {
+    throw new Error('fraNavn må oppgis sammen med hilsen')
+  }
+
+  // Manuell purring (mottakere oppgitt eksplisitt av admin/oppretter) skal ikke gates
+  // av cron-bryteren purring_aktiv — det er en admin-handling, ikke en cron-jobb. (#287)
+  if (!mottakere) {
+    if (!(await erVarselAktiv('purring_aktiv'))) return
+  }
 
   const supabase = createAdminClient()
 
-  const { data: paameldinger } = await supabase
-    .from('paameldinger')
-    .select('profil_id')
-    .eq('arrangement_id', arrangementId)
+  let sendTil: string[]
+  if (mottakere) {
+    // Mottakere er allerede beregnet av kalleren — bruk listen direkte.
+    sendTil = mottakere
+  } else {
+    // Cron-sti: beregn hvem som ikke har svart ennå.
+    const { data: paameldinger } = await supabase
+      .from('paameldinger')
+      .select('profil_id')
+      .eq('arrangement_id', arrangementId)
 
-  const harSvart = new Set((paameldinger ?? []).map(p => p.profil_id))
+    const harSvart = new Set((paameldinger ?? []).map(p => p.profil_id))
+    const profiler = await hentProfiler()
+    sendTil = profiler.filter(p => !harSvart.has(p.id)).map(p => p.id)
+  }
 
-  const profiler = await hentProfiler()
-  const utenSvar = profiler.filter(p => !harSvart.has(p.id))
-  if (utenSvar.length === 0) return
+  if (sendTil.length === 0) return
 
   const dato = formaterDatoKlokke(startTidspunkt)
+  // Personlig melding med avsender og hilsen — ellers standard cron-melding.
+  const melding = trimmetHilsen && fraNavn
+    ? `${fraNavn} purrer deg på ${tittel} (${dato}) og skriver: «${trimmetHilsen}»`
+    : `${tittel} — ${dato}. Du har ikke svart enda.`
+
   await sendVarsel({
-    mottakere: utenSvar.map(p => p.id),
+    mottakere: sendTil,
     tittel: 'Husk å svare!',
-    melding: `${tittel} — ${dato}. Du har ikke svart enda.`,
+    melding,
     url: `${BASE_URL}/arrangementer/${arrangementId}`,
     knappTekst: 'Svar nå',
     type: 'purring',
     arrangementId,
+    // Manuell purring fra admin er en bevisst handling — alltid send uavhengig av
+    // om de allerede har mottatt en cron-purring for dette arrangementet. (#287)
+    tillatDuplikat: !!mottakere,
   })
 }
 

--- a/lib/varsler.ts
+++ b/lib/varsler.ts
@@ -458,18 +458,18 @@ export async function sendPurringVarsler({
   startTidspunkt,
   fraNavn,
   hilsen,
-  mottakere,
+  ignorerAktivBryter = false,
 }: {
   arrangementId: string
   tittel: string
   startTidspunkt: string
   // Valgfri avsender og hilsen — satt ved manuell purring fra admin/oppretter (#287).
-  // Når disse er oppgitt brukes personlig meldingstekst og purring_aktiv-sjekken hoppes over.
+  // Når disse er oppgitt brukes personlig meldingstekst i stedet for cron-meldingen.
   fraNavn?: string
   hilsen?: string
-  // Hvis oppgitt: brukes som mottakerliste direkte — beregning av utenSvar hoppes over.
-  // Brukt av purreUtenSvar() som selv beregner hvem som ikke har svart. (#287)
-  mottakere?: string[]
+  // Manuell admin-purring skal ikke gates av cron-bryteren purring_aktiv — det er
+  // en bevisst handling, ikke en cron-jobb. Default false (cron-sti). (#287)
+  ignorerAktivBryter?: boolean
 }) {
   const trimmetHilsen = hilsen?.trim()
 
@@ -478,29 +478,22 @@ export async function sendPurringVarsler({
     throw new Error('fraNavn må oppgis sammen med hilsen')
   }
 
-  // Manuell purring (mottakere oppgitt eksplisitt av admin/oppretter) skal ikke gates
-  // av cron-bryteren purring_aktiv — det er en admin-handling, ikke en cron-jobb. (#287)
-  if (!mottakere) {
+  if (!ignorerAktivBryter) {
     if (!(await erVarselAktiv('purring_aktiv'))) return
   }
 
+  // Beregn mottakere her — så tett opp mot utsendingen som mulig. Tidligere lot vi
+  // kalleren sende inn en mottakerliste, men det åpnet et TOCTOU-vindu der noen
+  // kunne svare mellom action-beregning og utsending og fortsatt få purring. (#287)
   const supabase = createAdminClient()
+  const { data: paameldinger } = await supabase
+    .from('paameldinger')
+    .select('profil_id')
+    .eq('arrangement_id', arrangementId)
 
-  let sendTil: string[]
-  if (mottakere) {
-    // Mottakere er allerede beregnet av kalleren — bruk listen direkte.
-    sendTil = mottakere
-  } else {
-    // Cron-sti: beregn hvem som ikke har svart ennå.
-    const { data: paameldinger } = await supabase
-      .from('paameldinger')
-      .select('profil_id')
-      .eq('arrangement_id', arrangementId)
-
-    const harSvart = new Set((paameldinger ?? []).map(p => p.profil_id))
-    const profiler = await hentProfiler()
-    sendTil = profiler.filter(p => !harSvart.has(p.id)).map(p => p.id)
-  }
+  const harSvart = new Set((paameldinger ?? []).map(p => p.profil_id))
+  const profiler = await hentProfiler()
+  const sendTil = profiler.filter(p => !harSvart.has(p.id)).map(p => p.id)
 
   if (sendTil.length === 0) return
 
@@ -520,7 +513,7 @@ export async function sendPurringVarsler({
     arrangementId,
     // Manuell purring fra admin er en bevisst handling — alltid send uavhengig av
     // om de allerede har mottatt en cron-purring for dette arrangementet. (#287)
-    tillatDuplikat: !!mottakere,
+    tillatDuplikat: ignorerAktivBryter,
   })
 }
 

--- a/lib/varsler.ts
+++ b/lib/varsler.ts
@@ -486,10 +486,18 @@ export async function sendPurringVarsler({
   // kalleren sende inn en mottakerliste, men det åpnet et TOCTOU-vindu der noen
   // kunne svare mellom action-beregning og utsending og fortsatt få purring. (#287)
   const supabase = createAdminClient()
-  const { data: paameldinger } = await supabase
+  const { data: paameldinger, error: paameldingerFeil } = await supabase
     .from('paameldinger')
     .select('profil_id')
     .eq('arrangement_id', arrangementId)
+
+  // Fail closed: hvis spørringen feiler er harSvart tomt, og uten denne
+  // sjekken ville purringen gått til ALLE aktive medlemmer — også de som
+  // for lengst har svart. Manuell purring skal aldri eksplodere til hele
+  // klubben pga en transient DB-feil. (#287)
+  if (paameldingerFeil) {
+    throw new Error(`Kunne ikke hente påmeldinger for purring: ${paameldingerFeil.message}`)
+  }
 
   const harSvart = new Set((paameldinger ?? []).map(p => p.profil_id))
   const profiler = await hentProfiler()

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 2,
-  "versjon": "V3.2.2"
+  "nummer": 3,
+  "versjon": "V3.2.3"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 3,
-  "versjon": "V3.2.3"
+  "nummer": 4,
+  "versjon": "V3.2.4"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 4,
-  "versjon": "V3.2.4"
+  "nummer": 5,
+  "versjon": "V3.2.5"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.2.4'
+const CACHE_VERSION = 'V3.2.5'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.2.2'
+const CACHE_VERSION = 'V3.2.3'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.2.3'
+const CACHE_VERSION = 'V3.2.4'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
## Sammendrag
- «Purre disse»-pill i gruppe-headeren til «Ikke svart» i Vis liste-modalen.
- Kun synlig for admin/oppretter når gruppen har minst én person.
- Klikk lukker hovedmodalen og åpner hilsen-modal (samme mønster som PurreKnapp/VarsleNuKnapp).
- Send purrer alle som ikke har svart, med valgfri hilsen.

## Beslutninger underveis
- Manuell purring ignorerer cron-bryteren `purring_aktiv` (admin-handling).
- `sendPurringVarsler` beregner mottakerlisten selv rett før utsending — lukker TOCTOU-vinduet der noen kunne rekke å svare mellom action-beregning og send.
- `purreSendt` resettes når brukeren åpner modalen igjen (admin kan purre flere ganger per økt).
- Focus-fallback-kjede: opprinnelig trigger → hovedmodal-trigger → body.

Lukker #287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)