### PR TITLE
OS-fase 3: DB-bootstrap, første admin og generalsekretær fra UI (#294)

### DIFF
--- a/.github/workflows/paaminne.yml
+++ b/.github/workflows/paaminne.yml
@@ -1,3 +1,6 @@
+# Daglig påminnelsesjobb — kaller /api/cron/paaminne kl. 06:00 UTC.
+# Secret-oppsett (CRON_SECRET og APP_URL): se docs/oppsett.md, seksjon 9.
+
 name: Daglig påminnelse
 
 on:

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ scripts/data/import-rapport.json
 /scripts/fb-bilder-metadata.html
 .vercel
 .env*.local
+
+# init-admin: engangspassord skrevet til fil, må aldri committes
+/init-admin-passord.txt

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Privat web-app som erstatter Facebook for arrangementspåmelding, klubbchat og k
 - [Mappe-struktur](#mappe-struktur)
 - [Drift og deploy](#drift-og-deploy)
 - [Lokalt utviklingsmiljø](#lokalt-utviklingsmiljø)
+- [Oppsett fra scratch](docs/oppsett.md)
 - [Kritisk vurdering](#kritisk-vurdering)
 
 ---

--- a/app/(app)/klubbinfo/medlemmer/[id]/rediger/RedigerMedlemSkjema.tsx
+++ b/app/(app)/klubbinfo/medlemmer/[id]/rediger/RedigerMedlemSkjema.tsx
@@ -161,11 +161,21 @@ export default function RedigerMedlemSkjema({
         fodselsdato: fodselsdato || undefined,
       })
 
-      // Steg 2: fjern GS-tittel (om nødvendig)
+      // Steg 2: fjern GS-tittel (om nødvendig).
+      // Vi sender medlem.id som forventet profil — RPC-en avbryter hvis
+      // sittende GS ikke matcher (en annen admin har flyttet tittelen i
+      // mellomtiden). Da viser vi en pen melding heller enn å demotere
+      // feil person.
       if (skalFjernes) {
-        const res = await fjernGeneralsekretaer()
+        const res = await fjernGeneralsekretaer(medlem.id)
         if (!res.ok) {
-          alert(`Feil ved fjerning av generalsekretær: ${res.melding}`)
+          if (res.kode === 'race_mismatch') {
+            alert(
+              `${medlem.navn} er ikke generalsekretær lenger — en annen admin har flyttet tittelen siden du åpnet siden. Last siden på nytt for oppdatert status.`,
+            )
+          } else {
+            alert(`Feil ved fjerning av generalsekretær: ${res.melding}`)
+          }
           return
         }
       }

--- a/app/(app)/klubbinfo/medlemmer/[id]/rediger/RedigerMedlemSkjema.tsx
+++ b/app/(app)/klubbinfo/medlemmer/[id]/rediger/RedigerMedlemSkjema.tsx
@@ -8,7 +8,7 @@ import {
   settGeneralsekretaer,
   fjernGeneralsekretaer,
 } from '@/lib/actions/profil'
-import { VALGBARE_ROLLER, tittelFor, type Rolle } from '@/lib/roller'
+import { VALGBARE_ROLLER, tittelFor, kanAdministrere, type Rolle } from '@/lib/roller'
 import SkjemaBar from '@/components/ui/SkjemaBar'
 import SkjemaSeksjon from '@/components/ui/SkjemaSeksjon'
 import Segment from '@/components/ui/Segment'
@@ -90,9 +90,12 @@ export default function RedigerMedlemSkjema({
   // Generalsekretær-rollen styres av ToggleSwitch nedenfor.
   const erValgbar = (VALGBARE_ROLLER as string[]).includes(medlem.rolle)
   const [rolle, setRolle] = useState<Rolle>(
-    erValgbar ? (medlem.rolle as Rolle) : 'admin',
-    // Hvis GS er GS → vis 'admin' i Segmentet (GS har admin-rettigheter).
-    // ToggleSwitch-en viser selve GS-statusen separat.
+    // For valgbare roller (medlem/admin): bruk DB-rollen direkte.
+    // For andre (i praksis 'generalsekretaer'): velg admin/medlem basert på
+    // om rollen har admin-rettigheter. Bruker kanAdministrere() i stedet for
+    // hardkodet 'admin' så fremtidige roller med admin-rettigheter speiles
+    // riktig i Segmentet uten å måtte huske å oppdatere denne linja.
+    erValgbar ? (medlem.rolle as Rolle) : (kanAdministrere(medlem.rolle) ? 'admin' : 'medlem'),
   )
   const [aktiv, setAktiv] = useState<'aktiv' | 'deaktivert'>(
     medlem.aktiv ? 'aktiv' : 'deaktivert',
@@ -114,7 +117,7 @@ export default function RedigerMedlemSkjema({
         : null
 
       const beskjed = annenGs
-        ? `Flytte generalsekretær-tittelen fra ${annenGs.navn} til ${medlem.navn}? ${annenGs.navn} forblir admin, men mister tittelen.`
+        ? `Flytte generalsekretær-tittelen fra ${annenGs.navn} til ${medlem.navn}? ${annenGs.navn} blir admin og mister tittelen.`
         : `Gjøre ${medlem.navn} til generalsekretær?`
 
       if (!confirm(beskjed)) return  // bruker avbrøt → ikke toggle
@@ -127,25 +130,38 @@ export default function RedigerMedlemSkjema({
 
   async function handleLagre() {
     startTransition(async () => {
-      // handleLagre-rekkefølge (kritisk — rekkefølgen kan ikke byttes):
+      // handleLagre-rekkefølge:
       //
-      // 1. Fjern GS-tittelen FØRST hvis dette medlemmet er GS og skal slutte å
-      //    være det. Det gjelder både ved toggle-av og ved bytte til en annen.
-      //    Uten dette steget ville oppdaterMedlemAdmin (steg 2) se rolle=
-      //    'generalsekretaer' i DB og bevare den — ikke demotere.
+      // 1. Oppdater navn/telefon/aktiv/rolle FØRST. Hvis dette feiler så er
+      //    ingen GS-endring gjort ennå — vi ender ikke i den ekle tilstanden
+      //    hvor GS er stille demotert mens resten av skjemaet rullet tilbake.
+      //    Når DB-rolle er 'generalsekretaer' utelater oppdaterMedlemAdmin
+      //    rolle-feltet helt (defensiv invariant i actionen), så det er trygt
+      //    å kalle med rolle='admin'/'medlem' selv om personen er GS.
       //
-      // 2. Oppdater navn, telefon, aktiv-status og rolle (admin/medlem).
-      //    oppdaterMedlemAdmin bevarer 'generalsekretaer' hvis den fortsatt er i DB,
-      //    men etter steg 1 er den demotert og steg 2 kan sette 'admin'/'medlem' trygt.
+      // 2. Fjern GS-tittel hvis dette medlemmet er GS og skal slutte å være det.
+      //    Etter dette er DB ren for et evt. steg 3.
       //
-      // 3. Sett GS-tittel SIST hvis toggle er på. Da er DB i riktig tilstand
-      //    (forrige GS er demotert i steg 1) og RPC-ens partial unique index
-      //    vil ikke trigge 23505.
+      // 3. Sett GS-tittel hvis toggle er på. Partial unique index kan fortsatt
+      //    feile med 23505 hvis en annen admin satte ny GS i mellomtiden —
+      //    klienten viser da reaktiv confirm med oppdatert innehavernavn.
 
       const skalFjernes = medlem.rolle === 'generalsekretaer' && !erGeneralsekretaer
       const skalSettes  = erGeneralsekretaer && medlem.rolle !== 'generalsekretaer'
 
-      // Steg 1: fjern GS-tittel (om nødvendig)
+      // Steg 1: oppdater øvrige felter. Send 'admin' når personen er GS i DB
+      // (Segment kan ikke vise 'generalsekretaer'); actionen ignorerer feltet
+      // i bevaringsgrenen. Etter evt. steg 2 settes 'admin' uansett av RPC-en.
+      await oppdaterMedlemAdmin(medlem.id, {
+        navn,
+        visningsnavn: visningsnavn || navn,
+        telefon,
+        rolle,
+        aktiv: aktiv === 'aktiv',
+        fodselsdato: fodselsdato || undefined,
+      })
+
+      // Steg 2: fjern GS-tittel (om nødvendig)
       if (skalFjernes) {
         const res = await fjernGeneralsekretaer()
         if (!res.ok) {
@@ -153,16 +169,6 @@ export default function RedigerMedlemSkjema({
           return
         }
       }
-
-      // Steg 2: oppdater øvrige felter (navn, telefon, rolle, aktiv)
-      await oppdaterMedlemAdmin(medlem.id, {
-        navn,
-        visningsnavn: visningsnavn || navn,
-        telefon,
-        rolle,  // 'admin' eller 'medlem' — GS-rollen håndteres i steg 1 og 3
-        aktiv: aktiv === 'aktiv',
-        fodselsdato: fodselsdato || undefined,
-      })
 
       // Steg 3: sett GS-tittel (om nødvendig)
       if (skalSettes) {
@@ -172,12 +178,17 @@ export default function RedigerMedlemSkjema({
             // Race-tilstand: en annen admin satte en ny GS i mellomtiden.
             // Spør på nytt med oppdatert innehavernavn.
             const bekreft = confirm(
-              `${res.innehaver.navn} ble nettopp satt som generalsekretær av en annen admin. Vil du likevel flytte tittelen til ${medlem.navn}? ${res.innehaver.navn} forblir admin.`
+              `${res.innehaver.navn} ble nettopp satt som generalsekretær av en annen admin. Vil du likevel flytte tittelen til ${medlem.navn}? ${res.innehaver.navn} blir admin og mister tittelen.`
             )
             if (bekreft) {
               const res2 = await settGeneralsekretaer(medlem.id)
               if (!res2.ok) {
-                alert(`Feil ved bytte av generalsekretær: ${res2.kode === 'feil' ? res2.melding : 'Prøv igjen.'}`)
+                // Andre forsøk feilet også. Skill ut race-tilfellet for å
+                // unngå en uendelig retry-loop og gi en konkret melding.
+                const melding = res2.kode === 'generalsekretaer_finnes'
+                  ? `En annen admin satte ${res2.innehaver.navn} som generalsekretær igjen. Last siden på nytt og prøv om ønskelig.`
+                  : `Feil ved bytte av generalsekretær: ${res2.melding}`
+                alert(melding)
                 return
               }
             } else {

--- a/app/(app)/klubbinfo/medlemmer/[id]/rediger/RedigerMedlemSkjema.tsx
+++ b/app/(app)/klubbinfo/medlemmer/[id]/rediger/RedigerMedlemSkjema.tsx
@@ -2,11 +2,17 @@
 
 import { useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
-import { oppdaterMedlemAdmin, slettMedlem } from '@/lib/actions/profil'
+import {
+  oppdaterMedlemAdmin,
+  slettMedlem,
+  settGeneralsekretaer,
+  fjernGeneralsekretaer,
+} from '@/lib/actions/profil'
 import { VALGBARE_ROLLER, tittelFor, type Rolle } from '@/lib/roller'
 import SkjemaBar from '@/components/ui/SkjemaBar'
 import SkjemaSeksjon from '@/components/ui/SkjemaSeksjon'
 import Segment from '@/components/ui/Segment'
+import { ToggleRad } from '@/components/ui/ToggleSwitch'
 
 type Medlem = {
   id: string
@@ -18,6 +24,8 @@ type Medlem = {
   aktiv: boolean
   fodselsdato: string | null
 }
+
+type NaavaerendeGeneralsekretaer = { id: string; navn: string } | null
 
 const labelStil: React.CSSProperties = {
   fontFamily: 'var(--font-mono)',
@@ -63,7 +71,13 @@ function Rad({ children, last }: { children: React.ReactNode; last?: boolean }) 
   )
 }
 
-export default function RedigerMedlemSkjema({ medlem }: { medlem: Medlem }) {
+export default function RedigerMedlemSkjema({
+  medlem,
+  naavaerendeGeneralsekretaer,
+}: {
+  medlem: Medlem
+  naavaerendeGeneralsekretaer: NaavaerendeGeneralsekretaer
+}) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
 
@@ -71,27 +85,115 @@ export default function RedigerMedlemSkjema({ medlem }: { medlem: Medlem }) {
   const [visningsnavn, setVisningsnavn] = useState(medlem.visningsnavn)
   const [telefon, setTelefon] = useState(medlem.telefon ?? '')
   const [fodselsdato, setFodselsdato] = useState(medlem.fodselsdato ?? '')
-  // Generalsekretær-rollen settes ikke fra UI — den bevares som er hvis
-  // skjemaet åpnes for en bruker som allerede er generalsekretær.
-  // Valgbare roller (medlem/admin) hentes fra rolle-matrisen i lib/roller.ts.
+
+  // Valgbare roller (Segment): bare 'medlem' og 'admin'.
+  // Generalsekretær-rollen styres av ToggleSwitch nedenfor.
   const erValgbar = (VALGBARE_ROLLER as string[]).includes(medlem.rolle)
   const [rolle, setRolle] = useState<Rolle>(
-    erValgbar ? (medlem.rolle as Rolle) : 'medlem',
+    erValgbar ? (medlem.rolle as Rolle) : 'admin',
+    // Hvis GS er GS → vis 'admin' i Segmentet (GS har admin-rettigheter).
+    // ToggleSwitch-en viser selve GS-statusen separat.
   )
   const [aktiv, setAktiv] = useState<'aktiv' | 'deaktivert'>(
     medlem.aktiv ? 'aktiv' : 'deaktivert',
   )
 
-  function handleLagre() {
+  // GS-toggle: init fra om dette medlemmet er sittende GS.
+  const [erGeneralsekretaer, setErGeneralsekretaer] = useState(
+    medlem.rolle === 'generalsekretaer',
+  )
+
+  // handleToggleGs kalles av ToggleSwitch — confirm skjer her, ikke ved submit.
+  function handleToggleGs(nyVerdi: boolean) {
+    if (nyVerdi) {
+      // Toggle på: enten flytte tittelen fra eksisterende GS, eller ny GS.
+      // Sjekk om en annen person allerede er GS (kan ikke være seg selv her
+      // fordi da ville erGeneralsekretaer vært true og nyVerdi false).
+      const annenGs = naavaerendeGeneralsekretaer?.id !== medlem.id
+        ? naavaerendeGeneralsekretaer
+        : null
+
+      const beskjed = annenGs
+        ? `Flytte generalsekretær-tittelen fra ${annenGs.navn} til ${medlem.navn}? ${annenGs.navn} forblir admin, men mister tittelen.`
+        : `Gjøre ${medlem.navn} til generalsekretær?`
+
+      if (!confirm(beskjed)) return  // bruker avbrøt → ikke toggle
+    } else {
+      // Toggle av: kun mulig hvis dette medlemmet faktisk er GS.
+      if (!confirm(`Fjerne generalsekretær-tittelen fra ${medlem.navn}? Klubben står da uten generalsekretær.`)) return
+    }
+    setErGeneralsekretaer(nyVerdi)
+  }
+
+  async function handleLagre() {
     startTransition(async () => {
+      // handleLagre-rekkefølge (kritisk — rekkefølgen kan ikke byttes):
+      //
+      // 1. Fjern GS-tittelen FØRST hvis dette medlemmet er GS og skal slutte å
+      //    være det. Det gjelder både ved toggle-av og ved bytte til en annen.
+      //    Uten dette steget ville oppdaterMedlemAdmin (steg 2) se rolle=
+      //    'generalsekretaer' i DB og bevare den — ikke demotere.
+      //
+      // 2. Oppdater navn, telefon, aktiv-status og rolle (admin/medlem).
+      //    oppdaterMedlemAdmin bevarer 'generalsekretaer' hvis den fortsatt er i DB,
+      //    men etter steg 1 er den demotert og steg 2 kan sette 'admin'/'medlem' trygt.
+      //
+      // 3. Sett GS-tittel SIST hvis toggle er på. Da er DB i riktig tilstand
+      //    (forrige GS er demotert i steg 1) og RPC-ens partial unique index
+      //    vil ikke trigge 23505.
+
+      const skalFjernes = medlem.rolle === 'generalsekretaer' && !erGeneralsekretaer
+      const skalSettes  = erGeneralsekretaer && medlem.rolle !== 'generalsekretaer'
+
+      // Steg 1: fjern GS-tittel (om nødvendig)
+      if (skalFjernes) {
+        const res = await fjernGeneralsekretaer()
+        if (!res.ok) {
+          alert(`Feil ved fjerning av generalsekretær: ${res.melding}`)
+          return
+        }
+      }
+
+      // Steg 2: oppdater øvrige felter (navn, telefon, rolle, aktiv)
       await oppdaterMedlemAdmin(medlem.id, {
         navn,
         visningsnavn: visningsnavn || navn,
         telefon,
-        rolle: erValgbar ? rolle : medlem.rolle,
+        rolle,  // 'admin' eller 'medlem' — GS-rollen håndteres i steg 1 og 3
         aktiv: aktiv === 'aktiv',
         fodselsdato: fodselsdato || undefined,
       })
+
+      // Steg 3: sett GS-tittel (om nødvendig)
+      if (skalSettes) {
+        const res = await settGeneralsekretaer(medlem.id)
+        if (!res.ok) {
+          if (res.kode === 'generalsekretaer_finnes') {
+            // Race-tilstand: en annen admin satte en ny GS i mellomtiden.
+            // Spør på nytt med oppdatert innehavernavn.
+            const bekreft = confirm(
+              `${res.innehaver.navn} ble nettopp satt som generalsekretær av en annen admin. Vil du likevel flytte tittelen til ${medlem.navn}? ${res.innehaver.navn} forblir admin.`
+            )
+            if (bekreft) {
+              const res2 = await settGeneralsekretaer(medlem.id)
+              if (!res2.ok) {
+                alert(`Feil ved bytte av generalsekretær: ${res2.kode === 'feil' ? res2.melding : 'Prøv igjen.'}`)
+                return
+              }
+            } else {
+              // Bruker sa nei — naviger tilbake uten GS-endring
+              router.push(`/klubbinfo/medlemmer/${medlem.id}`)
+              router.refresh()
+              return
+            }
+          } else {
+            alert(`Feil ved setting av generalsekretær: ${res.melding}`)
+            return
+          }
+        }
+      }
+
+      // Vis kvittering og naviger tilbake
       router.push(`/klubbinfo/medlemmer/${medlem.id}`)
       router.refresh()
     })
@@ -167,20 +269,44 @@ export default function RedigerMedlemSkjema({ medlem }: { medlem: Medlem }) {
 
       {/* Tilgang */}
       <SkjemaSeksjon label="Tilgang">
+        {/* Segment for admin/medlem-rollen */}
         <div style={{ padding: '10px 4px', borderBottom: '0.5px solid var(--border-subtle)' }}>
           <div style={{ ...labelStil, marginBottom: 8 }}>Rolle</div>
-          {erValgbar ? (
-            <Segment
-              value={rolle}
-              onChange={setRolle}
-              options={VALGBARE_ROLLER.map(r => ({ value: r, label: tittelFor(r) }))}
-            />
-          ) : (
-            <div style={{ ...inputBaseStil, color: 'var(--accent)' }}>
-              {tittelFor(medlem.rolle)} (kan ikke endres her)
-            </div>
-          )}
+          <Segment
+            value={rolle}
+            onChange={setRolle}
+            options={VALGBARE_ROLLER.map(r => ({ value: r, label: tittelFor(r) }))}
+          />
         </div>
+
+        {/* ToggleSwitch for generalsekretær-tittelen — separat fra rolle-Segmentet
+            fordi GS er en utmerkelse, ikke en sidestilt status i to-valgs-skjemaet.
+            Confirm skjer ved toggle, ikke ved submit — slik at brukeren ser
+            konsekvensen (hvem som mister tittelen) før han klikker Lagre. */}
+        <div
+          style={{
+            padding: '10px 4px',
+            borderBottom: '0.5px solid var(--border-subtle)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 12,
+          }}
+        >
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ ...labelStil, marginBottom: 2 }}>Generalsekretær</div>
+            <div style={{ fontSize: 12, color: 'var(--text-tertiary)', lineHeight: 1.4 }}>
+              Bare én om gangen. Får gul glød på bildet.
+            </div>
+          </div>
+          <ToggleRad
+            on={erGeneralsekretaer}
+            onChange={handleToggleGs}
+            disabled={isPending}
+            ariaLabel="Generalsekretær"
+          />
+        </div>
+
         <div style={{ padding: '10px 4px' }}>
           <div style={{ ...labelStil, marginBottom: 8 }}>Status</div>
           <Segment

--- a/app/(app)/klubbinfo/medlemmer/[id]/rediger/page.tsx
+++ b/app/(app)/klubbinfo/medlemmer/[id]/rediger/page.tsx
@@ -9,13 +9,27 @@ export default async function RedigerMedlem({ params }: { params: Promise<{ id: 
   const [supabase, profil] = await Promise.all([createServerClient(), getProfil()])
   if (!kanAdministrere(profil?.rolle)) redirect('/klubbinfo/medlemmer')
 
-  const { data: medlem } = await supabase
-    .from('profiles')
-    .select('id, navn, visningsnavn, epost, telefon, rolle, aktiv, fodselsdato')
-    .eq('id', id)
-    .single()
+  // Hent både målmedlem og sittende GS i parallell — GS-prop trengs i
+  // RedigerMedlemSkjema for confirm-dialogen (hvem mister tittelen?).
+  const [{ data: medlem }, { data: naavaerendeGeneralsekretaer }] = await Promise.all([
+    supabase
+      .from('profiles')
+      .select('id, navn, visningsnavn, epost, telefon, rolle, aktiv, fodselsdato')
+      .eq('id', id)
+      .single(),
+    supabase
+      .from('profiles')
+      .select('id, navn')
+      .eq('rolle', 'generalsekretaer')
+      .maybeSingle(),
+  ])
 
   if (!medlem) notFound()
 
-  return <RedigerMedlemSkjema medlem={medlem} />
+  return (
+    <RedigerMedlemSkjema
+      medlem={medlem}
+      naavaerendeGeneralsekretaer={naavaerendeGeneralsekretaer}
+    />
+  )
 }

--- a/docs/oppsett.md
+++ b/docs/oppsett.md
@@ -1,0 +1,197 @@
+# Oppsett fra scratch
+
+Denne guiden beskriver hvordan du setter opp en ny instans av Mortensrud Herreklubb-appen fra bunnen av. Bruk den ved nytt Supabase-prosjekt, testinstans eller katastrofegjenoppretting.
+
+---
+
+## Oversikt over komponenter
+
+| Komponent | Hva det er | Hvor du oppretter det |
+|---|---|---|
+| **Vercel** | Hosting og CI/CD | vercel.com |
+| **Supabase** | Database (Postgres + RLS), Auth, Realtime | supabase.com |
+| **Cloudflare R2** | Bildelagring (S3-kompatibel, CDN) | dash.cloudflare.com |
+| **Resend** | Transaksjonell e-post | resend.com |
+| **VAPID-nøkler** | Web Push (push-varsler) | genereres lokalt |
+| **GitHub Actions-cron** | Daglig påminnelsesjobb | `.github/workflows/paaminne.yml` (allerede i repoet) |
+
+---
+
+## Forutsetninger
+
+- Node 20+
+- Supabase CLI (`npm install -g supabase`)
+- Git og GitHub-konto med tilgang til repoet
+- Vercel-konto koblet til GitHub-repoet
+
+---
+
+## 1. Klon og installer
+
+```bash
+git clone https://github.com/reidarei/Herreklubben.git
+cd Herreklubben
+npm install
+```
+
+---
+
+## 2. Supabase-prosjekt
+
+1. Opprett nytt prosjekt på [supabase.com](https://supabase.com).
+2. Koble CLI til prosjektet:
+   ```bash
+   npx supabase login
+   npx supabase link --project-ref <prosjekt-id>
+   ```
+3. Kjør alle migrasjoner (oppretter tabeller, RLS-policies, funksjoner):
+   ```bash
+   npx supabase db push
+   ```
+   Migrasjonsfilene ligger i `supabase/migrations/` og kjøres sekvensielt.
+
+4. Regenerer TypeScript-typer etter migrasjon:
+   ```bash
+   npx supabase gen types typescript --project-id <prosjekt-id> > lib/supabase/database.types.ts
+   ```
+
+**Storage-buckets:** Opprettes automatisk av migrasjon 017 (`arrangement_bilder`) og 037 (`profilbilder`). Du trenger ikke opprette dem manuelt.
+
+---
+
+## 3. Cloudflare R2
+
+1. Logg inn på [dash.cloudflare.com](https://dash.cloudflare.com) → R2.
+2. Opprett ny bucket (f.eks. `herreklubben-bilder`).
+3. Aktiver «Public access» på bucketen (bilder hentes direkte av klienten).
+4. Opprett API-token med «Object Read & Write»-tilgang for bucketen.
+5. Kopier: `Account ID`, `Access Key ID`, `Secret Access Key`, `Public URL`.
+
+---
+
+## 4. VAPID-nøkler (Web Push)
+
+```bash
+npx web-push generate-vapid-keys
+```
+
+Kopier `Public Key` og `Private Key` fra output.
+
+---
+
+## 5. Resend (e-post)
+
+1. Opprett konto på [resend.com](https://resend.com).
+2. Legg til og verifiser domenet ditt (eller bruk `@resend.dev` for testing).
+3. Opprett API-nøkkel med «Sending access».
+
+---
+
+## 6. Miljøvariabler
+
+Kopier malen og fyll inn:
+
+```bash
+cp .env.example .env.local
+# rediger .env.local med verdiene fra stegene over
+npm run sjekk-miljo   # verifiserer kritiske variabler
+```
+
+Sjekk `sjekk-miljo`-scriptet for alle påkrevde variabler. Kritiske er:
+- `NEXT_PUBLIC_SUPABASE_URL` og `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET`, `NEXT_PUBLIC_R2_PUBLIC_URL`
+- `NEXT_PUBLIC_VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`
+- `RESEND_API_KEY`
+
+---
+
+## 7. Første admin
+
+### Primær fremgangsmåte: Supabase Dashboard (anbefalt)
+
+Dette er den tryggeste og enkleste veien for en engangsoperasjon:
+
+1. Gå til Supabase Dashboard → Authentication → Users → «Add user».
+2. Fyll inn e-post og passord.
+3. Gå til SQL-editoren og kjør:
+   ```sql
+   UPDATE profiles
+   SET rolle = 'admin',
+       navn  = 'Ditt navn'
+   WHERE epost = 'din@epost.no';
+   ```
+4. Logg inn i appen og bytt passordet under Profil → Rediger.
+
+### Alternativ: init-admin-script
+
+For scripted oppsett eller gjenoppretting. Scriptet nekter å kjøre mot kjent prod-instans og mot en instans med eksisterende profiler.
+
+```bash
+node --env-file=.env.local scripts/init-admin.mjs din@epost.no "Ditt navn"
+```
+
+Passordet skrives til `./init-admin-passord.txt` (aldri til stdout). Slett filen straks etter bruk. Se kommentarer i scriptet for tre-lags sikkerhetssjekker.
+
+---
+
+## 8. Vercel-deploy
+
+1. Koble repoet til Vercel (Import Project på vercel.com).
+2. Legg til alle miljøvariabler fra `.env.local` som Vercel Environment Variables.
+   - `R2_SECRET_ACCESS_KEY` og `VAPID_PRIVATE_KEY`: merk som «Sensitive».
+3. Trigger deploy (push til `main` deployer automatisk).
+
+**`CRON_SECRET` og `APP_URL`:** Disse settes to steder med **identisk verdi** og **ingen trailing slash**:
+- `CRON_SECRET`: Vercel env-var (runtime-sjekk i cron-endepunktet) + GitHub Actions-secret (sendes som `Authorization`-header).
+- `APP_URL`: GitHub Actions-secret (peker cron-jobben til prod-URL). Brukes ikke av appen i runtime.
+
+Mismatch eller manglende verdi gir `401` fra `/api/cron/paaminne`.
+
+---
+
+## 9. GitHub Actions-secrets
+
+For at daglig påminnelsesjobb (`.github/workflows/paaminne.yml`) skal virke:
+
+| Secret | Verdi |
+|---|---|
+| `CRON_SECRET` | Samme som Vercel env-var `CRON_SECRET` |
+| `APP_URL` | Prod-URL uten trailing slash, f.eks. `https://mortensrudherreklubb.no` |
+
+Se `.github/workflows/paaminne.yml` for secret-oppsett-referanse.
+
+---
+
+## 10. Sett generalsekretær
+
+Generalsekretær settes i appen etter at første admin er opprettet:
+
+1. Logg inn som admin.
+2. Gå til Klubbinfo → Medlemmer → velg riktig person → Rediger.
+3. Skru på «Generalsekretær»-togglen (bekreft dialogen).
+
+Maks én generalsekretær er garantert av databasen (migrasjon 094: partial unique index + atomisk RPC).
+
+---
+
+## Feilsøking
+
+### `42501` fra Supabase (PostgREST)
+
+Betyr at Data API-rollen mangler `GRANT` på tabellen. Kjør `npx supabase db push` på nytt — migrasjon 086 gir eksplisitte grants til alle tabeller. Fra oktober 2026 håndheves dette på alle Supabase-prosjekter.
+
+### `401` fra `/api/cron/paaminne`
+
+`CRON_SECRET` i GitHub Actions-secrets stemmer ikke med Vercel env-var `CRON_SECRET`. Verdiene **må** være identiske. Sjekk at det ikke er trailing whitespace i noen av dem.
+
+### Push-varsler virker ikke
+
+- Sjekk at `NEXT_PUBLIC_VAPID_PUBLIC_KEY` og `VAPID_PRIVATE_KEY` er satt korrekt.
+- Sjekk at brukeren har slått på push under Profil → Innstillinger → Varsler.
+- Sjekk `varsel_logg`-tabellen i Supabase for eventuelle feilmeldinger.
+
+### Bilder lastes ikke
+
+- Sjekk at `NEXT_PUBLIC_R2_PUBLIC_URL` peker til riktig R2-bucket-URL.
+- Sjekk at bucketen har «Public access» aktivert i Cloudflare Dashboard.

--- a/lib/actions/profil.ts
+++ b/lib/actions/profil.ts
@@ -16,6 +16,8 @@ export type SettGeneralsekretaerResultat =
 
 export type FjernGeneralsekretaerResultat =
   | { ok: true; forrigeProfilId: string | null }
+  // Race: forventet profil var ikke sittende GS lenger. Ingen demotering ble gjort.
+  | { ok: false; kode: 'race_mismatch' }
   | { ok: false; kode: 'feil'; melding: string }
 
 export async function oppdaterEgenProfil(data: { navn: string; visningsnavn: string; telefon: string; fodselsdato?: string; bilde_url?: string | null }) {
@@ -70,11 +72,17 @@ export async function oppdaterMedlemAdmin(id: string, data: { navn: string; visn
   // rolle-feltet HELT fra update-objektet — vi rører det aldri. Det unngår
   // en TOCTOU-felle hvor en annen admin demoterer GS i mellomtiden og vi
   // re-promoterer i stillhet ved å skrive den gamle rollen tilbake.
-  const { data: gjeldende } = await supabase
+  // Slå opp gjeldende rolle. NB: RLS-select-policyen på profiles er
+  // `using (aktiv = true)` (se 009_rls_policyer.sql) — for INAKTIVE profiler
+  // returnerer .maybeSingle() null selv om raden finnes. Vi må derfor
+  // fail-safe: hvis oppslaget feiler ELLER returnerer null, rører vi IKKE
+  // rolle-feltet. Det unngår at en sittende GS demoteres stille gjennom
+  // denne actionen utenom RPC-flyten — som var bug-en Copilot fanget.
+  const { data: gjeldende, error: gjeldendeFeil } = await supabase
     .from('profiles')
     .select('rolle')
     .eq('id', id)
-    .single()
+    .maybeSingle()
 
   const baseOppdatering = {
     navn,
@@ -84,16 +92,16 @@ export async function oppdaterMedlemAdmin(id: string, data: { navn: string; visn
     aktiv: data.aktiv,
     oppdatert: naa(),
   }
-  // Bevaringsgren: DB sier GS, innsendt rolle er medlem/admin → ikke rør rolle.
-  // Klienten skal ha kalt fjernGeneralsekretaer() først hvis demotering var ønsket.
-  // Logg en advarsel når dette skjer, så vi oppdager UI-bugs som hopper over
-  // fjern-actionen og lar denne actionen «fikse» det stille.
-  const skalRoreRolle = gjeldende?.rolle !== 'generalsekretaer'
+  // Fail-safe: rør rolle KUN hvis vi har bekreftet at gjeldende rolle ikke
+  // er 'generalsekretaer'. Manglende oppslag (RLS-skjult inaktiv profil,
+  // nettverksfeil osv.) → ikke rør rolle. Klienten må kalle
+  // fjernGeneralsekretaer() først hvis demotering av GS er ønsket.
+  const skalRoreRolle = !gjeldendeFeil && gjeldende != null && gjeldende.rolle !== 'generalsekretaer'
   if (!skalRoreRolle) {
     console.warn(
       `[oppdaterMedlemAdmin] Hopper over rolle-oppdatering for profil ${id}: ` +
-      `DB-rolle er 'generalsekretaer', innsendt '${data.rolle}'. ` +
-      `Forventer at fjernGeneralsekretaer() ble kalt først.`,
+      `gjeldende rolle '${gjeldende?.rolle ?? 'ukjent'}' (oppslagsfeil: ${gjeldendeFeil?.message ?? 'nei'}), innsendt '${data.rolle}'. ` +
+      `Forventer at fjernGeneralsekretaer() ble kalt først hvis GS skulle demoteres.`,
     )
   }
   const oppdatering: Record<string, unknown> = skalRoreRolle
@@ -146,17 +154,35 @@ export async function settGeneralsekretaer(nyProfilId: string): Promise<SettGene
 
 // Fjerner generalsekretær-tittelen fra sittende GS (demoterer til 'admin').
 // Null GS er en gyldig tilstand — f.eks. i overgangsperiode.
-export async function fjernGeneralsekretaer(): Promise<FjernGeneralsekretaerResultat> {
+//
+// forventetProfilId: id-en klienten TRODDE var sittende GS da han åpnet siden.
+// RPC-en demoterer kun hvis dette matcher faktisk sittende GS. Mismatch →
+// `race_mismatch` returneres uten endring. Dette forhindrer at en annen admin
+// som flyttet GS i mellomtiden får sin nye GS demotert ved en uskyldig lagring
+// fra en utdatert side. Hvis forventetProfilId utelates faller vi tilbake til
+// gammel oppførsel (demoter den som sitter — brukes bare hvis kalleren ikke
+// har et entydig anker).
+export async function fjernGeneralsekretaer(forventetProfilId?: string): Promise<FjernGeneralsekretaerResultat> {
   const { supabase } = await ensureAdmin()
 
   const { data, error } = await supabase
-    .rpc('fjern_generalsekretaer')
+    .rpc('fjern_generalsekretaer', { forventet_profil: forventetProfilId ?? undefined })
 
   if (error) {
     return { ok: false, kode: 'feil', melding: error.message }
   }
 
   const rad = data?.[0]
+
+  // Race-mismatch-deteksjon: hvis vi oppga forventetProfilId men RPC-en
+  // returnerte tomrad (forrige_profil = null), betyr det enten at det ikke
+  // var noen GS, eller at sittende GS ikke matchet forventningen vår.
+  // Skill mellom de to ved å sjekke om vi i det hele tatt forventet en
+  // demotering — kalleren her vet at det var en GS før, så null = mismatch.
+  if (forventetProfilId && !rad?.forrige_profil) {
+    return { ok: false, kode: 'race_mismatch' }
+  }
+
   revalidatePath('/klubbinfo/medlemmer')
   if (rad?.forrige_profil) revalidatePath(`/klubbinfo/medlemmer/${rad.forrige_profil}`)
 

--- a/lib/actions/profil.ts
+++ b/lib/actions/profil.ts
@@ -7,6 +7,17 @@ import { ensureAdmin, ensureInnlogget } from '@/lib/auth'
 import { naa } from '@/lib/dato'
 import { normaliserTelefon } from '@/lib/telefon'
 
+// Resultattyper for GS-actions — strukturert retur i stedet for throw,
+// slik at klienten kan vise reaktiv confirm ved race-tilstand (23505).
+export type SettGeneralsekretaerResultat =
+  | { ok: true; forrigeProfilId: string | null; forrigeNavn: string | null }
+  | { ok: false; kode: 'generalsekretaer_finnes'; innehaver: { id: string; navn: string } }
+  | { ok: false; kode: 'feil'; melding: string }
+
+export type FjernGeneralsekretaerResultat =
+  | { ok: true; forrigeProfilId: string | null }
+  | { ok: false; kode: 'feil'; melding: string }
+
 export async function oppdaterEgenProfil(data: { navn: string; visningsnavn: string; telefon: string; fodselsdato?: string; bilde_url?: string | null }) {
   const { supabase, user } = await ensureInnlogget()
 
@@ -40,14 +51,99 @@ export async function oppdaterMedlemAdmin(id: string, data: { navn: string; visn
   if (!navn) throw new Error('Navn kan ikke være tomt')
   const visningsnavn = (data.visningsnavn?.trim() || navn)
 
-  // Bruk service-role for å oppdatere profiles (RLS tillater admin å oppdatere andres)
+  // Allowlist på rolle: generalsekretær settes KUN via settGeneralsekretaer()
+  // (RPC, atomisk). Hvis noen sender 'generalsekretaer' hit er det enten en
+  // bug eller et forsøk på å omgå RPC-ens atomic demotér+promotér — begge deler
+  // skal stoppes tidlig. Se migrasjon 094 for rationale.
+  if (data.rolle !== 'medlem' && data.rolle !== 'admin') {
+    // Spesialtilfelle: hvis personen i DB allerede ER generalsekretær og innsendt
+    // rolle er noe annet enn 'medlem'/'admin', er det UI-en som sender feil verdi.
+    // Vi kaster heller enn å stille demotere — demotering skal skje via
+    // fjernGeneralsekretaer() i handleLagre-rekkefølgen i RedigerMedlemSkjema.
+    throw new Error('Ugyldig rolle. Generalsekretær settes og fjernes via egen flyt.')
+  }
+
+  // Hvis personen i DB er generalsekretær og innsendt rolle er 'admin' eller
+  // 'medlem', skal IKKE denne actionen demotere — det håndteres av
+  // fjernGeneralsekretaer() som kalles FØR denne actionen i handleLagre.
+  // Vi henter aktuell rolle fra DB og bevarer 'generalsekretaer' hvis den
+  // innsendte rollen prøver å overskrive den uten at fjern-actionen er kalt.
+  // I praksis vil RedigerMedlemSkjema alltid kalle fjern-actionen først, så
+  // dette er en defensiv sjekk mot direktebruk av actionen.
+  const { data: gjeldende } = await supabase
+    .from('profiles')
+    .select('rolle')
+    .eq('id', id)
+    .single()
+
+  // Velg endelig rolle: hvis personen er GS og vi ikke fikk 'generalsekretaer'
+  // som innsendt rolle → bruk gjeldende (ingen endring). Klienten har allerede
+  // kalt fjernGeneralsekretaer() for å demotere hvis det var ønsket.
+  const endeligRolle = gjeldende?.rolle === 'generalsekretaer'
+    ? gjeldende.rolle  // bevarer GS-rollen; fjern-actionen demoterte om nødvendig
+    : data.rolle
+
   const { error } = await supabase
     .from('profiles')
-    .update({ navn, visningsnavn, telefon: normaliserTelefon(data.telefon), fodselsdato: data.fodselsdato || null, rolle: data.rolle, aktiv: data.aktiv, oppdatert: naa() })
+    .update({ navn, visningsnavn, telefon: normaliserTelefon(data.telefon), fodselsdato: data.fodselsdato || null, rolle: endeligRolle, aktiv: data.aktiv, oppdatert: naa() })
     .eq('id', id)
 
   if (error) throw new Error(error.message)
   revalidatePath('/klubbinfo/medlemmer')
+  revalidatePath(`/klubbinfo/medlemmer/${id}`)
+}
+
+// Setter en profilens rolle til 'generalsekretaer' via RPC (atomisk demotér+promotér).
+// Returnerer strukturert resultat i stedet for å kaste, slik at klienten kan
+// reagere på race-tilstand (23505 = unique violation) med reaktiv confirm.
+export async function settGeneralsekretaer(nyProfilId: string): Promise<SettGeneralsekretaerResultat> {
+  const { supabase } = await ensureAdmin()
+
+  const { data, error } = await supabase
+    .rpc('sett_generalsekretaer', { ny_profil: nyProfilId })
+
+  if (error) {
+    // 23505 = unique_violation: partial index profiles_unik_generalsekretaer
+    // blokkerte INSERT/UPDATE fordi en annen GS ble satt i mellomtiden.
+    if (error.code === '23505') {
+      // Slå opp sittende GS for å vise reaktiv confirm i klienten
+      const { data: gs } = await supabase
+        .from('profiles')
+        .select('id, navn')
+        .eq('rolle', 'generalsekretaer')
+        .maybeSingle()
+      if (gs) {
+        return { ok: false, kode: 'generalsekretaer_finnes', innehaver: { id: gs.id, navn: gs.navn } }
+      }
+    }
+    return { ok: false, kode: 'feil', melding: error.message }
+  }
+
+  const rad = data?.[0]
+  revalidatePath('/klubbinfo/medlemmer')
+  revalidatePath(`/klubbinfo/medlemmer/${nyProfilId}`)
+  if (rad?.forrige_profil) revalidatePath(`/klubbinfo/medlemmer/${rad.forrige_profil}`)
+
+  return { ok: true, forrigeProfilId: rad?.forrige_profil ?? null, forrigeNavn: rad?.forrige_navn ?? null }
+}
+
+// Fjerner generalsekretær-tittelen fra sittende GS (demoterer til 'admin').
+// Null GS er en gyldig tilstand — f.eks. i overgangsperiode.
+export async function fjernGeneralsekretaer(): Promise<FjernGeneralsekretaerResultat> {
+  const { supabase } = await ensureAdmin()
+
+  const { data, error } = await supabase
+    .rpc('fjern_generalsekretaer')
+
+  if (error) {
+    return { ok: false, kode: 'feil', melding: error.message }
+  }
+
+  const rad = data?.[0]
+  revalidatePath('/klubbinfo/medlemmer')
+  if (rad?.forrige_profil) revalidatePath(`/klubbinfo/medlemmer/${rad.forrige_profil}`)
+
+  return { ok: true, forrigeProfilId: rad?.forrige_profil ?? null }
 }
 
 export async function slettMedlem(id: string) {

--- a/lib/actions/profil.ts
+++ b/lib/actions/profil.ts
@@ -66,26 +66,43 @@ export async function oppdaterMedlemAdmin(id: string, data: { navn: string; visn
   // Hvis personen i DB er generalsekretær og innsendt rolle er 'admin' eller
   // 'medlem', skal IKKE denne actionen demotere — det håndteres av
   // fjernGeneralsekretaer() som kalles FØR denne actionen i handleLagre.
-  // Vi henter aktuell rolle fra DB og bevarer 'generalsekretaer' hvis den
-  // innsendte rollen prøver å overskrive den uten at fjern-actionen er kalt.
-  // I praksis vil RedigerMedlemSkjema alltid kalle fjern-actionen først, så
-  // dette er en defensiv sjekk mot direktebruk av actionen.
+  // Defensiv invariant: når DB-rollen er 'generalsekretaer', utelater vi
+  // rolle-feltet HELT fra update-objektet — vi rører det aldri. Det unngår
+  // en TOCTOU-felle hvor en annen admin demoterer GS i mellomtiden og vi
+  // re-promoterer i stillhet ved å skrive den gamle rollen tilbake.
   const { data: gjeldende } = await supabase
     .from('profiles')
     .select('rolle')
     .eq('id', id)
     .single()
 
-  // Velg endelig rolle: hvis personen er GS og vi ikke fikk 'generalsekretaer'
-  // som innsendt rolle → bruk gjeldende (ingen endring). Klienten har allerede
-  // kalt fjernGeneralsekretaer() for å demotere hvis det var ønsket.
-  const endeligRolle = gjeldende?.rolle === 'generalsekretaer'
-    ? gjeldende.rolle  // bevarer GS-rollen; fjern-actionen demoterte om nødvendig
-    : data.rolle
+  const baseOppdatering = {
+    navn,
+    visningsnavn,
+    telefon: normaliserTelefon(data.telefon),
+    fodselsdato: data.fodselsdato || null,
+    aktiv: data.aktiv,
+    oppdatert: naa(),
+  }
+  // Bevaringsgren: DB sier GS, innsendt rolle er medlem/admin → ikke rør rolle.
+  // Klienten skal ha kalt fjernGeneralsekretaer() først hvis demotering var ønsket.
+  // Logg en advarsel når dette skjer, så vi oppdager UI-bugs som hopper over
+  // fjern-actionen og lar denne actionen «fikse» det stille.
+  const skalRoreRolle = gjeldende?.rolle !== 'generalsekretaer'
+  if (!skalRoreRolle) {
+    console.warn(
+      `[oppdaterMedlemAdmin] Hopper over rolle-oppdatering for profil ${id}: ` +
+      `DB-rolle er 'generalsekretaer', innsendt '${data.rolle}'. ` +
+      `Forventer at fjernGeneralsekretaer() ble kalt først.`,
+    )
+  }
+  const oppdatering: Record<string, unknown> = skalRoreRolle
+    ? { ...baseOppdatering, rolle: data.rolle }
+    : baseOppdatering
 
   const { error } = await supabase
     .from('profiles')
-    .update({ navn, visningsnavn, telefon: normaliserTelefon(data.telefon), fodselsdato: data.fodselsdato || null, rolle: endeligRolle, aktiv: data.aktiv, oppdatert: naa() })
+    .update(oppdatering)
     .eq('id', id)
 
   if (error) throw new Error(error.message)

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -35,6 +35,12 @@ export const R2_PUBLIC_URL = (
   ''
 ).replace(/\/$/, '')
 
+// Kjent prod-URL for Supabase-prosjektet. Brukes som vakt i init-admin-scriptet
+// slik at scriptet nekter å kjøre mot prod (selv om .env.local peker dit).
+// Konstanten er trygg å eksponere — det er ikke en hemmelighet hvilken Supabase-
+// instans appen bruker; access keys er det hemmelige.
+export const KJENT_PROD_SUPABASE_URL = 'https://tdlfswmxezjdnxcbbiwn.supabase.co'
+
 // GitHub-repo som backer «innspill»-funksjonen. Issues med label
 // GITHUB_ONSKE_LABEL behandles som brukerønsker.
 export const GITHUB_REPO =

--- a/lib/roller.ts
+++ b/lib/roller.ts
@@ -88,6 +88,9 @@ export function rollerMed(rettighet: keyof Rettigheter): Rolle[] {
   return (Object.keys(ROLLER) as Rolle[]).filter(r => Boolean(ROLLER[r][rettighet]))
 }
 
-// Roller som kan velges fra admin-UI (rediger medlem). Generalsekretær
-// utelates bevisst fordi den settes manuelt via SQL, ikke via skjema.
+// Roller som kan velges fra to-valgs Segment i RedigerMedlemSkjema.
+// Generalsekretær utelates her — den settes via egen ToggleSwitch i
+// skjemaet som kaller server action settGeneralsekretaer() (RPC), ikke
+// via dette rolle-feltet. Det sikrer at RPC-ens atomisitetskrav alltid
+// overholdes og at partial unique index (migrasjon 094) aldri omgås.
 export const VALGBARE_ROLLER: Rolle[] = ['medlem', 'admin']

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -1388,17 +1388,22 @@ export type Database = {
       er_admin: { Args: never; Returns: boolean }
       er_generalsekretaer: { Args: never; Returns: boolean }
       fjern_generalsekretaer: {
-        Args: Record<PropertyKey, never>
+        // forventet_profil er valgfri (default null i SQL). Race-vakt: RPC
+        // demoterer kun hvis sittende GS matcher denne id-en.
+        Args: { forventet_profil?: string }
         Returns: {
-          forrige_profil: string
-          forrige_navn: string
+          // Nullable når ingen GS fantes, eller når forventet_profil ikke
+          // matchet sittende GS (race-mismatch).
+          forrige_profil: string | null
+          forrige_navn: string | null
         }[]
       }
       sett_generalsekretaer: {
         Args: { ny_profil: string }
         Returns: {
-          forrige_profil: string
-          forrige_navn: string
+          // Nullable når det ikke var noen sittende GS før byttet.
+          forrige_profil: string | null
+          forrige_navn: string | null
         }[]
       }
       get_statistikk: { Args: never; Returns: Json }

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -1387,6 +1387,20 @@ export type Database = {
       }
       er_admin: { Args: never; Returns: boolean }
       er_generalsekretaer: { Args: never; Returns: boolean }
+      fjern_generalsekretaer: {
+        Args: Record<PropertyKey, never>
+        Returns: {
+          forrige_profil: string
+          forrige_navn: string
+        }[]
+      }
+      sett_generalsekretaer: {
+        Args: { ny_profil: string }
+        Returns: {
+          forrige_profil: string
+          forrige_navn: string
+        }[]
+      }
       get_statistikk: { Args: never; Returns: Json }
       har_pass_tilgang: { Args: { eier: string }; Returns: boolean }
       lukk_kaaringspoll_naa: {

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 15,
-  "versjon": "V3.2.15"
+  "nummer": 16,
+  "versjon": "V3.2.16"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 13,
-  "versjon": "V3.2.13"
+  "nummer": 14,
+  "versjon": "V3.2.14"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 14,
-  "versjon": "V3.2.14"
+  "nummer": 15,
+  "versjon": "V3.2.15"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.2.15'
+const CACHE_VERSION = 'V3.2.16'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.2.14'
+const CACHE_VERSION = 'V3.2.15'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.2.13'
+const CACHE_VERSION = 'V3.2.14'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/scripts/init-admin.mjs
+++ b/scripts/init-admin.mjs
@@ -104,9 +104,14 @@ if (count > 0) {
 
   if (!eksisterende) {
     avbryt(
-      `profiles-tabellen er ikke tom (${count} rad(er)). ` +
-      'Scriptet kjøres kun på ferske instanser. ' +
-      'Legg til admin via Rediger-siden i appen, eller via Supabase Dashboard.'
+      `profiles-tabellen er ikke tom (${count} rad(er)), og eposten ${epost} ` +
+      'finnes ikke der fra før. Scriptet er ment for ferske instanser, eller ' +
+      'for re-kjøring med samme epost etter at Lag 1 (auth-bruker) gikk gjennom.\n\n' +
+      'Hvis du vil legge til denne adminen likevel:\n' +
+      '  1. Opprett brukeren via Supabase Dashboard → Authentication → Users\n' +
+      '  2. Sett rollen via SQL i Dashboard:\n' +
+      `     update public.profiles set rolle = 'admin' where epost = '${epost}';\n\n` +
+      'Eller bruk Rediger-siden i appen hvis du allerede har innloggede admins.'
     )
   }
 

--- a/scripts/init-admin.mjs
+++ b/scripts/init-admin.mjs
@@ -190,7 +190,11 @@ const filinnhold = [
   '',
 ].join('\n')
 
-fs.writeFileSync(passordFil, filinnhold, { encoding: 'utf8' })
+// mode: 0o600 settes ved opprettelse for å lukke vinduet mellom write og chmod
+// hvor en annen prosess kunne ha lest filen. På Windows er mode-flagget
+// effektivt en no-op, men det er trygt å sende. chmodSync nedenfor er
+// fallback i tilfelle umask eller eksisterende fil har endret tilgangen.
+fs.writeFileSync(passordFil, filinnhold, { encoding: 'utf8', mode: 0o600 })
 
 try {
   fs.chmodSync(passordFil, 0o600)

--- a/scripts/init-admin.mjs
+++ b/scripts/init-admin.mjs
@@ -1,0 +1,213 @@
+// Opprett første admin på en fersk Supabase-instans.
+//
+// ANBEFALT FREMGANGSMÅTE: Bruk Supabase Dashboard (Authentication → Add user)
+// + SQL: UPDATE profiles SET rolle = 'admin', navn = '...' WHERE id = '...';
+// Det er det tryggeste og minst feilsårbare for en engangsoperasjon.
+//
+// Dette scriptet er alternativet («advanced») — nyttig ved scripted oppsett
+// eller katastrofegjenoppretting. Det nekter å kjøre mot prod-instansen og
+// mot en instans som allerede har profiler.
+//
+// Kjøres: node --env-file=.env.local scripts/init-admin.mjs <epost> [navn]
+//
+// Etter kjøring: logg inn, gå til Profil → Rediger, og bytt passordet straks.
+
+import { createClient } from '@supabase/supabase-js'
+import * as fs from 'node:fs'
+import * as readline from 'node:readline/promises'
+import { stdin as input, stdout as output } from 'node:process'
+import { randomBytes } from 'node:crypto'
+
+// ─── Hjelpere ───────────────────────────────────────────────────────────────
+
+// Kjent prod-Supabase-URL (speil av KJENT_PROD_SUPABASE_URL i lib/config.ts).
+// .mjs kan ikke importere TypeScript-moduler, så vi dupliserer konstanten her
+// med kommentar om at de to skal holdes i synk. Se lib/config.ts.
+const KJENT_PROD_SUPABASE_URL = 'https://tdlfswmxezjdnxcbbiwn.supabase.co'
+
+function avbryt(melding) {
+  console.error(`\n  AVBRUTT: ${melding}\n`)
+  process.exit(1)
+}
+
+// Generer et sterkt tilfeldig passord (24 tegn, base64url uten padding).
+function genererPassord() {
+  return randomBytes(18).toString('base64url')
+}
+
+// Venter på at profiles-raden opprettes av trigger handle_ny_bruker (011).
+// Trigger-retten er asynkron; vi poller opptil ~5 sekunder.
+async function ventPaaProfil(adminClient, userId, maxForsok = 10) {
+  for (let i = 0; i < maxForsok; i++) {
+    const { data } = await adminClient
+      .from('profiles')
+      .select('id')
+      .eq('id', userId)
+      .maybeSingle()
+    if (data) return true
+    await new Promise(r => setTimeout(r, 500))
+  }
+  return false
+}
+
+// ─── Validering av argumenter ────────────────────────────────────────────────
+
+const [, , epost, navnArg] = process.argv
+if (!epost) {
+  console.error('Bruk: node --env-file=.env.local scripts/init-admin.mjs <epost> [navn]')
+  process.exit(1)
+}
+
+const SUPABASE_URL           = process.env.NEXT_PUBLIC_SUPABASE_URL
+const SUPABASE_SERVICE_KEY   = process.env.SUPABASE_SERVICE_ROLE_KEY
+const SUPABASE_ANON_KEY      = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
+  avbryt('NEXT_PUBLIC_SUPABASE_URL og SUPABASE_SERVICE_ROLE_KEY må være satt i .env.local')
+}
+
+// ─── Lag 1: Nekter å kjøre mot kjent prod-URL ────────────────────────────────
+// Prod-instansen er i aktiv bruk; init-scriptet skal aldri kjøre der selv om
+// noen ved uhell peker .env.local mot prod.
+
+if (SUPABASE_URL === KJENT_PROD_SUPABASE_URL) {
+  avbryt(
+    'SUPABASE_URL peker mot kjent prod-instans. ' +
+    'Dette scriptet kjøres kun på ferske / lokale instanser.\n' +
+    '  Vil du opprette admin i prod? Bruk Supabase Dashboard i stedet.'
+  )
+}
+
+// ─── Klientoppsett ───────────────────────────────────────────────────────────
+
+const adminClient = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+})
+
+// ─── Lag 2: Nekter å kjøre hvis profiles ikke er tom ─────────────────────────
+// Beskytter mot å kjøre ved uhell på en instans som allerede er i bruk.
+
+const { count, error: telFeil } = await adminClient
+  .from('profiles')
+  .select('*', { count: 'exact', head: true })
+
+if (telFeil) avbryt(`Klarte ikke telle profiler: ${telFeil.message}`)
+
+if (count > 0) {
+  // Idempotens-gren: re-kjøring etter delvis feil (kun hvis eposten finnes).
+  // Vi gjør ikke en full abort — sjekk om akkurat denne eposten finnes.
+  const { data: eksisterende } = await adminClient
+    .from('profiles')
+    .select('id, rolle, navn')
+    .eq('epost', epost)
+    .maybeSingle()
+
+  if (!eksisterende) {
+    avbryt(
+      `profiles-tabellen er ikke tom (${count} rad(er)). ` +
+      'Scriptet kjøres kun på ferske instanser. ' +
+      'Legg til admin via Rediger-siden i appen, eller via Supabase Dashboard.'
+    )
+  }
+
+  // Profilen finnes — promoter til admin (idempotent re-kjøring etter delvis feil).
+  console.log(`\n  Profilen ${epost} finnes allerede. Promoterer til admin ...\n`)
+  const { error } = await adminClient
+    .from('profiles')
+    .update({ rolle: 'admin', ...(navnArg ? { navn: navnArg } : {}) })
+    .eq('id', eksisterende.id)
+  if (error) avbryt(`Klarte ikke promotere: ${error.message}`)
+  console.log(`  OK — ${epost} er nå admin (id: ${eksisterende.id}).\n`)
+  process.exit(0)
+}
+
+// ─── Lag 3: Retype-URL-prompt (bekreftelsessperre) ────────────────────────────
+// Krever at brukeren skriver inn Supabase-URL-en på nytt. Enkelt, men effektivt
+// mot tastatur-feil («jeg mente å trykke Ctrl+C, ikke Enter»).
+
+const rl = readline.createInterface({ input, output })
+console.log(`\n  Du er i ferd med å opprette første admin på:\n  ${SUPABASE_URL}\n`)
+const bekreftet = await rl.question('  Skriv inn Supabase-URL-en på nytt for å bekrefte: ')
+rl.close()
+
+if (bekreftet.trim() !== SUPABASE_URL.trim()) {
+  avbryt('URL-ene stemmer ikke. Ingen endringer gjort.')
+}
+
+// ─── Opprett bruker ──────────────────────────────────────────────────────────
+
+const passord = genererPassord()
+
+const { data: nyBruker, error: brukerfeil } = await adminClient.auth.admin.createUser({
+  email: epost,
+  password: passord,
+  email_confirm: true,  // hopper over e-postbekreftelse for admin-oppsett
+})
+
+if (brukerfeil) avbryt(`Klarte ikke opprette bruker: ${brukerfeil.message}`)
+const userId = nyBruker.user.id
+console.log(`\n  Auth-bruker opprettet (id: ${userId}). Venter på profiles-trigger ...`)
+
+// ─── Vent på profiles-trigger ────────────────────────────────────────────────
+// handle_ny_bruker-triggeren (migrasjon 011) oppretter profiles-raden asynkront.
+// Maks 5 sekunders polling (500 ms × 10 forsøk).
+
+const funnet = await ventPaaProfil(adminClient, userId)
+if (!funnet) {
+  avbryt(
+    'profiles-raden ble ikke opprettet innen 5 sek. ' +
+    'Kjør manuelt:\n  UPDATE profiles SET rolle = \'admin\', navn = \'...\' WHERE id = \'' + userId + '\';'
+  )
+}
+
+// ─── Promoter til admin + sett navn ──────────────────────────────────────────
+
+const { error: oppdatertFeil } = await adminClient
+  .from('profiles')
+  .update({ rolle: 'admin', ...(navnArg ? { navn: navnArg } : {}) })
+  .eq('id', userId)
+
+if (oppdatertFeil) avbryt(`Klarte ikke sette rolle: ${oppdatertFeil.message}`)
+
+// ─── Skriv passord til fil (IKKE til stdout) ──────────────────────────────────
+// Passordet i stdout = shell-historikk-risiko. Vi skriver til fil med
+// begrenset tilgang. fs.chmodSync er no-op på Windows — vi printer da en
+// advarsel om å slette filen manuelt etter bruk.
+
+const passordFil = './init-admin-passord.txt'
+const filinnhold = [
+  `Engangpassord for ${epost}`,
+  `Supabase-instans: ${SUPABASE_URL}`,
+  '',
+  `Passord: ${passord}`,
+  '',
+  'Slett denne filen straks etter at du har logget inn og byttet passord!',
+  '',
+].join('\n')
+
+fs.writeFileSync(passordFil, filinnhold, { encoding: 'utf8' })
+
+try {
+  fs.chmodSync(passordFil, 0o600)
+} catch {
+  // Windows støtter ikke POSIX-tilganger — advarsel skrives nedenfor.
+  console.warn(`  NB: Klarte ikke sette begrenset tilgang på ${passordFil} (Windows-begrensning).`)
+  console.warn(`  Slett filen manuelt straks etter bruk.`)
+}
+
+// ─── Ferdig ──────────────────────────────────────────────────────────────────
+
+console.log(`
+  Admin opprettet:
+    E-post : ${epost}
+    Passord: se ${passordFil}
+    Id     : ${userId}
+
+  Neste steg:
+    1. Logg inn på appen med e-post og passordet fra filen.
+    2. Gå til Profil → Rediger og bytt passordet.
+    3. Slett ${passordFil} (eller la det stå til neste restart — men ikke commit det!).
+    4. Sett generalsekretær i appen: Rediger et annet medlem → toggle Generalsekretær.
+
+  VIKTIG: Aldri commit ${passordFil} til git.
+`)

--- a/supabase/migrations/094_unik_generalsekretaer.sql
+++ b/supabase/migrations/094_unik_generalsekretaer.sql
@@ -81,20 +81,34 @@ begin
      where id = v_forrige_id;
   end if;
 
-  -- Promotér ny profil til 'generalsekretaer'
+  -- Promotér ny profil til 'generalsekretaer'.
+  -- FOUND-sjekk: hvis ny_profil ikke finnes (slettet/feil id) blir UPDATE en
+  -- silent no-op som ellers ville returnert OK. Vi vil heller feile synlig.
   update profiles
      set rolle     = 'generalsekretaer',
          oppdatert = now()
    where id = ny_profil;
 
+  if not found then
+    raise exception 'Profil % finnes ikke — kan ikke settes som generalsekretær', ny_profil
+      using errcode = 'P0002';
+  end if;
+
   return query select v_forrige_id, v_forrige_navn;
 end;
 $$;
 
--- 3) RPC: fjern_generalsekretaer()
+-- 3) RPC: fjern_generalsekretaer(forventet_profil uuid)
 --    Demoterer sittende GS til 'admin'. Null GS er gyldig tilstand (f.eks.
 --    i overgangsperiode). Returnerer den som ble fjernet.
-create or replace function fjern_generalsekretaer()
+--
+--    forventet_profil-parameteren forhindrer race-tilstand: klienten leser
+--    sittende GS ved sidelast, men en annen admin kan ha flyttet tittelen
+--    mellom lasting og lagring. Vi demoterer KUN hvis sittende GS-id matcher
+--    det klienten forventet. Mismatch → tomrad returneres uten endring, og
+--    klienten kan oppdage det og varsle brukeren. forventet_profil = null
+--    bevarer gammel oppførsel (demoter hvem enn som sitter).
+create or replace function fjern_generalsekretaer(forventet_profil uuid default null)
 returns table (
   forrige_profil uuid,
   forrige_navn   text
@@ -123,6 +137,14 @@ begin
     return;
   end if;
 
+  -- Race-vakt: hvis klienten oppga forventet profil og det ikke matcher
+  -- sittende GS, har noen flyttet tittelen i mellomtiden. Ikke demoter —
+  -- returner tomrad så klienten kan oppdage at ingenting ble gjort.
+  if forventet_profil is not null and forventet_profil <> v_forrige_id then
+    return query select null::uuid, null::text;
+    return;
+  end if;
+
   update profiles
      set rolle     = 'admin',
          oppdatert = now()
@@ -138,5 +160,5 @@ $$;
 revoke all on function sett_generalsekretaer(uuid) from public;
 grant execute on function sett_generalsekretaer(uuid) to authenticated;
 
-revoke all on function fjern_generalsekretaer() from public;
-grant execute on function fjern_generalsekretaer() to authenticated;
+revoke all on function fjern_generalsekretaer(uuid) from public;
+grant execute on function fjern_generalsekretaer(uuid) to authenticated;

--- a/supabase/migrations/094_unik_generalsekretaer.sql
+++ b/supabase/migrations/094_unik_generalsekretaer.sql
@@ -1,0 +1,142 @@
+-- Unik-garanti for generalsekretær-rollen + atomisk RPC for bytte.
+--
+-- Bakgrunn (issue #294): tittelen «generalsekretær» skal det aldri være mer
+-- enn én av. Inntil nå var det kun konvensjon og UI-advarsel som voktet; en
+-- admin som jobber under stress (eller et direktiv via SQL) kunne sette to.
+-- Løsningen er belte-og-bukseseler: partial unique index som hard DB-invariant
+-- + atomisk RPC som gjør promotér+demotér i én transaksjon uten mellomtilstand.
+--
+-- Rollene demoteres til 'admin' (ikke 'medlem') fordi personen har tydelig
+-- vist at han er tillitsvalgt; en demosjon til vanlig medlem ville vært mer
+-- overraskende enn hensikten.
+
+-- 0) Pre-flight: avbryt hvis det allerede er mer enn én generalsekretær.
+--    (Ny instans: tabellen er tom, sjekken passerer. Prod: André Heede er
+--    den ene som finnes, sjekken passerer. Kantcase med to: vi ønsker at
+--    migrasjonene feiler synlig heller enn å lage et ulogisk alias.)
+do $$
+declare
+  antall integer;
+begin
+  select count(*) into antall
+    from profiles
+   where rolle = 'generalsekretaer';
+
+  if antall > 1 then
+    raise exception
+      'Migrasjon avbrutt: det er % generalsekretærer i databasen. '
+      'Reduser til maks én manuelt (UPDATE profiles SET rolle = ''admin'' WHERE …) '
+      'og kjør migrasjonen på nytt.', antall;
+  end if;
+end $$;
+
+-- 1) Partial unique index — garanterer maks én rad med rolle='generalsekretaer'.
+--    Partial fordi vi ikke vil begrense antallet admins eller medlemmer.
+create unique index if not exists profiles_unik_generalsekretaer
+  on public.profiles (rolle)
+  where rolle = 'generalsekretaer';
+
+-- 2) RPC: sett_generalsekretaer(ny_profil uuid)
+--    Demoterer eksisterende GS til 'admin', promoterer ny til 'generalsekretaer'
+--    — alt i én transaksjon. Returnerer den forrige innehaveren (null hvis ingen).
+--    Sikkerhetsmodell: SECURITY DEFINER med er_admin()-vakt, ikke RLS-avhengig,
+--    fordi en rolle-UPDATE på en annen brukers rad ellers ville kreve admin-policy
+--    som tillater UPDATE av alle kolonner.
+create or replace function sett_generalsekretaer(ny_profil uuid)
+returns table (
+  forrige_profil uuid,
+  forrige_navn   text
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_forrige_id   uuid;
+  v_forrige_navn text;
+begin
+  -- Kun admin/generalsekretær kan utføre bytte (speiler er_admin()-semantikk)
+  if not er_admin() then
+    raise exception 'Kun admin kan sette generalsekretær'
+      using errcode = '42501';
+  end if;
+
+  -- Slå opp sittende generalsekretær
+  select id, navn into v_forrige_id, v_forrige_navn
+    from profiles
+   where rolle = 'generalsekretaer'
+   for update;  -- lås raden for å unngå race ved parallelle kall
+
+  -- Tidlig retur hvis ny_profil allerede er GS (ingen operasjon nødvendig)
+  if v_forrige_id = ny_profil then
+    return query select v_forrige_id, v_forrige_navn;
+    return;
+  end if;
+
+  -- Demotér sittende GS til 'admin' (ikke 'medlem' — han er fortsatt tillitsvalgt)
+  if v_forrige_id is not null then
+    update profiles
+       set rolle     = 'admin',
+           oppdatert = now()
+     where id = v_forrige_id;
+  end if;
+
+  -- Promotér ny profil til 'generalsekretaer'
+  update profiles
+     set rolle     = 'generalsekretaer',
+         oppdatert = now()
+   where id = ny_profil;
+
+  return query select v_forrige_id, v_forrige_navn;
+end;
+$$;
+
+-- 3) RPC: fjern_generalsekretaer()
+--    Demoterer sittende GS til 'admin'. Null GS er gyldig tilstand (f.eks.
+--    i overgangsperiode). Returnerer den som ble fjernet.
+create or replace function fjern_generalsekretaer()
+returns table (
+  forrige_profil uuid,
+  forrige_navn   text
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_forrige_id   uuid;
+  v_forrige_navn text;
+begin
+  if not er_admin() then
+    raise exception 'Kun admin kan fjerne generalsekretær'
+      using errcode = '42501';
+  end if;
+
+  select id, navn into v_forrige_id, v_forrige_navn
+    from profiles
+   where rolle = 'generalsekretaer'
+   for update;
+
+  if v_forrige_id is null then
+    -- Ingen GS å fjerne — returner tomrad (OK, ikke feil)
+    return query select null::uuid, null::text;
+    return;
+  end if;
+
+  update profiles
+     set rolle     = 'admin',
+         oppdatert = now()
+   where id = v_forrige_id;
+
+  return query select v_forrige_id, v_forrige_navn;
+end;
+$$;
+
+-- 4) Tilgangsstyring for RPC-funksjonene.
+--    Public har ingen execute-grant (Supabase default) — vi gir kun til
+--    authenticated slik at anon og public ikke kan kalle funksjonene.
+revoke all on function sett_generalsekretaer(uuid) from public;
+grant execute on function sett_generalsekretaer(uuid) to authenticated;
+
+revoke all on function fjern_generalsekretaer() from public;
+grant execute on function fjern_generalsekretaer() to authenticated;

--- a/supabase/migrations/095_varsel_preferanser_trigger.sql
+++ b/supabase/migrations/095_varsel_preferanser_trigger.sql
@@ -1,0 +1,42 @@
+-- Trigger: opprett varsel_preferanser-rad automatisk ved ny profil.
+--
+-- Bakgrunn (issue #294): nye brukere opprettet via init-admin-script,
+-- admin-UI eller manuell SQL fikk ikke varsel_preferanser-rad automatisk.
+-- Mangelen ble oppdaget fordi push-varsler (029) bruker .eq('profil_id', …)
+-- og feiler stille når raden mangler. Triggerløsningen lukker problemklassen
+-- for alle nåværende og fremtidige inn-veier — i stedet for å patche per sted.
+--
+-- varsel_preferanser-skjema (029 + 030):
+--   profil_id uuid PRIMARY KEY  → ON CONFLICT (profil_id) er trygt
+--   push_aktiv boolean NOT NULL DEFAULT false
+--   epost_aktiv boolean NOT NULL DEFAULT true
+--   oppdatert timestamptz DEFAULT now()
+-- Alle kolonner har default; minimal insert med bare profil_id er nok.
+
+create or replace function opprett_varsel_preferanser()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into varsel_preferanser (profil_id)
+  values (new.id)
+  on conflict (profil_id) do nothing;
+  return new;
+end;
+$$;
+
+-- Trigger på profiles (handle_ny_bruker håndterer auth.users → profiles;
+-- denne triggeren tar seg av profiles → varsel_preferanser).
+drop trigger if exists ved_ny_profil_varsel_preferanser on public.profiles;
+create trigger ved_ny_profil_varsel_preferanser
+  after insert on public.profiles
+  for each row
+  execute function opprett_varsel_preferanser();
+
+-- Idempotent backfill: opprett rad for alle eksisterende profiler som mangler.
+-- ON CONFLICT sikrer at eksisterende rader ikke påvirkes.
+insert into varsel_preferanser (profil_id)
+select id from profiles
+on conflict (profil_id) do nothing;

--- a/supabase/migrations/096_vedtekter_seed_avhardkoding.sql
+++ b/supabase/migrations/096_vedtekter_seed_avhardkoding.sql
@@ -1,17 +1,21 @@
 -- Fixup: fjern klubbnavnet fra vedtekter-seedens default-tekst.
 --
--- Bakgrunn: migrasjon 005 sådde tre innholdssider med teksten
+-- Bakgrunn: migrasjon 005 sådde 'vedtekter'-raden med teksten
 --   '# Vedtekter for Mortensrud Herreklubb\n\n_Ingen vedtekter lagt inn ennå._'
 -- Dette hardkoder klubbnavnet i innholdet, noe vi ønsker å unngå.
--- Ny default-tekst er generisk og passer ethvert oppsett.
 --
--- Vi aldri redigerer 005 — migrasjonshistorikk er append-only. Dette er en
--- idempotent fixup som kun treffer den opprinnelige seed-teksten; redigert
--- innhold (der noen faktisk har lagt inn vedtekter) røres ikke.
+-- VIKTIG: 005 brukte vanlig singlequote-streng, så `\n` lagres som to
+-- bokstavelige tegn (`\` + `n`) — IKKE som linjeskift. Verifisert mot prod
+-- 2026-06-10. Den ekte vedtekter-raden er for lengst redigert til reelt
+-- innhold (1700+ tegn med ekte newlines), så for å unngå å overskrive
+-- redigert innhold matcher vi på EKSAKT opprinnelig seed-streng — ikke
+-- prefiks. Migrasjonen er da idempotent og no-op i prod (raden er endret).
 --
--- Bruker E''-syntaks for newlines slik at \n tolkes som linjeskift av Postgres.
+-- Vi rører heller ikke `regler`/`historikk` her — de har ikke klubbnavn
+-- i seg, så de er utenfor scope for denne fixupen. (Literal `\n` i de
+-- radene er en separat skjønnhetsfeil som tas i eget issue ved behov.)
 
 update public.vedtekter
-   set innhold = E'# Vedtekter\n\n_Ingen vedtekter lagt inn ennå._'
+   set innhold = '# Vedtekter\n\n_Ingen vedtekter lagt inn ennå._'
  where slug = 'vedtekter'
-   and innhold like '# Vedtekter for Mortensrud Herreklubb%';
+   and innhold = '# Vedtekter for Mortensrud Herreklubb\n\n_Ingen vedtekter lagt inn ennå._';

--- a/supabase/migrations/096_vedtekter_seed_avhardkoding.sql
+++ b/supabase/migrations/096_vedtekter_seed_avhardkoding.sql
@@ -1,0 +1,17 @@
+-- Fixup: fjern klubbnavnet fra vedtekter-seedens default-tekst.
+--
+-- Bakgrunn: migrasjon 005 sådde tre innholdssider med teksten
+--   '# Vedtekter for Mortensrud Herreklubb\n\n_Ingen vedtekter lagt inn ennå._'
+-- Dette hardkoder klubbnavnet i innholdet, noe vi ønsker å unngå.
+-- Ny default-tekst er generisk og passer ethvert oppsett.
+--
+-- Vi aldri redigerer 005 — migrasjonshistorikk er append-only. Dette er en
+-- idempotent fixup som kun treffer den opprinnelige seed-teksten; redigert
+-- innhold (der noen faktisk har lagt inn vedtekter) røres ikke.
+--
+-- Bruker E''-syntaks for newlines slik at \n tolkes som linjeskift av Postgres.
+
+update public.vedtekter
+   set innhold = E'# Vedtekter\n\n_Ingen vedtekter lagt inn ennå._'
+ where slug = 'vedtekter'
+   and innhold like '# Vedtekter for Mortensrud Herreklubb%';


### PR DESCRIPTION
Løser del av #294 (OS-fase 3). Behandlet av arkitekturstyret — se [uttalelsen på issuet](https://github.com/reidarei/Herreklubben/issues/294#issuecomment-4666597820).

## Innhold

- **Migrasjon 094:** Partial unique index (maks én generalsekretær) + atomiske RPC-er `sett_generalsekretaer`/`fjern_generalsekretaer` (SECURITY DEFINER, `er_admin()`-vakt, FOR UPDATE-lås, demoterer forrige innehaver til admin)
- **Migrasjon 095:** Trigger `after insert on profiles` som oppretter `varsel_preferanser`-rad — lukker pre-existing bug for alle inn-veier + idempotent backfill
- **Migrasjon 096:** Avhardkoding av vedtekter-seed (eksakt-match-guard, no-op i dagens prod)
- **UI:** ToggleSwitch «Generalsekretær» i medlemsredigering med confirm-dialoger og race-håndtering; generalsekretær settes nå fra appen (Reidars issue-kommentar)
- **Server actions:** `settGeneralsekretaer`/`fjernGeneralsekretaer`; allowlist i `oppdaterMedlemAdmin` som aldri rører rolle-feltet for sittende GS
- **Bootstrap:** `scripts/init-admin.mjs` med tre-lags vakt (prod-URL, tom-DB, retype-prompt), passord til fil; `docs/oppsett.md` med full deploy-fra-scratch-guide; Dashboard som primær vei
- **Cron/Storage:** dokumentert i oppsett.md; buckets opprettes allerede av migrasjonene

## Beslutninger underveis

- **Intern review:** 1 BLOCKER rettet (096-guarden ville overskrevet redigerte prod-vedtekter — strammet til eksakt match mot opprinnelig seed-tekst etter read-only prod-verifikasjon), 4 MAJOR rettet (handleLagre-rekkefølge snudd, race-recovery-melding, TOCTOU i rolle-bevaring, warn-logging), 2 MINOR + 2 NIT rettet, 5 funn forsvart/avvist med begrunnelse.
- **Oppfølger-issues opprettet:** #301 (er_admin() search_path), #302 (literal \n i regler/historikk-seed).
- **Typer:** RPC-typene er lagt manuelt i database.types.ts — regenereres etter at migrasjonene er kjørt mot prod.

## Test

- lint, 129 tester og build grønne
- Migrasjonene kjøres mot prod etter merge (db push + typeregenerering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)