### PR TITLE
Avhardkode klubbidentitet til lib/klubb-config.ts (#292)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# Klubbidentitet — alle har defaults (Mortensrud Herreklubb).
+# Fullstendig miljøoversikt kommer i fase 2 (#293).
+
+# NEXT_PUBLIC_KLUBB_NAVN=Mortensrud Herreklubb
+# NEXT_PUBLIC_KLUBB_KORTNAVN=Herreklubben
+# NEXT_PUBLIC_KLUBB_NAVN_LINJE_1=Mortensrud
+# NEXT_PUBLIC_KLUBB_NAVN_LINJE_2=Herreklubb
+# NEXT_PUBLIC_KLUBB_BESKRIVELSE=Privat klubbapp for Mortensrud Herreklubb
+# NEXT_PUBLIC_KLUBB_DOMENE=mortensrudherreklubb.no
+# NEXT_PUBLIC_KLUBB_STIFTET_AAR=2007
+# NEXT_PUBLIC_KLUBB_STIFTET_MAANED=11
+# NEXT_PUBLIC_KLUBB_STIFTET_DAG=24
+# NEXT_PUBLIC_ROLLE_TITTEL_GENERALSEKRETAER=Generalsekretær
+
+# Resend — avsendernavn i utgående e-post
+# RESEND_FROM=Herreklubben <onboarding@resend.dev>
+
+# GitHub-innspill
+# NEXT_PUBLIC_GITHUB_REPO=reidarei/Herreklubben
+# NEXT_PUBLIC_GITHUB_ONSKE_LABEL=ønske
+
+# Cloudflare R2 custom domain (når aktivert)
+# NEXT_PUBLIC_R2_CUSTOM_DOMAIN=bilder.mortensrudherreklubb.no

--- a/__tests__/mention.test.ts
+++ b/__tests__/mention.test.ts
@@ -74,7 +74,7 @@ describe('lagMentionForslag', () => {
   const profiler: ChatProfil[] = [
     profil('1', 'Reidar Eik Haavik'),
     profil('2', 'Michael'),
-    profil('3', 'André Heede'),
+    profil('3', 'Kari Nordmann'),
   ]
 
   it('tom liste når mentionSøk === null', () => {

--- a/app/(app)/klubbinfo/page.tsx
+++ b/app/(app)/klubbinfo/page.tsx
@@ -6,8 +6,10 @@ import { norskAar } from '@/lib/dato'
 import Icon, { IkonNavn } from '@/components/ui/Icon'
 import { kanAdministrere } from '@/lib/roller'
 import versjon from '@/lib/versjon.json'
+import { KLUBB_STIFTET, KLUBB_NAVN_LINJE_1, KLUBB_NAVN_LINJE_2 } from '@/lib/klubb-config'
 
-const KLUBBEN_START_AAR = 2007
+// Hentes fra KLUBB_STIFTET i stedet for hardkodet konstant
+const KLUBBEN_START_AAR = KLUBB_STIFTET.aar
 
 export default async function Klubbinfo() {
   const [supabase, profil] = await Promise.all([createServerClient(), getProfil()])
@@ -142,7 +144,7 @@ export default async function Klubbinfo() {
             fontStyle: 'italic',
           }}
         >
-          Mortensrud
+          {KLUBB_NAVN_LINJE_1}
         </h2>
         <h2
           style={{
@@ -155,7 +157,7 @@ export default async function Klubbinfo() {
             margin: '2px 0 0',
           }}
         >
-          Herreklubb
+          {KLUBB_NAVN_LINJE_2}
         </h2>
 
         {/* Nøkkeltall */}

--- a/app/(app)/om-appen/page.tsx
+++ b/app/(app)/om-appen/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import SectionLabel from '@/components/ui/SectionLabel'
 import versjon from '@/lib/versjon.json'
+import { KLUBB_NAVN } from '@/lib/klubb-config'
 
 export default function OmAppen() {
   return (
@@ -42,7 +43,7 @@ export default function OmAppen() {
             maxWidth: 420,
           }}
         >
-          Privat klubbapp for Mortensrud Herreklubb. Erstatter Facebook for
+          Privat klubbapp for {KLUBB_NAVN}. Erstatter Facebook for
           påmelding, klubbinfo og kåringer.
         </p>
       </header>

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -5,6 +5,7 @@ import { createClient } from '@/lib/supabase/client'
 import { useRouter } from 'next/navigation'
 import Image from 'next/image'
 import Button from '@/components/ui/Button'
+import { KLUBB_NAVN, KLUBB_KORTNAVN } from '@/lib/klubb-config'
 
 const inputStil: React.CSSProperties = {
   background: 'var(--bg-elevated-2)',
@@ -89,7 +90,7 @@ export default function LoginSide() {
         <div className="flex justify-center">
           <Image
             src="/icon-512.png"
-            alt="Mortensrud Herreklubb"
+            alt={KLUBB_NAVN}
             width={160}
             height={160}
             priority
@@ -98,10 +99,10 @@ export default function LoginSide() {
         </div>
         <div className="text-center mt-6">
           <h1 className="text-xl font-bold tracking-tight" style={{ color: 'var(--accent)' }}>
-            Herreklubben
+            {KLUBB_KORTNAVN}
           </h1>
           <p className="text-xs mt-1" style={{ color: 'var(--text-secondary)' }}>
-            Mortensrud Herreklubb
+            {KLUBB_NAVN}
           </p>
         </div>
       </div>

--- a/app/(auth)/oppdater-passord/page.tsx
+++ b/app/(auth)/oppdater-passord/page.tsx
@@ -5,6 +5,7 @@ import { createClient } from '@/lib/supabase/client'
 import { useRouter } from 'next/navigation'
 import Ordsky from '@/components/Ordsky'
 import Button from '@/components/ui/Button'
+import { KLUBB_NAVN, KLUBB_KORTNAVN } from '@/lib/klubb-config'
 
 const inputStil: React.CSSProperties = {
   background: 'var(--bg-elevated-2)',
@@ -75,10 +76,10 @@ export default function OppdaterPassordSide() {
         <Ordsky className="w-full" style={{ maxHeight: '160px' }} />
         <div className="text-center mt-14">
           <h1 className="text-xl font-bold tracking-tight" style={{ color: 'var(--accent)' }}>
-            Herreklubben
+            {KLUBB_KORTNAVN}
           </h1>
           <p className="text-xs mt-1" style={{ color: 'var(--text-secondary)' }}>
-            Mortensrud Herreklubb
+            {KLUBB_NAVN}
           </p>
         </div>
       </div>

--- a/app/api/admin/opprett-medlem/route.ts
+++ b/app/api/admin/opprett-medlem/route.ts
@@ -4,6 +4,7 @@ import { sendEpost, velkommenEpostHtml } from '@/lib/epost'
 import { NextResponse } from 'next/server'
 import { kanAdministrere } from '@/lib/roller'
 import { BASE_URL } from '@/lib/config'
+import { KLUBB_NAVN } from '@/lib/klubb-config'
 
 function genererPassord() {
   const tegn = 'ABCDEFGHJKMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789'
@@ -50,7 +51,7 @@ export async function POST(request: Request) {
   // Send velkomst-e-post med innloggingsinfo
   await sendEpost({
     til: epost,
-    emne: 'Velkommen til Mortensrud Herreklubb',
+    emne: `Velkommen til ${KLUBB_NAVN}`,
     html: velkommenEpostHtml({
       navn,
       epost,

--- a/app/api/arrangementer/[id]/ics/route.ts
+++ b/app/api/arrangementer/[id]/ics/route.ts
@@ -2,7 +2,7 @@ import { createServerClient } from '@/lib/supabase/server'
 import { NextResponse } from 'next/server'
 import { formaterDato, TIDSSONE } from '@/lib/dato'
 import { BASE_URL } from '@/lib/config'
-import { KLUBB_NAVN, KLUBB_DOMENE } from '@/lib/klubb-config'
+import { KLUBB_NAVN, KLUBB_KORTNAVN, KLUBB_DOMENE } from '@/lib/klubb-config'
 
 // Escape for .ics TEXT-verdier: backslash, semikolon, komma og linjeskift
 function escapeIcs(s: string): string {
@@ -60,7 +60,10 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
   ]
 
   const ics = linjer.join('\r\n')
-  const filnavn = `herreklubben-${id.slice(0, 8)}.ics`
+  // Filnavn fra kortnavnet, forenklet til trygge ASCII-tegn (æ/ø/å og
+  // spesialtegn kan skape trøbbel i Content-Disposition på enkelte klienter).
+  const navnSlug = KLUBB_KORTNAVN.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'kalender'
+  const filnavn = `${navnSlug}-${id.slice(0, 8)}.ics`
 
   return new NextResponse(ics, {
     headers: {

--- a/app/api/arrangementer/[id]/ics/route.ts
+++ b/app/api/arrangementer/[id]/ics/route.ts
@@ -40,7 +40,8 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
   const linjer = [
     'BEGIN:VCALENDAR',
     'VERSION:2.0',
-    `PRODID:-//${KLUBB_NAVN}//NO`,
+    // KLUBB_NAVN kan inneholde tegn som må escapes for ICS TEXT (komma, semikolon).
+    `PRODID:-//${escapeIcs(KLUBB_NAVN)}//NO`,
     'CALSCALE:GREGORIAN',
     'METHOD:PUBLISH',
     `BEGIN:VTIMEZONE`,

--- a/app/api/arrangementer/[id]/ics/route.ts
+++ b/app/api/arrangementer/[id]/ics/route.ts
@@ -2,6 +2,7 @@ import { createServerClient } from '@/lib/supabase/server'
 import { NextResponse } from 'next/server'
 import { formaterDato, TIDSSONE } from '@/lib/dato'
 import { BASE_URL } from '@/lib/config'
+import { KLUBB_NAVN, KLUBB_DOMENE } from '@/lib/klubb-config'
 
 // Escape for .ics TEXT-verdier: backslash, semikolon, komma og linjeskift
 function escapeIcs(s: string): string {
@@ -39,14 +40,14 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
   const linjer = [
     'BEGIN:VCALENDAR',
     'VERSION:2.0',
-    'PRODID:-//Mortensrud Herreklubb//NO',
+    `PRODID:-//${KLUBB_NAVN}//NO`,
     'CALSCALE:GREGORIAN',
     'METHOD:PUBLISH',
     `BEGIN:VTIMEZONE`,
     `TZID:${TIDSSONE}`,
     `END:VTIMEZONE`,
     'BEGIN:VEVENT',
-    `UID:${id}@mortensrudherreklubb.no`,
+    `UID:${id}@${KLUBB_DOMENE}`,
     `DTSTAMP:${new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d{3}/, '')}`,
     `DTSTART;TZID=${TIDSSONE}:${formatIcsDate(arr.start_tidspunkt)}`,
     `DTEND;TZID=${TIDSSONE}:${formatIcsDate(sluttIso)}`,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from 'next'
 import { Inter, Instrument_Serif, JetBrains_Mono } from 'next/font/google'
 import { SpeedInsights } from '@vercel/speed-insights/next'
 import VitalsLogger from '@/components/VitalsLogger'
+import { KLUBB_NAVN, KLUBB_KORTNAVN, KLUBB_BESKRIVELSE } from '@/lib/klubb-config'
 import './globals.css'
 
 const inter = Inter({
@@ -37,8 +38,8 @@ export const viewport: Viewport = {
 }
 
 export const metadata: Metadata = {
-  title: 'Mortensrud Herreklubb',
-  description: 'Privat klubbapp for Mortensrud Herreklubb',
+  title: KLUBB_NAVN,
+  description: KLUBB_BESKRIVELSE,
   manifest: '/manifest.webmanifest',
   icons: {
     icon: [
@@ -52,7 +53,7 @@ export const metadata: Metadata = {
   appleWebApp: {
     capable: true,
     statusBarStyle: 'black-translucent',
-    title: 'Herreklubben',
+    title: KLUBB_KORTNAVN,
   },
 }
 
@@ -77,7 +78,7 @@ export default function RootLayout({
           <div style={{ fontSize: 40, lineHeight: 1 }}>↻</div>
           <div style={{ fontSize: 18, fontWeight: 500 }}>Roter telefonen</div>
           <div style={{ fontSize: 14, color: 'var(--text-secondary)', maxWidth: 320 }}>
-            Herreklubben fungerer best i portrett-modus.
+            {KLUBB_KORTNAVN} fungerer best i portrett-modus.
           </div>
         </div>
         <SpeedInsights />

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,10 +1,11 @@
 import type { MetadataRoute } from 'next'
+import { KLUBB_NAVN, KLUBB_KORTNAVN, KLUBB_BESKRIVELSE } from '@/lib/klubb-config'
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: 'Mortensrud Herreklubb',
-    short_name: 'Herreklubben',
-    description: 'Privat klubbapp for Mortensrud Herreklubb',
+    name: KLUBB_NAVN,
+    short_name: KLUBB_KORTNAVN,
+    description: KLUBB_BESKRIVELSE,
     start_url: '/',
     display: 'standalone',
     background_color: '#060608',

--- a/components/InstallVeiledning.tsx
+++ b/components/InstallVeiledning.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import Icon from '@/components/ui/Icon'
+import { KLUBB_KORTNAVN } from '@/lib/klubb-config'
 
 const AVVIST_NOKKEL = 'install-veiledning-avvist'
 
@@ -175,7 +176,7 @@ export default function InstallVeiledning() {
               letterSpacing: '-0.2px',
             }}
           >
-            Installer Herreklubben på telefonen
+            Installer {KLUBB_KORTNAVN} på telefonen
           </div>
 
           {iosNettleser === 'safari' && (

--- a/components/TopHeader.tsx
+++ b/components/TopHeader.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'next/navigation'
 import { type CSSProperties, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import Avatar from '@/components/ui/Avatar'
 import { harGulGloed } from '@/lib/roller'
+import { KLUBB_KORTNAVN } from '@/lib/klubb-config'
 
 type Tab = {
   href: string
@@ -263,7 +264,7 @@ export default function TopHeader({ brukerNavn, bildeUrl, rolle, ulestChat = fal
           }}
         >
           <Avatar
-            name={brukerNavn ?? 'Herreklubben'}
+            name={brukerNavn ?? KLUBB_KORTNAVN}
             src={bildeUrl ?? null}
             rolle={rolle ?? null}
             size={38}

--- a/components/agenda/KlubbJubileumKort.tsx
+++ b/components/agenda/KlubbJubileumKort.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import Icon from '@/components/ui/Icon'
 import { formaterDato, aarHvisAvvik } from '@/lib/dato'
+import { KLUBB_KORTNAVN, KLUBB_NAVN_LINJE_1, KLUBB_NAVN_LINJE_2 } from '@/lib/klubb-config'
 
 export type KlubbJubileumData = {
   id: string
@@ -81,7 +82,7 @@ export default function KlubbJubileumKort({ jubileum }: { jubileum: KlubbJubileu
             lineHeight: 1.2,
           }}
         >
-          Herreklubben{' '}
+          {KLUBB_KORTNAVN}{' '}
           <span style={{ color: 'var(--text-tertiary)', fontWeight: 400 }}>
             fyller {jubileum.alder}
           </span>
@@ -108,8 +109,8 @@ export default function KlubbJubileumKort({ jubileum }: { jubileum: KlubbJubileu
         }}
         aria-hidden="true"
       >
-        <span style={{ fontStyle: 'italic' }}>Mortensrud</span>
-        <span>Herreklubb</span>
+        <span style={{ fontStyle: 'italic' }}>{KLUBB_NAVN_LINJE_1}</span>
+        <span>{KLUBB_NAVN_LINJE_2}</span>
       </div>
     </Link>
   )

--- a/lib/agenda-sortering.ts
+++ b/lib/agenda-sortering.ts
@@ -46,10 +46,11 @@ import type { KlubbJubileumData } from '@/components/agenda/KlubbJubileumKort'
 import type { PollKortData } from '@/components/agenda/PollKort'
 import type { MeldingKortData } from '@/components/agenda/MeldingKort'
 import type { AlbumSpotlight } from '@/lib/melding-spotlight'
+import { KLUBB_STIFTET } from '@/lib/klubb-config'
 
-// Herreklubben ble stiftet 24. november 2007. Brukes til å beregne
-// neste stiftelsesdag på agendaen.
-export const STIFTET_DATO = { maaned: 11, dag: 24, aar: 2007 } as const
+// Stiftelsesdato — brukes til å beregne neste jubileumsdag på agendaen.
+// Hentes fra klubb-config slik at den kan overstyres via env-var.
+export const STIFTET_DATO = KLUBB_STIFTET
 
 // Levetidsregler for meldinger på agenda. En melding er «levende» (vises
 // øverst) så lenge det er mindre enn MELDING_LEVENDE_DAGER siden siste

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,7 +1,10 @@
 // Sentral applikasjons-konfigurasjon. All env-var-lesing og miljø-defaults
 // skal samles her, ikke spres ut i actions/route handlers.
 
-const PROD_URL = 'https://mortensrudherreklubb.no'
+import { KLUBB_DOMENE } from './klubb-config'
+
+// PROD_URL bygges fra KLUBB_DOMENE slik at domenet kun er hardkodet ett sted.
+const PROD_URL = `https://${KLUBB_DOMENE}`
 const DEV_URL = 'http://localhost:3000'
 
 // Brukes i absolutte URL-er i varsler (push/epost), ICS-filer og lignende.
@@ -34,8 +37,10 @@ export const R2_PUBLIC_URL = (
 
 // GitHub-repo som backer «innspill»-funksjonen. Issues med label
 // GITHUB_ONSKE_LABEL behandles som brukerønsker.
-export const GITHUB_REPO = 'reidarei/Herreklubben'
-export const GITHUB_ONSKE_LABEL = 'ønske'
+export const GITHUB_REPO =
+  process.env.NEXT_PUBLIC_GITHUB_REPO ?? 'reidarei/Herreklubben'
+export const GITHUB_ONSKE_LABEL =
+  process.env.NEXT_PUBLIC_GITHUB_ONSKE_LABEL ?? 'ønske'
 
 // Bygg GitHub Issues-list URL med ønske-label og gitt state.
 export function githubIssuesUrl(params: {

--- a/lib/epost.ts
+++ b/lib/epost.ts
@@ -1,6 +1,8 @@
 // Krever verifisert domene i Resend — sett RESEND_FROM til f.eks. "Herreklubben <noreply@dittdomene.no>"
+import { KLUBB_NAVN, KLUBB_EPOST_AVSENDER } from './klubb-config'
 const RESEND_API_KEY = process.env.RESEND_API_KEY!
-const RESEND_FROM = process.env.RESEND_FROM ?? 'Herreklubben <onboarding@resend.dev>'
+// RESEND_FROM hentes fra klubb-config slik at avsendernavn ikke er hardkodet her.
+const RESEND_FROM = KLUBB_EPOST_AVSENDER
 
 export async function sendEpost({ til, emne, html }: { til: string; emne: string; html: string }) {
   try {
@@ -68,7 +70,7 @@ export function arrangementEpostHtml({
     <tr><td align="center">
       <table width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:480px;">
         <tr><td style="padding:32px;">
-          <p style="margin:0 0 4px;font-size:12px;letter-spacing:0.1em;text-transform:uppercase;">Mortensrud Herreklubb</p>
+          <p style="margin:0 0 4px;font-size:12px;letter-spacing:0.1em;text-transform:uppercase;">${escapeHtml(KLUBB_NAVN)}</p>
           <h1 style="margin:0 0 16px;font-size:20px;font-weight:700;">${tittelEsc}</h1>
           <p style="margin:0 0 24px;font-size:15px;line-height:1.6;white-space:pre-wrap;">${tekstEsc}</p>
           <table cellpadding="0" cellspacing="0" border="0" role="presentation" style="border-collapse:separate;">
@@ -115,9 +117,9 @@ export function velkommenEpostHtml({
     <tr><td align="center">
       <table width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:480px;">
         <tr><td style="padding:32px;">
-          <p style="margin:0 0 4px;font-size:12px;letter-spacing:0.1em;text-transform:uppercase;">Mortensrud Herreklubb</p>
+          <p style="margin:0 0 4px;font-size:12px;letter-spacing:0.1em;text-transform:uppercase;">${escapeHtml(KLUBB_NAVN)}</p>
           <h1 style="margin:0 0 16px;font-size:22px;font-weight:700;">Velkommen herr ${etternavnEsc}!</h1>
-          <p style="margin:0 0 24px;font-size:15px;line-height:1.6;">Du er lagt til som medlem i Mortensrud Herreklubb. Under finner du innloggingsinfoen din.</p>
+          <p style="margin:0 0 24px;font-size:15px;line-height:1.6;">Du er lagt til som medlem i ${escapeHtml(KLUBB_NAVN)}. Under finner du innloggingsinfoen din.</p>
           <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px;">
             <tr><td style="padding:6px 0;">
               <p style="margin:0 0 2px;font-size:11px;letter-spacing:0.08em;text-transform:uppercase;opacity:0.7;">Brukernavn</p>

--- a/lib/epost.ts
+++ b/lib/epost.ts
@@ -1,8 +1,9 @@
 // Krever verifisert domene i Resend — sett RESEND_FROM til f.eks. "Herreklubben <noreply@dittdomene.no>"
-import { KLUBB_NAVN, KLUBB_EPOST_AVSENDER } from './klubb-config'
+import { KLUBB_NAVN } from './klubb-config'
 const RESEND_API_KEY = process.env.RESEND_API_KEY!
-// RESEND_FROM hentes fra klubb-config slik at avsendernavn ikke er hardkodet her.
-const RESEND_FROM = KLUBB_EPOST_AVSENDER
+// Avsender er server-only-konfig (Resend-spesifikk) og holdes derfor her,
+// ikke i klient-trygg klubb-config. Ingen NEXT_PUBLIC_-prefiks.
+const RESEND_FROM = process.env.RESEND_FROM ?? 'Herreklubben <onboarding@resend.dev>'
 
 export async function sendEpost({ til, emne, html }: { til: string; emne: string; html: string }) {
   try {
@@ -58,6 +59,8 @@ export function arrangementEpostHtml({
   const tekstEsc = escapeHtml(tekst)
   const urlEsc = escapeHtml(url)
   const knappTekstEsc = escapeHtml(knappTekst)
+  // KLUBB_NAVN kommer fra env-var (NEXT_PUBLIC_KLUBB_NAVN) — escapes som
+  // forsvar i dybden selv om kilden i praksis kontrolleres av deployer.
   return `
 <!DOCTYPE html>
 <html lang="no">

--- a/lib/klubb-config.ts
+++ b/lib/klubb-config.ts
@@ -1,0 +1,36 @@
+// Sentral klubbidentitet. Alle hardkodede navn, URL-er og datoer som er
+// spesifikke for Mortensrud Herreklubb samles her med env-override.
+// Defaults = dagens prod-verdier, slik at eksisterende deploy ikke endrer seg.
+
+// Todelt navn brukes i hero-seksjoner med to-linjers typografi
+// (f.eks. klubbinfo-siden og KlubbJubileumKort).
+export const KLUBB_NAVN = process.env.NEXT_PUBLIC_KLUBB_NAVN ?? 'Mortensrud Herreklubb'
+export const KLUBB_KORTNAVN = process.env.NEXT_PUBLIC_KLUBB_KORTNAVN ?? 'Herreklubben'
+export const KLUBB_NAVN_LINJE_1 = process.env.NEXT_PUBLIC_KLUBB_NAVN_LINJE_1 ?? 'Mortensrud'
+export const KLUBB_NAVN_LINJE_2 = process.env.NEXT_PUBLIC_KLUBB_NAVN_LINJE_2 ?? 'Herreklubb'
+
+export const KLUBB_BESKRIVELSE =
+  process.env.NEXT_PUBLIC_KLUBB_BESKRIVELSE ?? 'Privat klubbapp for Mortensrud Herreklubb'
+
+// KLUBB_DOMENE er hostname-identifikatoren — brukes i ICS PRODID/UID og
+// som base for PROD_URL i config.ts. Adskilt fra BASE_URL fordi ICS-UID
+// trenger bare hostnavn, ikke protokoll.
+export const KLUBB_DOMENE =
+  process.env.NEXT_PUBLIC_KLUBB_DOMENE ?? 'mortensrudherreklubb.no'
+
+// Stiftelsesdato — brukes til å beregne jubileumsdagen på agendaen.
+export const KLUBB_STIFTET = {
+  aar: Number(process.env.NEXT_PUBLIC_KLUBB_STIFTET_AAR ?? 2007),
+  maaned: Number(process.env.NEXT_PUBLIC_KLUBB_STIFTET_MAANED ?? 11),
+  dag: Number(process.env.NEXT_PUBLIC_KLUBB_STIFTET_DAG ?? 24),
+} as const
+
+// Resend-avsender for alle utgående e-poster. Default speiler dagens verdi
+// i lib/epost.ts slik at eksisterende Resend-oppsett fungerer uten endring.
+export const KLUBB_EPOST_AVSENDER =
+  process.env.RESEND_FROM ?? 'Herreklubben <onboarding@resend.dev>'
+
+// Tittel-streng for generalsekretær-rollen i UI. Rolle-koden i DB
+// («generalsekretaer») endres ikke — kun visningsnavnet kan overstyres.
+export const ROLLE_TITTEL_GENERALSEKRETAER =
+  process.env.NEXT_PUBLIC_ROLLE_TITTEL_GENERALSEKRETAER ?? 'Generalsekretær'

--- a/lib/klubb-config.ts
+++ b/lib/klubb-config.ts
@@ -1,6 +1,10 @@
 // Sentral klubbidentitet. Alle hardkodede navn, URL-er og datoer som er
 // spesifikke for Mortensrud Herreklubb samles her med env-override.
 // Defaults = dagens prod-verdier, slik at eksisterende deploy ikke endrer seg.
+//
+// Klient-trygg modul: importeres fra Client Components (bl.a. via lib/roller.ts)
+// og må forbli klient-trygg. Kun NEXT_PUBLIC_-env-vars og rene konstanter —
+// aldri secrets, server-only-config eller node-API-er.
 
 // Todelt navn brukes i hero-seksjoner med to-linjers typografi
 // (f.eks. klubbinfo-siden og KlubbJubileumKort).
@@ -10,25 +14,25 @@ export const KLUBB_NAVN_LINJE_1 = process.env.NEXT_PUBLIC_KLUBB_NAVN_LINJE_1 ?? 
 export const KLUBB_NAVN_LINJE_2 = process.env.NEXT_PUBLIC_KLUBB_NAVN_LINJE_2 ?? 'Herreklubb'
 
 export const KLUBB_BESKRIVELSE =
-  process.env.NEXT_PUBLIC_KLUBB_BESKRIVELSE ?? 'Privat klubbapp for Mortensrud Herreklubb'
+  process.env.NEXT_PUBLIC_KLUBB_BESKRIVELSE ?? `Privat klubbapp for ${KLUBB_NAVN}`
 
 // KLUBB_DOMENE er hostname-identifikatoren — brukes i ICS PRODID/UID og
 // som base for PROD_URL i config.ts. Adskilt fra BASE_URL fordi ICS-UID
 // trenger bare hostnavn, ikke protokoll.
+// MÅ være et gyldig hostname (ASCII, ingen mellomrom/komma/skråstrek) —
+// vi saniterer ikke ved bruk, så feil format gir ugyldig ICS-UID.
 export const KLUBB_DOMENE =
   process.env.NEXT_PUBLIC_KLUBB_DOMENE ?? 'mortensrudherreklubb.no'
 
 // Stiftelsesdato — brukes til å beregne jubileumsdagen på agendaen.
+// `||` foran fallback (ikke `??`) fordi env-vars er strenger:
+// Number('') = 0 og Number('søppel') = NaN — begge er falsy og uønskede
+// her (0 er aldri gyldig år/måned/dag), så `||` fanger alt i ett.
 export const KLUBB_STIFTET = {
-  aar: Number(process.env.NEXT_PUBLIC_KLUBB_STIFTET_AAR ?? 2007),
-  maaned: Number(process.env.NEXT_PUBLIC_KLUBB_STIFTET_MAANED ?? 11),
-  dag: Number(process.env.NEXT_PUBLIC_KLUBB_STIFTET_DAG ?? 24),
+  aar: Number(process.env.NEXT_PUBLIC_KLUBB_STIFTET_AAR) || 2007,
+  maaned: Number(process.env.NEXT_PUBLIC_KLUBB_STIFTET_MAANED) || 11,
+  dag: Number(process.env.NEXT_PUBLIC_KLUBB_STIFTET_DAG) || 24,
 } as const
-
-// Resend-avsender for alle utgående e-poster. Default speiler dagens verdi
-// i lib/epost.ts slik at eksisterende Resend-oppsett fungerer uten endring.
-export const KLUBB_EPOST_AVSENDER =
-  process.env.RESEND_FROM ?? 'Herreklubben <onboarding@resend.dev>'
 
 // Tittel-streng for generalsekretær-rollen i UI. Rolle-koden i DB
 // («generalsekretaer») endres ikke — kun visningsnavnet kan overstyres.

--- a/lib/roller.ts
+++ b/lib/roller.ts
@@ -1,5 +1,7 @@
 // Sentral rolle- og rettighetsmatrise. Alle andre steder i koden skal gå
 // gjennom hjelperne her — aldri sammenligne `rolle === 'admin'` direkte.
+
+import { ROLLE_TITTEL_GENERALSEKRETAER } from './klubb-config'
 //
 // Modellen:
 //   - Tre roller: medlem, admin, generalsekretaer
@@ -42,7 +44,9 @@ export const ROLLER: Record<Rolle, Rettigheter> = {
     loeserTiebreak: false,
   },
   generalsekretaer: {
-    tittel: 'Generalsekretær',
+    // Tittel hentes fra klubb-config slik at den kan overstyres via env-var
+    // uten kode-endring. Rolle-koden i DB («generalsekretaer») er uendret.
+    tittel: ROLLE_TITTEL_GENERALSEKRETAER,
     kanAdministrere: true,
     faarIssueVarsler: false,
     harGulGloed: true,

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 9,
-  "versjon": "V3.2.9"
+  "nummer": 10,
+  "versjon": "V3.2.10"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 8,
-  "versjon": "V3.2.8"
+  "nummer": 9,
+  "versjon": "V3.2.9"
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -44,10 +44,11 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: '*.r2.dev',
       },
-      // Custom domain for R2 (når aktivert) — bilder.mortensrudherreklubb.no
+      // Custom domain for R2 (når aktivert). next.config.ts kan ikke
+      // importere fra lib/, så vi leser process.env direkte her.
       {
         protocol: 'https',
-        hostname: 'bilder.mortensrudherreklubb.no',
+        hostname: process.env.NEXT_PUBLIC_R2_CUSTOM_DOMAIN ?? 'bilder.mortensrudherreklubb.no',
       },
     ],
   },

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.2.8'
+const CACHE_VERSION = 'V3.2.9'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 
@@ -162,7 +162,8 @@ self.addEventListener('push', (event) => {
   const { tittel, melding, url } = data
 
   event.waitUntil(
-    self.registration.showNotification(tittel ?? 'Herreklubben', {
+    // SW kan ikke importere TS-moduler; serveren setter alltid tittel i praksis.
+    self.registration.showNotification(tittel ?? 'Varsel', {
       body: melding,
       icon: '/icon-192.png',
       badge: '/icon-192.png',

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.2.9'
+const CACHE_VERSION = 'V3.2.10'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
## Sammendrag

Fase 1 av open source-klargjøring (#291): all klubb-spesifikk identitet flyttes fra hardkodede strenger til ny `lib/klubb-config.ts` med `NEXT_PUBLIC_KLUBB_*`-env-overrides. Defaults speiler dagens prod-verdier — endringen er no-op for mortensrudherreklubb.no.

- Ny `lib/klubb-config.ts`: KLUBB_NAVN, KLUBB_KORTNAVN, KLUBB_NAVN_LINJE_1/2 (todelt hero-design), KLUBB_BESKRIVELSE, KLUBB_DOMENE, KLUBB_STIFTET, ROLLE_TITTEL_GENERALSEKRETAER. Modulen er klient-trygg (kun NEXT_PUBLIC_-vars).
- 18 filer avhardkodet: manifest, layout-metadata, login/oppdater-passord, om-appen, klubbinfo-hero, jubileumskort, installveiledning, TopHeader-fallback, sw.js, ICS-route, velkomst-epost, epost-maler, agenda-sortering (stiftelsesdato), next.config.ts (R2-domene), roller.ts (GS-tittel)
- `GITHUB_REPO`/`GITHUB_ONSKE_LABEL` fikk env-override i `lib/config.ts`
- Testnavn «André Heede» → «Kari Nordmann» i mention-testen
- Minimal `.env.example`-stub (fase 2 #293 utvider)

Klubbinfo-brødteksten (klubb-kultur-setningene) er bevisst urørt — hver klubb redigerer den selv.

## Beslutninger underveis

**Intern review — rettet:**
- MAJOR: ICS PRODID interpolerte KLUBB_NAVN uescapet (delimiter injection ved komma/semikolon i klubbnavn) → `escapeIcs()`
- MINOR: `Number(env ?? d)` ga 0/NaN ved tom/ugyldig env → `Number(env) || d`
- MINOR: server-only RESEND_FROM flyttet ut av klient-trygg klubb-config, tilbake til `lib/epost.ts`
- NIT: KLUBB_BESKRIVELSE-default bygges nå fra KLUBB_NAVN

**Intern review — forsvart:**
- sw.js-fallback `'Herreklubben'` → `'Varsel'`: SW kan ikke importere TS-moduler; serveren setter alltid tittel, fallbacken er teoretisk.

**Notat til fase 2 (#293):** vurdér konsolidering av `NEXT_PUBLIC_KLUBB_DOMENE` og `NEXT_PUBLIC_BASE_URL` til én sannhetskilde.

Se #292.