### PR TITLE
Miljøvalidering + fullstendig .env.example (#293)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,7 @@ R2_ACCESS_KEY_ID=
 # SECRET
 R2_SECRET_ACCESS_KEY=
 # R2_BUCKET=herreklubben-bilder            # valgfri; default er herreklubben-bilder
-# R2_JURISDICTION=eu                       # valgfri; default|eu — velg etter bucket-jurisdiksjon
+# R2_JURISDICTION=eu                       # valgfri; default|eu|fedramp — velg etter bucket-jurisdiksjon
 # Public CDN-URL for bilder — minst én av de to under må settes.
 # R2_PUBLIC_URL brukes server-side; NEXT_PUBLIC_R2_PUBLIC_URL er tilgjengelig
 # også fra klient-koden. Ofte settes samme verdi på begge.
@@ -58,7 +58,10 @@ R2_PUBLIC_URL=
 NEXT_PUBLIC_VAPID_PUBLIC_KEY=
 # SECRET
 VAPID_PRIVATE_KEY=
-# VAPID_CONTACT_EMAIL=                     # valgfri; default reidar.haavik@gmail.com
+# VAPID_CONTACT_EMAIL: bør settes per klubb. Apple/Google push-tjenester bruker
+# denne for å kontakte klubben ved misbruk eller tekniske problemer. Default er
+# kildeklubbens kontaktadresse (se lib/config.ts) — sett din egen ved fork.
+# VAPID_CONTACT_EMAIL=
 
 # ─────────────────────────────────────────────────────────────────────────────
 # RESEND — utgående e-post (anbefalt; e-postvarsler mangler uten)
@@ -75,9 +78,10 @@ RESEND_API_KEY=
 
 # ─────────────────────────────────────────────────────────────────────────────
 # CRON (anbefalt; påminnelsesvarsler sendes ikke uten)
-# CRON_SECRET: valgfri streng — samme verdi settes som GitHub Actions-secret
-# CRON_SECRET i repo-innstillinger. Workflow-secreten APP_URL (prod-URL)
-# settes KUN i GitHub, ikke her.
+# CRON_SECRET: delt hemmelighet. Settes BÅDE her (Vercel env — runtime sjekker
+# Authorization-headeren mot denne) OG som GitHub Actions-secret (workflow-en
+# sender headeren). Samme verdi begge steder, ellers svarer cron-endepunktet
+# 401. Workflow-secreten APP_URL (prod-URL) settes KUN i GitHub, ikke her.
 # ─────────────────────────────────────────────────────────────────────────────
 
 # SECRET

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,90 @@
-# Klubbidentitet — alle har defaults (Mortensrud Herreklubb).
-# Fullstendig miljøoversikt kommer i fase 2 (#293).
+# Kopier denne filen til .env.local og fyll inn verdiene.
+# Kjør deretter: npm run sjekk-miljo
+#
+# På Vercel settes verdiene i Dashboard → Settings → Environment Variables,
+# ikke via fil. .env.local brukes kun lokalt.
+#
+# NEXT_PUBLIC_-prefiks: disse verdiene inlines i browser-bundlen ved build.
+# ALDRI legg secrets (API-nøkler, private nøkler) med NEXT_PUBLIC_-prefiks.
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SUPABASE (kritisk — appen starter ikke uten disse)
+# Hentes: Supabase Dashboard → Project Settings → API
+# ─────────────────────────────────────────────────────────────────────────────
+
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=                 # SECRET
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CLOUDFLARE R2 — bildelagring (kritisk)
+# Hentes: Cloudflare Dashboard → R2 → Manage API Tokens
+# ─────────────────────────────────────────────────────────────────────────────
+
+R2_ACCOUNT_ID=
+R2_ACCESS_KEY_ID=                          # SECRET
+R2_SECRET_ACCESS_KEY=                      # SECRET
+# R2_BUCKET=herreklubben-bilder            # valgfri; default er herreklubben-bilder
+# R2_JURISDICTION=eu                       # valgfri; default|eu|fedramp — velg etter bucket-jurisdiksjon
+R2_PUBLIC_URL=                             # eller NEXT_PUBLIC_R2_PUBLIC_URL (se under)
+
+# Sett én av disse to for public CDN-URL (minst én er kritisk):
+# NEXT_PUBLIC_R2_PUBLIC_URL=              # bruk denne hvis klient-kode trenger URL-en direkte
+# R2_PUBLIC_URL=                          # holder for server-side-only bruk
+
+# Kun ved custom domain (f.eks. bilder.mortensrudherreklubb.no):
+# NEXT_PUBLIC_R2_CUSTOM_DOMAIN=bilder.mortensrudherreklubb.no
+
+# ─────────────────────────────────────────────────────────────────────────────
+# WEB PUSH / VAPID (kritisk — push-varsler fungerer ikke uten)
+# Generer nøkkelpar: npx web-push generate-vapid-keys
+# ─────────────────────────────────────────────────────────────────────────────
+
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=                         # SECRET
+# VAPID_CONTACT_EMAIL=                     # valgfri; default reidar.haavik@gmail.com
+
+# ─────────────────────────────────────────────────────────────────────────────
+# RESEND — utgående e-post (anbefalt; e-postvarsler mangler uten)
+# Hentes: resend.com → API Keys
+# Merk: domenet må verifiseres i Resend-dashboard for å sende fra egen avsender.
+# ─────────────────────────────────────────────────────────────────────────────
+
+RESEND_API_KEY=                            # SECRET
+# RESEND_FROM=Herreklubben <onboarding@resend.dev>   # valgfri; over er default
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CRON (anbefalt; påminnelsesvarsler sendes ikke uten)
+# CRON_SECRET: valgfri streng — samme verdi settes som GitHub Actions-secret
+# CRON_SECRET i repo-innstillinger. Workflow-secreten APP_URL (prod-URL)
+# settes KUN i GitHub, ikke her.
+# ─────────────────────────────────────────────────────────────────────────────
+
+CRON_SECRET=                               # SECRET
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GITHUB-INNSPILL (anbefalt; innspill-funksjonen mot GitHub Issues mangler uten)
+# GITHUB_TOKEN: fine-grained PAT med Issues read/write for NEXT_PUBLIC_GITHUB_REPO
+# GITHUB_WEBHOOK_SECRET: brukes til å validere innkommende webhook-kall
+# ─────────────────────────────────────────────────────────────────────────────
+
+GITHUB_TOKEN=                              # SECRET — fine-grained PAT med Issues read/write
+GITHUB_WEBHOOK_SECRET=                     # SECRET
+# NEXT_PUBLIC_GITHUB_REPO=reidarei/Herreklubben  # valgfri; over er default
+# NEXT_PUBLIC_GITHUB_ONSKE_LABEL=ønske           # valgfri; over er default
+
+# ─────────────────────────────────────────────────────────────────────────────
+# BASE-URL (valgfri — trengs normalt ikke)
+# Prod-URL utledes fra NEXT_PUBLIC_KLUBB_DOMENE, preview-URL fra VERCEL_URL
+# (settes automatisk av Vercel), og dev bruker localhost:3000.
+# Kun for spesialtilfeller som ikke-Vercel-deploy.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# NEXT_PUBLIC_BASE_URL=https://mortensrudherreklubb.no
+
+# ─────────────────────────────────────────────────────────────────────────────
+# KLUBBIDENTITET (valgfri — alle har defaults tilsvarende Mortensrud Herreklubb)
+# ─────────────────────────────────────────────────────────────────────────────
 
 # NEXT_PUBLIC_KLUBB_NAVN=Mortensrud Herreklubb
 # NEXT_PUBLIC_KLUBB_KORTNAVN=Herreklubben
@@ -13,12 +98,21 @@
 # NEXT_PUBLIC_KLUBB_STED=Søndre Nordstrand
 # NEXT_PUBLIC_ROLLE_TITTEL_GENERALSEKRETAER=Generalsekretær
 
-# Resend — avsendernavn i utgående e-post
-# RESEND_FROM=Herreklubben <onboarding@resend.dev>
+# ─────────────────────────────────────────────────────────────────────────────
+# DEV-ONLY
+# ─────────────────────────────────────────────────────────────────────────────
 
-# GitHub-innspill
-# NEXT_PUBLIC_GITHUB_REPO=reidarei/Herreklubben
-# NEXT_PUBLIC_GITHUB_ONSKE_LABEL=ønske
+# ALLOW_LOCAL_NOTIFICATIONS=true    # sett for å sende ekte varsler fra dev-miljø
 
-# Cloudflare R2 custom domain (når aktivert)
-# NEXT_PUBLIC_R2_CUSTOM_DOMAIN=bilder.mortensrudherreklubb.no
+# ─────────────────────────────────────────────────────────────────────────────
+# SETTES AV PLATTFORM/BUILD — ikke sett disse manuelt
+#
+# VERCEL_URL              — preview-URL, settes av Vercel på deployment
+# VERCEL_GIT_COMMIT_SHA   — commit-hash, settes av Vercel
+# NODE_ENV                — production|development, settes av runtime
+# BUILD_TIMESTAMP         — tidspunkt for bygget, settes av next.config.ts
+# APP_VERSION             — versjonstreng, settes av next.config.ts
+#
+# Skript-verktøy (import-skript, db push) bruker i tillegg:
+# SUPABASE_DB_PASSWORD    — se Supabase Dashboard → Project Settings → Database
+# ─────────────────────────────────────────────────────────────────────────────

--- a/.env.example
+++ b/.env.example
@@ -6,15 +6,26 @@
 #
 # NEXT_PUBLIC_-prefiks: disse verdiene inlines i browser-bundlen ved build.
 # ALDRI legg secrets (API-nøkler, private nøkler) med NEXT_PUBLIC_-prefiks.
+#
+# Merk om formatet i denne filen: Node `--env-file` tolker `#` som
+# kommentarstart MIDT i en linje, så trailing inline-kommentarer etter en
+# verdi kan klippe verdien. Vi plasserer derfor forklaringer på egen linje
+# OVER variabelen som skal fylles inn. Linjer som allerede er kommentert
+# ut i sin helhet (med ledende `#`) kan trygt ha trailing kommentar.
 
 # ─────────────────────────────────────────────────────────────────────────────
 # SUPABASE (kritisk — appen starter ikke uten disse)
 # Hentes: Supabase Dashboard → Project Settings → API
+#
+# Nye prosjekter (fra ~2025) får nøkler på formatet `sb_publishable_...`
+# (anon/klient) og `sb_secret_...` (service-role). Eldre prosjekter har
+# fortsatt legacy JWT (`eyJ...`). Begge formater fungerer.
 # ─────────────────────────────────────────────────────────────────────────────
 
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
-SUPABASE_SERVICE_ROLE_KEY=                 # SECRET
+# SECRET — service-role-nøkkel, må aldri eksponeres til klient
+SUPABASE_SERVICE_ROLE_KEY=
 
 # ─────────────────────────────────────────────────────────────────────────────
 # CLOUDFLARE R2 — bildelagring (kritisk)
@@ -22,15 +33,17 @@ SUPABASE_SERVICE_ROLE_KEY=                 # SECRET
 # ─────────────────────────────────────────────────────────────────────────────
 
 R2_ACCOUNT_ID=
-R2_ACCESS_KEY_ID=                          # SECRET
-R2_SECRET_ACCESS_KEY=                      # SECRET
+# SECRET
+R2_ACCESS_KEY_ID=
+# SECRET
+R2_SECRET_ACCESS_KEY=
 # R2_BUCKET=herreklubben-bilder            # valgfri; default er herreklubben-bilder
-# R2_JURISDICTION=eu                       # valgfri; default|eu|fedramp — velg etter bucket-jurisdiksjon
-R2_PUBLIC_URL=                             # eller NEXT_PUBLIC_R2_PUBLIC_URL (se under)
-
-# Sett én av disse to for public CDN-URL (minst én er kritisk):
-# NEXT_PUBLIC_R2_PUBLIC_URL=              # bruk denne hvis klient-kode trenger URL-en direkte
-# R2_PUBLIC_URL=                          # holder for server-side-only bruk
+# R2_JURISDICTION=eu                       # valgfri; default|eu — velg etter bucket-jurisdiksjon
+# Public CDN-URL for bilder — minst én av de to under må settes.
+# R2_PUBLIC_URL brukes server-side; NEXT_PUBLIC_R2_PUBLIC_URL er tilgjengelig
+# også fra klient-koden. Ofte settes samme verdi på begge.
+R2_PUBLIC_URL=
+# NEXT_PUBLIC_R2_PUBLIC_URL=
 
 # Kun ved custom domain (f.eks. bilder.mortensrudherreklubb.no):
 # NEXT_PUBLIC_R2_CUSTOM_DOMAIN=bilder.mortensrudherreklubb.no
@@ -38,20 +51,27 @@ R2_PUBLIC_URL=                             # eller NEXT_PUBLIC_R2_PUBLIC_URL (se
 # ─────────────────────────────────────────────────────────────────────────────
 # WEB PUSH / VAPID (kritisk — push-varsler fungerer ikke uten)
 # Generer nøkkelpar: npx web-push generate-vapid-keys
+# Den offentlige nøkkelen er et P-256 punkt (~87 base64url-tegn), den private
+# er en P-256 skalar (43–44 base64url-tegn) — derav lengdeforskjellen.
 # ─────────────────────────────────────────────────────────────────────────────
 
 NEXT_PUBLIC_VAPID_PUBLIC_KEY=
-VAPID_PRIVATE_KEY=                         # SECRET
+# SECRET
+VAPID_PRIVATE_KEY=
 # VAPID_CONTACT_EMAIL=                     # valgfri; default reidar.haavik@gmail.com
 
 # ─────────────────────────────────────────────────────────────────────────────
 # RESEND — utgående e-post (anbefalt; e-postvarsler mangler uten)
 # Hentes: resend.com → API Keys
-# Merk: domenet må verifiseres i Resend-dashboard for å sende fra egen avsender.
 # ─────────────────────────────────────────────────────────────────────────────
 
-RESEND_API_KEY=                            # SECRET
-# RESEND_FROM=Herreklubben <onboarding@resend.dev>   # valgfri; over er default
+# SECRET
+RESEND_API_KEY=
+# RESEND_FROM angir avsender. Defaulten "onboarding@resend.dev" fungerer KUN
+# for testing og kan bare sende til den registrerte Resend-kontoens egen
+# e-postadresse. For reell bruk må domenet verifiseres i Resend-dashboard og
+# en egen avsender på det domenet brukes (f.eks. "Klubben <noreply@klubb.no>").
+# RESEND_FROM=Herreklubben <onboarding@resend.dev>
 
 # ─────────────────────────────────────────────────────────────────────────────
 # CRON (anbefalt; påminnelsesvarsler sendes ikke uten)
@@ -60,16 +80,21 @@ RESEND_API_KEY=                            # SECRET
 # settes KUN i GitHub, ikke her.
 # ─────────────────────────────────────────────────────────────────────────────
 
-CRON_SECRET=                               # SECRET
+# SECRET
+CRON_SECRET=
 
 # ─────────────────────────────────────────────────────────────────────────────
-# GITHUB-INNSPILL (anbefalt; innspill-funksjonen mot GitHub Issues mangler uten)
-# GITHUB_TOKEN: fine-grained PAT med Issues read/write for NEXT_PUBLIC_GITHUB_REPO
+# GITHUB-INNSPILL (anbefalt; flere funksjoner mangler uten)
+# GITHUB_TOKEN: fine-grained PAT med Issues read/write for NEXT_PUBLIC_GITHUB_REPO.
+# Uten denne feiler både innspill-funksjonen og bli-utvikler-endepunktet
+# (/api/bli-utvikler) — sistnevnte krasjer hardt ved kall.
 # GITHUB_WEBHOOK_SECRET: brukes til å validere innkommende webhook-kall
 # ─────────────────────────────────────────────────────────────────────────────
 
-GITHUB_TOKEN=                              # SECRET — fine-grained PAT med Issues read/write
-GITHUB_WEBHOOK_SECRET=                     # SECRET
+# SECRET — fine-grained PAT med Issues read/write
+GITHUB_TOKEN=
+# SECRET
+GITHUB_WEBHOOK_SECRET=
 # NEXT_PUBLIC_GITHUB_REPO=reidarei/Herreklubben  # valgfri; over er default
 # NEXT_PUBLIC_GITHUB_ONSKE_LABEL=ønske           # valgfri; over er default
 
@@ -83,7 +108,8 @@ GITHUB_WEBHOOK_SECRET=                     # SECRET
 # NEXT_PUBLIC_BASE_URL=https://mortensrudherreklubb.no
 
 # ─────────────────────────────────────────────────────────────────────────────
-# KLUBBIDENTITET (valgfri — alle har defaults tilsvarende Mortensrud Herreklubb)
+# KLUBBIDENTITET (valgfri — defaults speiler Mortensrud Herreklubb, som er
+# kildeklubben. Ved fork: overstyr med egne verdier.)
 # ─────────────────────────────────────────────────────────────────────────────
 
 # NEXT_PUBLIC_KLUBB_NAVN=Mortensrud Herreklubb

--- a/README.md
+++ b/README.md
@@ -242,7 +242,9 @@ Skriptet sjekker tre nivåer:
 - **Anbefalt** (Resend, CRON_SECRET, GitHub-token) — appen starter, men e-post, påminnelsesvarsler eller innspill-funksjonen mangler.
 - **Valgfri** (klubbidentitet m.m.) — har defaults, vises kun hvis eksplisitt satt.
 
-**GitHub Actions-secrets** (`APP_URL`, `CRON_SECRET`) settes i repo Settings → Secrets and variables → Actions — ikke i `.env.local`.
+**CRON_SECRET** settes to steder med samme verdi: i Vercel env-vars (runtime-sjekken i cron-endepunktet) og som GitHub Actions-secret (workflow-en som sender headeren). Mismatch eller manglende verdi gir 401 fra cron-endepunktet.
+
+**APP_URL** settes kun som GitHub Actions-secret (peker workflow-en til prod-URL) — den brukes ikke av appen i runtime og hører ikke hjemme i `.env.local`.
 
 ## Lokalt utviklingsmiljø
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,24 @@ __tests__/       # Vitest — fokuserte enhets-tester på utvalgte helpers
 
 ---
 
+## Miljøvariabler
+
+Kopier `.env.example` til `.env.local`, fyll inn verdiene, og kjør `npm run sjekk-miljo` for å verifisere:
+
+```bash
+cp .env.example .env.local
+# fyll inn verdiene
+npm run sjekk-miljo
+```
+
+Skriptet sjekker tre nivåer:
+
+- **Kritisk** (Supabase, R2, VAPID) — appen/kjernefunksjoner starter ikke uten disse.
+- **Anbefalt** (Resend, CRON_SECRET, GitHub-token) — appen starter, men e-post, påminnelsesvarsler eller innspill-funksjonen mangler.
+- **Valgfri** (klubbidentitet m.m.) — har defaults, vises kun hvis eksplisitt satt.
+
+**GitHub Actions-secrets** (`APP_URL`, `CRON_SECRET`) settes i repo Settings → Secrets and variables → Actions — ikke i `.env.local`.
+
 ## Lokalt utviklingsmiljø
 
 ```bash
@@ -239,6 +257,7 @@ npm install
 npx vercel link
 npx vercel env pull .env.local --environment=production
 
+npm run sjekk-miljo  # verifiser miljøet
 npm run dev          # http://localhost:3000
 npm run build        # Produksjonsbygg
 npm run lint         # ESLint

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 12,
-  "versjon": "V3.2.12"
+  "nummer": 13,
+  "versjon": "V3.2.13"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 11,
-  "versjon": "V3.2.11"
+  "nummer": 12,
+  "versjon": "V3.2.12"
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "stamp-versjon": "node scripts/stamp-versjon.mjs",
-    "import:messenger": "node --env-file=.env.local scripts/import-messenger-klubbchat.mjs"
+    "import:messenger": "node --env-file=.env.local scripts/import-messenger-klubbchat.mjs",
+    "sjekk-miljo": "node --env-file=.env.local scripts/sjekk-miljo.mjs"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.2.12'
+const CACHE_VERSION = 'V3.2.13'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.2.11'
+const CACHE_VERSION = 'V3.2.12'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/scripts/sjekk-miljo.mjs
+++ b/scripts/sjekk-miljo.mjs
@@ -21,6 +21,20 @@ const erLegacyJwt = (v) => {
   return deler.length === 3 && deler[0].startsWith('eyJ')
 }
 
+// Hjelper: les `role`-claimen ut av en legacy Supabase-JWT.
+// Returnerer strengen ved suksess, eller null hvis payloaden ikke kan dekodes.
+// Vi printer ALDRI verdier herfra — kun navn på variabelen som ev. er byttet.
+const lesJwtRole = (v) => {
+  try {
+    const payload = JSON.parse(
+      Buffer.from(v.split('.')[1], 'base64url').toString('utf8'),
+    )
+    return typeof payload?.role === 'string' ? payload.role : null
+  } catch {
+    return null
+  }
+}
+
 const typer = {
   // Gyldig URL med https eller http
   url: (v) => {
@@ -31,12 +45,26 @@ const typer = {
   // To formatgenerasjoner finnes side om side:
   //   - Ny (fra ~2025): "sb_publishable_<base64>" — opaque token, ikke JWT.
   //   - Legacy: signert JWT (eyJ...). Eksisterende prosjekter har fortsatt denne.
-  // Vi godtar begge — gamle prosjekter trenger ikke roteres.
-  'supabase-publishable': (v) => v.startsWith('sb_publishable_') || erLegacyJwt(v),
+  // Vi godtar begge — gamle prosjekter trenger ikke roteres. For legacy JWT
+  // sjekker vi at role-claimen i payloaden er 'anon' så vi fanger nøkkelbytte
+  // (service_role lagt i anon-variabelen) — men aksepterer udekodbar payload
+  // for å ikke være strengere enn nødvendig mot ukjente legacy-varianter.
+  'supabase-publishable': (v) => {
+    if (v.startsWith('sb_publishable_')) return true
+    if (!erLegacyJwt(v)) return false
+    const role = lesJwtRole(v)
+    return role === null || role === 'anon'
+  },
   // Supabase secret/service-role-nøkkel.
   //   - Ny: "sb_secret_<base64>" — opaque token.
-  //   - Legacy: JWT med role: service_role i payload.
-  'supabase-secret': (v) => v.startsWith('sb_secret_') || erLegacyJwt(v),
+  //   - Legacy: JWT med role: service_role i payload. Vi sjekker claimen for
+  //     å fange byttede nøkler (anon-JWT lagt inn som service-role).
+  'supabase-secret': (v) => {
+    if (v.startsWith('sb_secret_')) return true
+    if (!erLegacyJwt(v)) return false
+    const role = lesJwtRole(v)
+    return role === null || role === 'service_role'
+  },
   // VAPID offentlig nøkkel: ukomprimert P-256 punkt → 65 bytes → 87 base64url-tegn
   // (uten padding). Bruker 80–100 for slingring rundt eventuelle implementasjoner
   // som padder eller hopper et tegn.
@@ -52,12 +80,17 @@ const typer = {
   // Resend API-nøkkel
   'resend-key': (v) => v.startsWith('re_'),
   // R2 jurisdiksjon — speiler verdiene lib/r2.ts faktisk forventer.
-  // 'default' gir tomt segment i endpointet, 'eu' gir '.eu'-segment.
-  'r2-jurisdiction': (v) => ['default', 'eu'].includes(v.toLowerCase()),
+  // 'default' gir tomt segment i endpointet, 'eu' gir '.eu'-segment,
+  // 'fedramp' gir '.fedramp'-segment (Cloudflares US-myndighetstilbud).
+  'r2-jurisdiction': (v) => ['default', 'eu', 'fedramp'].includes(v.toLowerCase()),
   // Ikke-tom streng
   streng: (v) => v.trim().length > 0,
   // Positivt heltall
   'pos-int': (v) => /^\d+$/.test(v) && parseInt(v, 10) > 0,
+  // Måned 1–12
+  maaned: (v) => /^\d+$/.test(v) && parseInt(v, 10) >= 1 && parseInt(v, 10) <= 12,
+  // Dag 1–31 (vi sjekker ikke at dag faktisk finnes i måneden — overkill her)
+  dag: (v) => /^\d+$/.test(v) && parseInt(v, 10) >= 1 && parseInt(v, 10) <= 31,
 }
 
 function valider(type, verdi) {
@@ -83,13 +116,16 @@ const variabler = [
   { navn: 'R2_ACCESS_KEY_ID',          nivaa: 'kritisk',   type: 'streng',   beskrivelse: 'R2 access key ID (SECRET)' },
   { navn: 'R2_SECRET_ACCESS_KEY',      nivaa: 'kritisk',   type: 'streng',   beskrivelse: 'R2 secret access key (SECRET)' },
   { navn: 'R2_BUCKET',                 nivaa: 'valgfri',   type: 'streng',   beskrivelse: 'R2 bucket-navn (default: herreklubben-bilder)' },
-  { navn: 'R2_JURISDICTION',           nivaa: 'valgfri',   type: 'r2-jurisdiction', beskrivelse: 'R2 jurisdiksjon: default|eu' },
+  { navn: 'R2_JURISDICTION',           nivaa: 'valgfri',   type: 'r2-jurisdiction', beskrivelse: 'R2 jurisdiksjon: default|eu|fedramp' },
   // R2_PUBLIC_URL og NEXT_PUBLIC_R2_PUBLIC_URL håndteres som spesialsjekk under
 
   // VAPID
   { navn: 'NEXT_PUBLIC_VAPID_PUBLIC_KEY', nivaa: 'kritisk', type: 'vapid-public',  beskrivelse: 'VAPID offentlig nøkkel (base64url, ~87 tegn)' },
   { navn: 'VAPID_PRIVATE_KEY',          nivaa: 'kritisk',   type: 'vapid-private', beskrivelse: 'VAPID privat nøkkel (base64url, 43–44 tegn, SECRET)' },
-  { navn: 'VAPID_CONTACT_EMAIL',        nivaa: 'valgfri',   type: 'epost',    beskrivelse: 'Kontakt-epost for push-tjenester' },
+  // Anbefalt fordi defaulten i lib/config.ts er kildeklubbens egen kontakt-epost.
+  // Ved fork: push-tjenester (Apple/Google) skal kunne nå klubbens egen kontakt,
+  // ikke en annens. Vi skriker ⚠ men blokkerer ikke.
+  { navn: 'VAPID_CONTACT_EMAIL',        nivaa: 'anbefalt',  type: 'epost',    beskrivelse: 'Kontakt-epost for push-tjenester — bør settes per klubb (default er kildeklubbens kontakt)' },
 
   // Resend
   { navn: 'RESEND_API_KEY',            nivaa: 'anbefalt',  type: 'resend-key', beskrivelse: 'Resend API-nøkkel (re_...) — e-postvarsler mangler uten' },
@@ -115,8 +151,8 @@ const variabler = [
   { navn: 'NEXT_PUBLIC_KLUBB_BESKRIVELSE',       nivaa: 'valgfri', type: 'streng', beskrivelse: 'Beskrivelse av appen' },
   { navn: 'NEXT_PUBLIC_KLUBB_DOMENE',            nivaa: 'valgfri', type: 'hostname', beskrivelse: 'Domenenavn (default: mortensrudherreklubb.no)' },
   { navn: 'NEXT_PUBLIC_KLUBB_STIFTET_AAR',       nivaa: 'valgfri', type: 'pos-int', beskrivelse: 'Stiftelsesår' },
-  { navn: 'NEXT_PUBLIC_KLUBB_STIFTET_MAANED',    nivaa: 'valgfri', type: 'pos-int', beskrivelse: 'Stiftelsesmåned (1–12)' },
-  { navn: 'NEXT_PUBLIC_KLUBB_STIFTET_DAG',       nivaa: 'valgfri', type: 'pos-int', beskrivelse: 'Stiftelsesdag (1–31)' },
+  { navn: 'NEXT_PUBLIC_KLUBB_STIFTET_MAANED',    nivaa: 'valgfri', type: 'maaned',  beskrivelse: 'Stiftelsesmåned (1–12)' },
+  { navn: 'NEXT_PUBLIC_KLUBB_STIFTET_DAG',       nivaa: 'valgfri', type: 'dag',     beskrivelse: 'Stiftelsesdag (1–31)' },
   { navn: 'NEXT_PUBLIC_KLUBB_STED',              nivaa: 'valgfri', type: 'streng', beskrivelse: 'Sted/bydel' },
   { navn: 'NEXT_PUBLIC_ROLLE_TITTEL_GENERALSEKRETAER', nivaa: 'valgfri', type: 'streng', beskrivelse: 'Tittel for generalsekretær-rollen' },
   { navn: 'NEXT_PUBLIC_R2_CUSTOM_DOMAIN',        nivaa: 'valgfri', type: 'hostname', beskrivelse: 'Custom domain for R2-bilder (kun ved eget domene)' },
@@ -164,8 +200,19 @@ for (const { navn, nivaa, type, beskrivelse } of variabler) {
   // Satt — formatkontroll
   const ok = valider(type, verdi)
   if (!ok) {
+    // Skill mellom rent formatfeil og legacy-JWT med feil role-claim.
+    // Sistnevnte er en sterk indikator på at nøklene er byttet om mellom
+    // anon- og service-role-variabelen — vanlig feil ved kopiering.
+    let melding = `ugyldig format (forventet: ${type})`
+    if ((type === 'supabase-publishable' || type === 'supabase-secret') && erLegacyJwt(verdi)) {
+      const role = lesJwtRole(verdi)
+      const forventetRole = type === 'supabase-secret' ? 'service_role' : 'anon'
+      if (role && role !== forventetRole) {
+        melding = `legacy JWT med role='${role}', forventet '${forventetRole}' — sannsynlig nøkkel-bytte mellom anon og service-role`
+      }
+    }
     // Satt, men feil format — alltid kritisk feil
-    const linje = `  ${r('✖')} ${navn} — ugyldig format (forventet: ${type})  (${beskrivelse})`
+    const linje = `  ${r('✖')} ${navn} — ${melding}  (${beskrivelse})`
     if (nivaa === 'kritisk') {
       meldinger.kritisk.push(linje)
     } else {

--- a/scripts/sjekk-miljo.mjs
+++ b/scripts/sjekk-miljo.mjs
@@ -15,19 +15,34 @@ const b = (s) => tty ? `\x1b[1m${s}\x1b[0m` : s    // fet
 
 // ─── TYPVALIDATORER ──────────────────────────────────────────────────────────
 
+// Hjelper: legacy Supabase-nøkkel er en JWT (eyJ + 3 deler).
+const erLegacyJwt = (v) => {
+  const deler = v.split('.')
+  return deler.length === 3 && deler[0].startsWith('eyJ')
+}
+
 const typer = {
   // Gyldig URL med https eller http
   url: (v) => {
     try { const u = new URL(v); return u.protocol === 'https:' || u.protocol === 'http:' }
     catch { return false }
   },
-  // JWT: tre punktum-separerte deler, første starter med eyJ (base64url for {"...)
-  jwt: (v) => {
-    const deler = v.split('.')
-    return deler.length === 3 && deler[0].startsWith('eyJ')
-  },
-  // VAPID-nøkler er base64url-kodet, 43 tegn (256-bit uten padding) eller 88 tegn (512-bit)
-  base64url: (v) => /^[A-Za-z0-9_-]{43,}$/.test(v),
+  // Supabase publishable/anon-nøkkel.
+  // To formatgenerasjoner finnes side om side:
+  //   - Ny (fra ~2025): "sb_publishable_<base64>" — opaque token, ikke JWT.
+  //   - Legacy: signert JWT (eyJ...). Eksisterende prosjekter har fortsatt denne.
+  // Vi godtar begge — gamle prosjekter trenger ikke roteres.
+  'supabase-publishable': (v) => v.startsWith('sb_publishable_') || erLegacyJwt(v),
+  // Supabase secret/service-role-nøkkel.
+  //   - Ny: "sb_secret_<base64>" — opaque token.
+  //   - Legacy: JWT med role: service_role i payload.
+  'supabase-secret': (v) => v.startsWith('sb_secret_') || erLegacyJwt(v),
+  // VAPID offentlig nøkkel: ukomprimert P-256 punkt → 65 bytes → 87 base64url-tegn
+  // (uten padding). Bruker 80–100 for slingring rundt eventuelle implementasjoner
+  // som padder eller hopper et tegn.
+  'vapid-public': (v) => /^[A-Za-z0-9_-]{80,100}$/.test(v),
+  // VAPID privat nøkkel: en P-256 skalar → 32 bytes → 43 base64url-tegn (44 med padding).
+  'vapid-private': (v) => /^[A-Za-z0-9_-]{43,44}$/.test(v),
   // E-postadresse
   epost: (v) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v),
   // Hostnavn (domene uten protokoll)
@@ -36,8 +51,9 @@ const typer = {
   'github-token': (v) => v.startsWith('ghp_') || v.startsWith('github_pat_') || v.startsWith('gho_'),
   // Resend API-nøkkel
   'resend-key': (v) => v.startsWith('re_'),
-  // R2 jurisdiksjon
-  'r2-jurisdiction': (v) => ['default', 'eu', 'fedramp'].includes(v.toLowerCase()),
+  // R2 jurisdiksjon — speiler verdiene lib/r2.ts faktisk forventer.
+  // 'default' gir tomt segment i endpointet, 'eu' gir '.eu'-segment.
+  'r2-jurisdiction': (v) => ['default', 'eu'].includes(v.toLowerCase()),
   // Ikke-tom streng
   streng: (v) => v.trim().length > 0,
   // Positivt heltall
@@ -56,23 +72,23 @@ function valider(type, verdi) {
 //        'anbefalt' → ⚠ ved mangler, ✖ ved satt-men-feil-format
 //        'valgfri'  → ✓ kun hvis satt, ellers stille
 
-const variablar = [
+const variabler = [
   // Supabase
   { navn: 'NEXT_PUBLIC_SUPABASE_URL',   nivaa: 'kritisk',   type: 'url',      beskrivelse: 'Supabase prosjekt-URL' },
-  { navn: 'NEXT_PUBLIC_SUPABASE_ANON_KEY', nivaa: 'kritisk', type: 'jwt',     beskrivelse: 'Supabase anon-nøkkel (JWT)' },
-  { navn: 'SUPABASE_SERVICE_ROLE_KEY',  nivaa: 'kritisk',   type: 'jwt',      beskrivelse: 'Supabase service-role-nøkkel (JWT, SECRET)' },
+  { navn: 'NEXT_PUBLIC_SUPABASE_ANON_KEY', nivaa: 'kritisk', type: 'supabase-publishable', beskrivelse: 'Supabase anon/publishable-nøkkel (sb_publishable_... eller legacy JWT)' },
+  { navn: 'SUPABASE_SERVICE_ROLE_KEY',  nivaa: 'kritisk',   type: 'supabase-secret', beskrivelse: 'Supabase service-role-nøkkel (sb_secret_... eller legacy JWT, SECRET)' },
 
   // R2
   { navn: 'R2_ACCOUNT_ID',             nivaa: 'kritisk',   type: 'streng',   beskrivelse: 'Cloudflare konto-ID' },
   { navn: 'R2_ACCESS_KEY_ID',          nivaa: 'kritisk',   type: 'streng',   beskrivelse: 'R2 access key ID (SECRET)' },
   { navn: 'R2_SECRET_ACCESS_KEY',      nivaa: 'kritisk',   type: 'streng',   beskrivelse: 'R2 secret access key (SECRET)' },
   { navn: 'R2_BUCKET',                 nivaa: 'valgfri',   type: 'streng',   beskrivelse: 'R2 bucket-navn (default: herreklubben-bilder)' },
-  { navn: 'R2_JURISDICTION',           nivaa: 'valgfri',   type: 'r2-jurisdiction', beskrivelse: 'R2 jurisdiksjon: default|eu|fedramp' },
+  { navn: 'R2_JURISDICTION',           nivaa: 'valgfri',   type: 'r2-jurisdiction', beskrivelse: 'R2 jurisdiksjon: default|eu' },
   // R2_PUBLIC_URL og NEXT_PUBLIC_R2_PUBLIC_URL håndteres som spesialsjekk under
 
   // VAPID
-  { navn: 'NEXT_PUBLIC_VAPID_PUBLIC_KEY', nivaa: 'kritisk', type: 'base64url', beskrivelse: 'VAPID offentlig nøkkel (base64url)' },
-  { navn: 'VAPID_PRIVATE_KEY',          nivaa: 'kritisk',   type: 'base64url', beskrivelse: 'VAPID privat nøkkel (base64url, SECRET)' },
+  { navn: 'NEXT_PUBLIC_VAPID_PUBLIC_KEY', nivaa: 'kritisk', type: 'vapid-public',  beskrivelse: 'VAPID offentlig nøkkel (base64url, ~87 tegn)' },
+  { navn: 'VAPID_PRIVATE_KEY',          nivaa: 'kritisk',   type: 'vapid-private', beskrivelse: 'VAPID privat nøkkel (base64url, 43–44 tegn, SECRET)' },
   { navn: 'VAPID_CONTACT_EMAIL',        nivaa: 'valgfri',   type: 'epost',    beskrivelse: 'Kontakt-epost for push-tjenester' },
 
   // Resend
@@ -83,7 +99,7 @@ const variablar = [
   { navn: 'CRON_SECRET',               nivaa: 'anbefalt',  type: 'streng',   beskrivelse: 'Delt hemmelighet for cron-endepunkt — påminnelsesvarsler mangler uten' },
 
   // GitHub
-  { navn: 'GITHUB_TOKEN',              nivaa: 'anbefalt',  type: 'github-token', beskrivelse: 'GitHub PAT (ghp_/github_pat_) — innspill-funksjon mangler uten' },
+  { navn: 'GITHUB_TOKEN',              nivaa: 'anbefalt',  type: 'github-token', beskrivelse: 'GitHub PAT (ghp_/github_pat_) — innspill-funksjon + bli-utvikler-endepunktet (/api/bli-utvikler) feiler uten' },
   { navn: 'GITHUB_WEBHOOK_SECRET',     nivaa: 'anbefalt',  type: 'streng',   beskrivelse: 'GitHub webhook-hemmelighet — innkommende webhook-validering mangler uten' },
   { navn: 'NEXT_PUBLIC_GITHUB_REPO',   nivaa: 'valgfri',   type: 'streng',   beskrivelse: 'GitHub-repo for innspill (default: reidarei/Herreklubben)' },
   { navn: 'NEXT_PUBLIC_GITHUB_ONSKE_LABEL', nivaa: 'valgfri', type: 'streng', beskrivelse: 'GitHub Issues-label for ønsker (default: ønske)' },
@@ -112,10 +128,10 @@ const variablar = [
 // ─── INNSAMLING OG SJEKK ─────────────────────────────────────────────────────
 
 let kritiskFeil = 0
-let advarslar = 0
-const meldingar = { kritisk: [], anbefalt: [], valgfri: [] }
+let advarsler = 0
+const meldinger = { kritisk: [], anbefalt: [], valgfri: [] }
 
-for (const { navn, nivaa, type, beskrivelse } of variablar) {
+for (const { navn, nivaa, type, beskrivelse } of variabler) {
   const verdi = process.env[navn]
   const satt = verdi !== undefined && verdi !== ''
 
@@ -123,10 +139,10 @@ for (const { navn, nivaa, type, beskrivelse } of variablar) {
     if (satt) {
       const ok = valider(type, verdi)
       if (ok) {
-        meldingar.valgfri.push(`  ${g('✓')} ${navn}`)
+        meldinger.valgfri.push(`  ${g('✓')} ${navn}`)
       } else {
         // Satt, men feil format — alltid feil uansett nivå
-        meldingar.valgfri.push(`  ${r('✖')} ${navn} — satt, men ugyldig format (${type})`)
+        meldinger.valgfri.push(`  ${r('✖')} ${navn} — satt, men ugyldig format (${type})`)
         kritiskFeil++
       }
     }
@@ -136,11 +152,11 @@ for (const { navn, nivaa, type, beskrivelse } of variablar) {
 
   if (!satt) {
     if (nivaa === 'kritisk') {
-      meldingar.kritisk.push(`  ${r('✖')} ${navn} — mangler  (${beskrivelse})`)
+      meldinger.kritisk.push(`  ${r('✖')} ${navn} — mangler  (${beskrivelse})`)
       kritiskFeil++
     } else {
-      meldingar.anbefalt.push(`  ${y('⚠')} ${navn} — ikke satt  (${beskrivelse})`)
-      advarslar++
+      meldinger.anbefalt.push(`  ${y('⚠')} ${navn} — ikke satt  (${beskrivelse})`)
+      advarsler++
     }
     continue
   }
@@ -151,66 +167,56 @@ for (const { navn, nivaa, type, beskrivelse } of variablar) {
     // Satt, men feil format — alltid kritisk feil
     const linje = `  ${r('✖')} ${navn} — ugyldig format (forventet: ${type})  (${beskrivelse})`
     if (nivaa === 'kritisk') {
-      meldingar.kritisk.push(linje)
+      meldinger.kritisk.push(linje)
     } else {
-      meldingar.anbefalt.push(linje)
+      meldinger.anbefalt.push(linje)
     }
     kritiskFeil++
     continue
   }
 
   if (nivaa === 'kritisk') {
-    meldingar.kritisk.push(`  ${g('✓')} ${navn}`)
+    meldinger.kritisk.push(`  ${g('✓')} ${navn}`)
   } else {
-    meldingar.anbefalt.push(`  ${g('✓')} ${navn}`)
+    meldinger.anbefalt.push(`  ${g('✓')} ${navn}`)
   }
 }
 
 // ─── SPESIALSJEKK 1: R2 public URL ──────────────────────────────────────────
 // Minst én av R2_PUBLIC_URL eller NEXT_PUBLIC_R2_PUBLIC_URL må være satt.
+// Vi rapporterer som én linje for å unngå støy når begge er satt til samme verdi.
 
 const r2PubServer = process.env.R2_PUBLIC_URL
 const r2PubKlient = process.env.NEXT_PUBLIC_R2_PUBLIC_URL
-const r2PubSatt = (r2PubServer && r2PubServer !== '') || (r2PubKlient && r2PubKlient !== '')
+const r2ServerSatt = r2PubServer && r2PubServer !== ''
+const r2KlientSatt = r2PubKlient && r2PubKlient !== ''
 
-if (!r2PubSatt) {
-  meldingar.kritisk.push(`  ${r('✖')} R2_PUBLIC_URL / NEXT_PUBLIC_R2_PUBLIC_URL — minst én må settes (bilder kan ikke vises uten)`)
+if (!r2ServerSatt && !r2KlientSatt) {
+  meldinger.kritisk.push(`  ${r('✖')} R2_PUBLIC_URL / NEXT_PUBLIC_R2_PUBLIC_URL — minst én må settes (bilder kan ikke vises uten)`)
   kritiskFeil++
 } else {
   // Valider format på de som er satt
-  if (r2PubServer && r2PubServer !== '') {
-    if (!typer.url(r2PubServer)) {
-      meldingar.kritisk.push(`  ${r('✖')} R2_PUBLIC_URL — ugyldig URL-format`)
-      kritiskFeil++
-    } else {
-      meldingar.kritisk.push(`  ${g('✓')} R2_PUBLIC_URL`)
-    }
+  const serverOk = !r2ServerSatt || typer.url(r2PubServer)
+  const klientOk = !r2KlientSatt || typer.url(r2PubKlient)
+
+  if (!serverOk) {
+    meldinger.kritisk.push(`  ${r('✖')} R2_PUBLIC_URL — ugyldig URL-format`)
+    kritiskFeil++
   }
-  if (r2PubKlient && r2PubKlient !== '') {
-    if (!typer.url(r2PubKlient)) {
-      meldingar.kritisk.push(`  ${r('✖')} NEXT_PUBLIC_R2_PUBLIC_URL — ugyldig URL-format`)
-      kritiskFeil++
-    } else {
-      meldingar.kritisk.push(`  ${g('✓')} NEXT_PUBLIC_R2_PUBLIC_URL`)
-    }
+  if (!klientOk) {
+    meldinger.kritisk.push(`  ${r('✖')} NEXT_PUBLIC_R2_PUBLIC_URL — ugyldig URL-format`)
+    kritiskFeil++
+  }
+  if (serverOk && klientOk) {
+    // Beskriv hvilken som faktisk er satt — gir nyttig synlighet uten å printe verdier.
+    const navn = r2ServerSatt && r2KlientSatt
+      ? 'R2_PUBLIC_URL + NEXT_PUBLIC_R2_PUBLIC_URL (begge satt)'
+      : r2ServerSatt ? 'R2_PUBLIC_URL' : 'NEXT_PUBLIC_R2_PUBLIC_URL'
+    meldinger.kritisk.push(`  ${g('✓')} R2 public URL (${navn})`)
   }
 }
 
-// ─── SPESIALSJEKK 2: VAPID-nøkler i par ─────────────────────────────────────
-// Begge må settes — advarsel hvis kun én er satt (fanges også av kritisk-sjekk,
-// men her gir vi en spesifikk parforklaring).
-
-const vapidPub = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
-const vapidPriv = process.env.VAPID_PRIVATE_KEY
-const vapidPubSatt = vapidPub && vapidPub !== ''
-const vapidPrivSatt = vapidPriv && vapidPriv !== ''
-if (vapidPubSatt !== vapidPrivSatt) {
-  meldingar.kritisk.push(
-    `  ${y('⚠')} VAPID-nøkler er ikke i par — begge må genereres og settes sammen (npx web-push generate-vapid-keys)`
-  )
-}
-
-// ─── SPESIALSJEKK 3: BASE_URL vs KLUBB_DOMENE drift ─────────────────────────
+// ─── SPESIALSJEKK 2: BASE_URL vs KLUBB_DOMENE drift ─────────────────────────
 // Hvis begge er satt og BASE_URL ikke stemmer med KLUBB_DOMENE, er det
 // to sannhetskilder som kan gi forskjellige URL-er i varsler og ICS.
 
@@ -219,14 +225,14 @@ const klubbDomene = process.env.NEXT_PUBLIC_KLUBB_DOMENE
 if (baseUrl && baseUrl !== '' && klubbDomene && klubbDomene !== '') {
   const forventet = `https://${klubbDomene}`
   if (baseUrl !== forventet) {
-    meldingar.anbefalt.push(
+    meldinger.anbefalt.push(
       `  ${y('⚠')} NEXT_PUBLIC_BASE_URL (${baseUrl}) stemmer ikke med NEXT_PUBLIC_KLUBB_DOMENE (${forventet}) — mulig drift mellom to sannhetskilder`
     )
-    advarslar++
+    advarsler++
   }
 }
 
-// ─── SPESIALSJEKK 4: Secret-lekkasje i NEXT_PUBLIC_ ─────────────────────────
+// ─── SPESIALSJEKK 3: Secret-lekkasje i NEXT_PUBLIC_ ─────────────────────────
 // Heuristikk: hvis verdien til en NEXT_PUBLIC_-variabel ligner et kjent
 // secret-format, er det sannsynligvis en feilkonfigurasjon.
 // VIKTIG: vi printer ALDRI verdien — kun variabelnavnet.
@@ -236,12 +242,19 @@ for (const [key, val] of Object.entries(process.env)) {
 
   let lekkasje = false
 
-  // Kjente token-prefikser
-  if (val.startsWith('ghp_') || val.startsWith('github_pat_') || val.startsWith('re_')) {
+  // Kjente token-prefikser — inkluderer både Supabase ny-format (sb_secret_)
+  // og GitHub/Resend.
+  if (
+    val.startsWith('ghp_') ||
+    val.startsWith('github_pat_') ||
+    val.startsWith('re_') ||
+    val.startsWith('sb_secret_')
+  ) {
     lekkasje = true
   }
 
-  // JWT med service_role i payload (base64-dekod midtdel, let etter "role":"service_role")
+  // Legacy Supabase JWT med service_role i payload
+  // (base64-dekod midtdel, let etter "role":"service_role")
   if (!lekkasje && val.split('.').length === 3) {
     try {
       const payload = JSON.parse(Buffer.from(val.split('.')[1], 'base64url').toString('utf8'))
@@ -250,7 +263,7 @@ for (const [key, val] of Object.entries(process.env)) {
   }
 
   if (lekkasje) {
-    meldingar.kritisk.push(
+    meldinger.kritisk.push(
       `  ${r('✖')} ${key} — verdien ser ut som et secret (token/nøkkel) og skal IKKE ha NEXT_PUBLIC_-prefiks (inlines i browser-bundle)`
     )
     kritiskFeil++
@@ -263,34 +276,34 @@ console.log('')
 console.log(b('=== Herreklubben — miljøsjekk ==='))
 console.log('')
 
-if (meldingar.kritisk.length > 0) {
+if (meldinger.kritisk.length > 0) {
   console.log(b('Kritiske (app starter ikke uten):'))
-  meldingar.kritisk.forEach((m) => console.log(m))
+  meldinger.kritisk.forEach((m) => console.log(m))
   console.log('')
 }
 
-if (meldingar.anbefalt.length > 0) {
+if (meldinger.anbefalt.length > 0) {
   console.log(b('Anbefalte (mangler gir redusert funksjonalitet):'))
-  meldingar.anbefalt.forEach((m) => console.log(m))
+  meldinger.anbefalt.forEach((m) => console.log(m))
   console.log('')
 }
 
-if (meldingar.valgfri.length > 0) {
+if (meldinger.valgfri.length > 0) {
   console.log(b('Valgfrie (satt, med defaults):'))
-  meldingar.valgfri.forEach((m) => console.log(m))
+  meldinger.valgfri.forEach((m) => console.log(m))
   console.log('')
 }
 
 // Oppsummering
-const kritiskOk = meldingar.kritisk.filter((m) => m.includes('✓')).length
-const anbefaltOk = meldingar.anbefalt.filter((m) => m.includes('✓')).length
+const kritiskOk = meldinger.kritisk.filter((m) => m.includes('✓')).length
+const anbefaltOk = meldinger.anbefalt.filter((m) => m.includes('✓')).length
 
-if (kritiskFeil === 0 && advarslar === 0) {
+if (kritiskFeil === 0 && advarsler === 0) {
   console.log(g(`✓ Alt OK — ${kritiskOk} kritiske og ${anbefaltOk} anbefalte variabler er satt og gyldige.`))
 } else if (kritiskFeil === 0) {
-  console.log(y(`⚠ ${advarslar} advarsel(er) — ${kritiskOk} kritiske OK. Appen starter, men noen funksjoner mangler.`))
+  console.log(y(`⚠ ${advarsler} advarsel(er) — ${kritiskOk} kritiske OK. Appen starter, men noen funksjoner mangler.`))
 } else {
-  console.log(r(`✖ ${kritiskFeil} kritisk feil — ${advarslar} advarsel(er). Fiks feil markert med ✖ før deploy.`))
+  console.log(r(`✖ ${kritiskFeil} kritisk feil — ${advarsler} advarsel(er). Fiks feil markert med ✖ før deploy.`))
 }
 console.log('')
 

--- a/scripts/sjekk-miljo.mjs
+++ b/scripts/sjekk-miljo.mjs
@@ -1,0 +1,297 @@
+// Validerer miljøvariabler for Herreklubben-appen.
+// Sjekker format og tilstedeværelse, og rapporterer mangler per nivå.
+//
+// Kjøres: npm run sjekk-miljo  (alias for node --env-file=.env.local scripts/sjekk-miljo.mjs)
+//
+// Exit-kode 0 = OK (evt. advarsler), 1 = kritisk feil.
+
+// ─── ANSI-farger (kun i TTY) ────────────────────────────────────────────────
+
+const tty = process.stdout.isTTY
+const r = (s) => tty ? `\x1b[31m${s}\x1b[0m` : s   // rød
+const g = (s) => tty ? `\x1b[32m${s}\x1b[0m` : s   // grønn
+const y = (s) => tty ? `\x1b[33m${s}\x1b[0m` : s   // gul
+const b = (s) => tty ? `\x1b[1m${s}\x1b[0m` : s    // fet
+
+// ─── TYPVALIDATORER ──────────────────────────────────────────────────────────
+
+const typer = {
+  // Gyldig URL med https eller http
+  url: (v) => {
+    try { const u = new URL(v); return u.protocol === 'https:' || u.protocol === 'http:' }
+    catch { return false }
+  },
+  // JWT: tre punktum-separerte deler, første starter med eyJ (base64url for {"...)
+  jwt: (v) => {
+    const deler = v.split('.')
+    return deler.length === 3 && deler[0].startsWith('eyJ')
+  },
+  // VAPID-nøkler er base64url-kodet, 43 tegn (256-bit uten padding) eller 88 tegn (512-bit)
+  base64url: (v) => /^[A-Za-z0-9_-]{43,}$/.test(v),
+  // E-postadresse
+  epost: (v) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v),
+  // Hostnavn (domene uten protokoll)
+  hostname: (v) => /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*\.[a-zA-Z]{2,}$/.test(v),
+  // GitHub-token med kjente prefikser
+  'github-token': (v) => v.startsWith('ghp_') || v.startsWith('github_pat_') || v.startsWith('gho_'),
+  // Resend API-nøkkel
+  'resend-key': (v) => v.startsWith('re_'),
+  // R2 jurisdiksjon
+  'r2-jurisdiction': (v) => ['default', 'eu', 'fedramp'].includes(v.toLowerCase()),
+  // Ikke-tom streng
+  streng: (v) => v.trim().length > 0,
+  // Positivt heltall
+  'pos-int': (v) => /^\d+$/.test(v) && parseInt(v, 10) > 0,
+}
+
+function valider(type, verdi) {
+  const fn = typer[type]
+  if (!fn) return true // ukjent type = ingen formatsjekk
+  return fn(verdi)
+}
+
+// ─── VARIABELDEFINISJON ──────────────────────────────────────────────────────
+//
+// nivaa: 'kritisk' → ✖ + exit 1 ved feil/mangler
+//        'anbefalt' → ⚠ ved mangler, ✖ ved satt-men-feil-format
+//        'valgfri'  → ✓ kun hvis satt, ellers stille
+
+const variablar = [
+  // Supabase
+  { navn: 'NEXT_PUBLIC_SUPABASE_URL',   nivaa: 'kritisk',   type: 'url',      beskrivelse: 'Supabase prosjekt-URL' },
+  { navn: 'NEXT_PUBLIC_SUPABASE_ANON_KEY', nivaa: 'kritisk', type: 'jwt',     beskrivelse: 'Supabase anon-nøkkel (JWT)' },
+  { navn: 'SUPABASE_SERVICE_ROLE_KEY',  nivaa: 'kritisk',   type: 'jwt',      beskrivelse: 'Supabase service-role-nøkkel (JWT, SECRET)' },
+
+  // R2
+  { navn: 'R2_ACCOUNT_ID',             nivaa: 'kritisk',   type: 'streng',   beskrivelse: 'Cloudflare konto-ID' },
+  { navn: 'R2_ACCESS_KEY_ID',          nivaa: 'kritisk',   type: 'streng',   beskrivelse: 'R2 access key ID (SECRET)' },
+  { navn: 'R2_SECRET_ACCESS_KEY',      nivaa: 'kritisk',   type: 'streng',   beskrivelse: 'R2 secret access key (SECRET)' },
+  { navn: 'R2_BUCKET',                 nivaa: 'valgfri',   type: 'streng',   beskrivelse: 'R2 bucket-navn (default: herreklubben-bilder)' },
+  { navn: 'R2_JURISDICTION',           nivaa: 'valgfri',   type: 'r2-jurisdiction', beskrivelse: 'R2 jurisdiksjon: default|eu|fedramp' },
+  // R2_PUBLIC_URL og NEXT_PUBLIC_R2_PUBLIC_URL håndteres som spesialsjekk under
+
+  // VAPID
+  { navn: 'NEXT_PUBLIC_VAPID_PUBLIC_KEY', nivaa: 'kritisk', type: 'base64url', beskrivelse: 'VAPID offentlig nøkkel (base64url)' },
+  { navn: 'VAPID_PRIVATE_KEY',          nivaa: 'kritisk',   type: 'base64url', beskrivelse: 'VAPID privat nøkkel (base64url, SECRET)' },
+  { navn: 'VAPID_CONTACT_EMAIL',        nivaa: 'valgfri',   type: 'epost',    beskrivelse: 'Kontakt-epost for push-tjenester' },
+
+  // Resend
+  { navn: 'RESEND_API_KEY',            nivaa: 'anbefalt',  type: 'resend-key', beskrivelse: 'Resend API-nøkkel (re_...) — e-postvarsler mangler uten' },
+  { navn: 'RESEND_FROM',               nivaa: 'valgfri',   type: 'streng',   beskrivelse: 'Avsendernavn i utgående e-post' },
+
+  // Cron
+  { navn: 'CRON_SECRET',               nivaa: 'anbefalt',  type: 'streng',   beskrivelse: 'Delt hemmelighet for cron-endepunkt — påminnelsesvarsler mangler uten' },
+
+  // GitHub
+  { navn: 'GITHUB_TOKEN',              nivaa: 'anbefalt',  type: 'github-token', beskrivelse: 'GitHub PAT (ghp_/github_pat_) — innspill-funksjon mangler uten' },
+  { navn: 'GITHUB_WEBHOOK_SECRET',     nivaa: 'anbefalt',  type: 'streng',   beskrivelse: 'GitHub webhook-hemmelighet — innkommende webhook-validering mangler uten' },
+  { navn: 'NEXT_PUBLIC_GITHUB_REPO',   nivaa: 'valgfri',   type: 'streng',   beskrivelse: 'GitHub-repo for innspill (default: reidarei/Herreklubben)' },
+  { navn: 'NEXT_PUBLIC_GITHUB_ONSKE_LABEL', nivaa: 'valgfri', type: 'streng', beskrivelse: 'GitHub Issues-label for ønsker (default: ønske)' },
+
+  // Base-URL
+  { navn: 'NEXT_PUBLIC_BASE_URL',      nivaa: 'valgfri',   type: 'url',      beskrivelse: 'Base-URL override (trengs normalt ikke — utledes fra KLUBB_DOMENE/VERCEL_URL)' },
+
+  // Klubbidentitet
+  { navn: 'NEXT_PUBLIC_KLUBB_NAVN',              nivaa: 'valgfri', type: 'streng', beskrivelse: 'Klubbnavn (default: Mortensrud Herreklubb)' },
+  { navn: 'NEXT_PUBLIC_KLUBB_KORTNAVN',          nivaa: 'valgfri', type: 'streng', beskrivelse: 'Kortnavn (default: Herreklubben)' },
+  { navn: 'NEXT_PUBLIC_KLUBB_NAVN_LINJE_1',      nivaa: 'valgfri', type: 'streng', beskrivelse: 'Visningsnavn linje 1' },
+  { navn: 'NEXT_PUBLIC_KLUBB_NAVN_LINJE_2',      nivaa: 'valgfri', type: 'streng', beskrivelse: 'Visningsnavn linje 2' },
+  { navn: 'NEXT_PUBLIC_KLUBB_BESKRIVELSE',       nivaa: 'valgfri', type: 'streng', beskrivelse: 'Beskrivelse av appen' },
+  { navn: 'NEXT_PUBLIC_KLUBB_DOMENE',            nivaa: 'valgfri', type: 'hostname', beskrivelse: 'Domenenavn (default: mortensrudherreklubb.no)' },
+  { navn: 'NEXT_PUBLIC_KLUBB_STIFTET_AAR',       nivaa: 'valgfri', type: 'pos-int', beskrivelse: 'Stiftelsesår' },
+  { navn: 'NEXT_PUBLIC_KLUBB_STIFTET_MAANED',    nivaa: 'valgfri', type: 'pos-int', beskrivelse: 'Stiftelsesmåned (1–12)' },
+  { navn: 'NEXT_PUBLIC_KLUBB_STIFTET_DAG',       nivaa: 'valgfri', type: 'pos-int', beskrivelse: 'Stiftelsesdag (1–31)' },
+  { navn: 'NEXT_PUBLIC_KLUBB_STED',              nivaa: 'valgfri', type: 'streng', beskrivelse: 'Sted/bydel' },
+  { navn: 'NEXT_PUBLIC_ROLLE_TITTEL_GENERALSEKRETAER', nivaa: 'valgfri', type: 'streng', beskrivelse: 'Tittel for generalsekretær-rollen' },
+  { navn: 'NEXT_PUBLIC_R2_CUSTOM_DOMAIN',        nivaa: 'valgfri', type: 'hostname', beskrivelse: 'Custom domain for R2-bilder (kun ved eget domene)' },
+
+  // Dev-only
+  { navn: 'ALLOW_LOCAL_NOTIFICATIONS',  nivaa: 'valgfri', type: 'streng', beskrivelse: 'Aktiver ekte varsler i dev (sett true)' },
+]
+
+// ─── INNSAMLING OG SJEKK ─────────────────────────────────────────────────────
+
+let kritiskFeil = 0
+let advarslar = 0
+const meldingar = { kritisk: [], anbefalt: [], valgfri: [] }
+
+for (const { navn, nivaa, type, beskrivelse } of variablar) {
+  const verdi = process.env[navn]
+  const satt = verdi !== undefined && verdi !== ''
+
+  if (nivaa === 'valgfri') {
+    if (satt) {
+      const ok = valider(type, verdi)
+      if (ok) {
+        meldingar.valgfri.push(`  ${g('✓')} ${navn}`)
+      } else {
+        // Satt, men feil format — alltid feil uansett nivå
+        meldingar.valgfri.push(`  ${r('✖')} ${navn} — satt, men ugyldig format (${type})`)
+        kritiskFeil++
+      }
+    }
+    // Ikke satt og valgfri → stille
+    continue
+  }
+
+  if (!satt) {
+    if (nivaa === 'kritisk') {
+      meldingar.kritisk.push(`  ${r('✖')} ${navn} — mangler  (${beskrivelse})`)
+      kritiskFeil++
+    } else {
+      meldingar.anbefalt.push(`  ${y('⚠')} ${navn} — ikke satt  (${beskrivelse})`)
+      advarslar++
+    }
+    continue
+  }
+
+  // Satt — formatkontroll
+  const ok = valider(type, verdi)
+  if (!ok) {
+    // Satt, men feil format — alltid kritisk feil
+    const linje = `  ${r('✖')} ${navn} — ugyldig format (forventet: ${type})  (${beskrivelse})`
+    if (nivaa === 'kritisk') {
+      meldingar.kritisk.push(linje)
+    } else {
+      meldingar.anbefalt.push(linje)
+    }
+    kritiskFeil++
+    continue
+  }
+
+  if (nivaa === 'kritisk') {
+    meldingar.kritisk.push(`  ${g('✓')} ${navn}`)
+  } else {
+    meldingar.anbefalt.push(`  ${g('✓')} ${navn}`)
+  }
+}
+
+// ─── SPESIALSJEKK 1: R2 public URL ──────────────────────────────────────────
+// Minst én av R2_PUBLIC_URL eller NEXT_PUBLIC_R2_PUBLIC_URL må være satt.
+
+const r2PubServer = process.env.R2_PUBLIC_URL
+const r2PubKlient = process.env.NEXT_PUBLIC_R2_PUBLIC_URL
+const r2PubSatt = (r2PubServer && r2PubServer !== '') || (r2PubKlient && r2PubKlient !== '')
+
+if (!r2PubSatt) {
+  meldingar.kritisk.push(`  ${r('✖')} R2_PUBLIC_URL / NEXT_PUBLIC_R2_PUBLIC_URL — minst én må settes (bilder kan ikke vises uten)`)
+  kritiskFeil++
+} else {
+  // Valider format på de som er satt
+  if (r2PubServer && r2PubServer !== '') {
+    if (!typer.url(r2PubServer)) {
+      meldingar.kritisk.push(`  ${r('✖')} R2_PUBLIC_URL — ugyldig URL-format`)
+      kritiskFeil++
+    } else {
+      meldingar.kritisk.push(`  ${g('✓')} R2_PUBLIC_URL`)
+    }
+  }
+  if (r2PubKlient && r2PubKlient !== '') {
+    if (!typer.url(r2PubKlient)) {
+      meldingar.kritisk.push(`  ${r('✖')} NEXT_PUBLIC_R2_PUBLIC_URL — ugyldig URL-format`)
+      kritiskFeil++
+    } else {
+      meldingar.kritisk.push(`  ${g('✓')} NEXT_PUBLIC_R2_PUBLIC_URL`)
+    }
+  }
+}
+
+// ─── SPESIALSJEKK 2: VAPID-nøkler i par ─────────────────────────────────────
+// Begge må settes — advarsel hvis kun én er satt (fanges også av kritisk-sjekk,
+// men her gir vi en spesifikk parforklaring).
+
+const vapidPub = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+const vapidPriv = process.env.VAPID_PRIVATE_KEY
+const vapidPubSatt = vapidPub && vapidPub !== ''
+const vapidPrivSatt = vapidPriv && vapidPriv !== ''
+if (vapidPubSatt !== vapidPrivSatt) {
+  meldingar.kritisk.push(
+    `  ${y('⚠')} VAPID-nøkler er ikke i par — begge må genereres og settes sammen (npx web-push generate-vapid-keys)`
+  )
+}
+
+// ─── SPESIALSJEKK 3: BASE_URL vs KLUBB_DOMENE drift ─────────────────────────
+// Hvis begge er satt og BASE_URL ikke stemmer med KLUBB_DOMENE, er det
+// to sannhetskilder som kan gi forskjellige URL-er i varsler og ICS.
+
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL
+const klubbDomene = process.env.NEXT_PUBLIC_KLUBB_DOMENE
+if (baseUrl && baseUrl !== '' && klubbDomene && klubbDomene !== '') {
+  const forventet = `https://${klubbDomene}`
+  if (baseUrl !== forventet) {
+    meldingar.anbefalt.push(
+      `  ${y('⚠')} NEXT_PUBLIC_BASE_URL (${baseUrl}) stemmer ikke med NEXT_PUBLIC_KLUBB_DOMENE (${forventet}) — mulig drift mellom to sannhetskilder`
+    )
+    advarslar++
+  }
+}
+
+// ─── SPESIALSJEKK 4: Secret-lekkasje i NEXT_PUBLIC_ ─────────────────────────
+// Heuristikk: hvis verdien til en NEXT_PUBLIC_-variabel ligner et kjent
+// secret-format, er det sannsynligvis en feilkonfigurasjon.
+// VIKTIG: vi printer ALDRI verdien — kun variabelnavnet.
+
+for (const [key, val] of Object.entries(process.env)) {
+  if (!key.startsWith('NEXT_PUBLIC_') || !val) continue
+
+  let lekkasje = false
+
+  // Kjente token-prefikser
+  if (val.startsWith('ghp_') || val.startsWith('github_pat_') || val.startsWith('re_')) {
+    lekkasje = true
+  }
+
+  // JWT med service_role i payload (base64-dekod midtdel, let etter "role":"service_role")
+  if (!lekkasje && val.split('.').length === 3) {
+    try {
+      const payload = JSON.parse(Buffer.from(val.split('.')[1], 'base64url').toString('utf8'))
+      if (payload?.role === 'service_role') lekkasje = true
+    } catch { /* ugyldig base64 eller JSON — ikke en JWT */ }
+  }
+
+  if (lekkasje) {
+    meldingar.kritisk.push(
+      `  ${r('✖')} ${key} — verdien ser ut som et secret (token/nøkkel) og skal IKKE ha NEXT_PUBLIC_-prefiks (inlines i browser-bundle)`
+    )
+    kritiskFeil++
+  }
+}
+
+// ─── UTSKRIFT ────────────────────────────────────────────────────────────────
+
+console.log('')
+console.log(b('=== Herreklubben — miljøsjekk ==='))
+console.log('')
+
+if (meldingar.kritisk.length > 0) {
+  console.log(b('Kritiske (app starter ikke uten):'))
+  meldingar.kritisk.forEach((m) => console.log(m))
+  console.log('')
+}
+
+if (meldingar.anbefalt.length > 0) {
+  console.log(b('Anbefalte (mangler gir redusert funksjonalitet):'))
+  meldingar.anbefalt.forEach((m) => console.log(m))
+  console.log('')
+}
+
+if (meldingar.valgfri.length > 0) {
+  console.log(b('Valgfrie (satt, med defaults):'))
+  meldingar.valgfri.forEach((m) => console.log(m))
+  console.log('')
+}
+
+// Oppsummering
+const kritiskOk = meldingar.kritisk.filter((m) => m.includes('✓')).length
+const anbefaltOk = meldingar.anbefalt.filter((m) => m.includes('✓')).length
+
+if (kritiskFeil === 0 && advarslar === 0) {
+  console.log(g(`✓ Alt OK — ${kritiskOk} kritiske og ${anbefaltOk} anbefalte variabler er satt og gyldige.`))
+} else if (kritiskFeil === 0) {
+  console.log(y(`⚠ ${advarslar} advarsel(er) — ${kritiskOk} kritiske OK. Appen starter, men noen funksjoner mangler.`))
+} else {
+  console.log(r(`✖ ${kritiskFeil} kritisk feil — ${advarslar} advarsel(er). Fiks feil markert med ✖ før deploy.`))
+}
+console.log('')
+
+process.exit(kritiskFeil > 0 ? 1 : 0)


### PR DESCRIPTION
## Sammendrag

Fase 2 av open source-klargjøring (#291): en ny klubb skal kunne kopiere `.env.example` → `.env.local`, fylle inn og verifisere oppsettet før første deploy.

- `.env.example` totalskrevet: 9 grupper (Supabase, R2, VAPID, Resend, cron, GitHub-innspill, base-URL, klubbidentitet, dev-only) med kommentar om hvor hver verdi hentes og hva som mangler uten den. Plattform-injected vars dokumentert nederst.
- Ny `scripts/sjekk-miljo.mjs` (kjøres via `npm run sjekk-miljo`): validerer at variabler er satt og har riktig format. Tre nivåer — kritisk (✖, exit 1), anbefalt (⚠, exit 0), valgfri. Spesialsjekker: R2 public-URL (minst én av to), BASE_URL/KLUBB_DOMENE-drift, secret-lekkasje-heuristikk for NEXT_PUBLIC_-vars. Printer aldri secret-verdier.
- README: kort «Miljøvariabler»-seksjon + GitHub Actions-secrets (APP_URL, CRON_SECRET).
- KLUBB_DOMENE/BASE_URL-konsolidering vurdert (notat fra #292): beholdes begge — BASE_URL er nå dokumentert som spesialtilfelle-override, prod utledes fra KLUBB_DOMENE.

## Beslutninger underveis

**Intern review — rettet:**
- BLOCKER: validatoren avviste Supabases nye nøkkelformater (`sb_publishable_`/`sb_secret_`) — nye klubber får disse, ikke legacy JWT. Begge generasjoner aksepteres nå.
- MAJOR: inline-kommentarer etter `VAR=` i .env.example kunne korruptere verdier (Node --env-file klipper på `#`) — flyttet til linjen over
- MAJOR: R2-URL-duplikat-utskrift; GITHUB_TOKEN-beskrivelse presisert
- MINOR: VAPID-lengdegrenser, redundant par-sjekk fjernet, jurisdiction-liste speiler lib/r2.ts, RESEND_FROM-sandbox-fella dokumentert, bokmål-konsistens

**Forfunn → eget issue:**
- #299: `bli-utvikler`-ruten krasjer uten GITHUB_TOKEN (pre-eksisterende `process.env.GITHUB_TOKEN!`)

Se #293.