### PR TITLE
OS-fase 5: sikkerhetsgjennomgang — search_path, webhook fail-closed, lisensaudit (#296)

### DIFF
--- a/app/api/github/webhook/route.ts
+++ b/app/api/github/webhook/route.ts
@@ -17,10 +17,19 @@ function verifiserSignatur(body: string, signatur: string | null): boolean {
 }
 
 export async function POST(request: Request) {
+  // Fail-closed: hvis hemmeligheten ikke er satt avviser vi requesten.
+  // Et tidligere mønster (`if (WEBHOOK_SECRET && !verifiserSignatur(...))`)
+  // hoppet over verifisering ved manglende env-var — det er fail-open og
+  // ble fanget i sikkerhetsgjennomgangen 2026-06.
+  if (!WEBHOOK_SECRET) {
+    console.error('[github-webhook] GITHUB_WEBHOOK_SECRET er ikke satt — avviser kall')
+    return NextResponse.json({ feil: 'Webhook ikke konfigurert' }, { status: 503 })
+  }
+
   const rawBody = await request.text()
   const signatur = request.headers.get('x-hub-signature-256')
 
-  if (WEBHOOK_SECRET && !verifiserSignatur(rawBody, signatur)) {
+  if (!verifiserSignatur(rawBody, signatur)) {
     return NextResponse.json({ feil: 'Ugyldig signatur' }, { status: 401 })
   }
 

--- a/docs/sikkerhetsgjennomgang-2026-06.md
+++ b/docs/sikkerhetsgjennomgang-2026-06.md
@@ -7,7 +7,7 @@
 
 ## 1. Row Level Security (RLS)
 
-Alle 31 tabeller i `public`-schema har RLS aktivert. Default-holdningen er deny-by-default: ingen rad leses eller skrives uten en eksplisitt policy som tillater det.
+Alle 31 tabeller i `public`-schema har RLS aktivert (verifisert mot prod 2026-06-10). Default-holdningen er deny-by-default: ingen rad leses eller skrives uten en eksplisitt policy som tillater det.
 
 **Admin-policies** bruker funksjonen `er_admin()` (definert i mig. 041, search_path-låst i mig. 097) i stedet for inline `rolle = 'admin'`-sjekker. Det gjør at rollen `generalsekretaer` automatisk arver admin-rettigheter uten at hver policy må oppdateres.
 
@@ -16,7 +16,7 @@ Alle 31 tabeller i `public`-schema har RLS aktivert. Default-holdningen er deny-
 | Tabell | Begrunnelse |
 |--------|-------------|
 | `varsel_logg` | Har kun SELECT-policy for eier + admin. INSERT skjer via service_role i `sendVarsel()` — brukere kan ikke selv skrive varsler til seg selv eller andre. |
-| `vitals_logg` | Har kun SELECT-policy for admin. INSERT skjer via service_role i `/api/vitals`-ruta — ingen innlogget bruker kan manipulere ytelsesdataene. |
+| `vitals_logg` | Har kun SELECT-policy for admin. INSERT skjer via service_role fra `/api/vitals`-ruta. Ruta er bevisst uautentisert (se §2) — beskyttelsen mot manipulasjon ligger i streng server-side validering av enum-felter og capping av tallverdier før insert. |
 
 Disse er ikke hull — deny-by-default er tilsiktet for skrive-tilgang.
 
@@ -30,10 +30,15 @@ Disse er ikke hull — deny-by-default er tilsiktet for skrive-tilgang.
 
 | Rute | Beskyttelsesmekanisme |
 |------|-----------------------|
-| `/api/cron/paaminne` | `CRON_SECRET` i Authorization-header — verifiseres mot env-variabel før noe annet skjer |
+| `/api/cron/paaminne` | `CRON_SECRET` i Authorization-header — verifiseres på alle metoder (GET og POST) før noe annet skjer |
 | `/api/github/webhook` | HMAC-SHA256 signatur (`X-Hub-Signature-256`) — verifiseres mot `GITHUB_WEBHOOK_SECRET` |
+| `/api/vitals` | Ingen — bevisst uautentisert (se under) |
 
-Begge rutene returnerer 401 umiddelbart ved feil/manglende hemmelighet, uten å røpe detaljer om hva som feilet.
+Webhook-ruta returnerer 401 ved ugyldig signatur. Manglende `GITHUB_WEBHOOK_SECRET` gir 503 (fail-closed) — ruten aksepterer aldri en payload uten å ha verifisert signaturen først. Cron-ruta returnerer 401 ved manglende eller feil bearer-token. Ingen av rutene røper detaljer om hva som feilet.
+
+**Bevisst uautentisert: `/api/vitals`**
+
+Ruta tar imot Web Vitals-målinger (LCP, INP, CLS, FCP, TTFB) fra klientene. Den må være uautentisert fordi målingene sendes via `navigator.sendBeacon` ved page-unload, der Supabase-sesjonen ikke pålitelig er tilgjengelig. Misbruksrisikoen er begrenset av streng server-side validering: `metric` må være i en hvitliste, `rating` likeså, `verdi` må være et tall mellom 0 og 600 000, og `rute` capet til 120 tegn. En angriper kan i verste fall forurense egne ytelsesdata — ingen sensitiv tilstand kan endres. Akseptert risiko for dette endepunktet.
 
 ---
 

--- a/docs/sikkerhetsgjennomgang-2026-06.md
+++ b/docs/sikkerhetsgjennomgang-2026-06.md
@@ -1,0 +1,90 @@
+# Sikkerhetsgjennomgang — Mortensrud Herreklubb-appen
+
+**Dato:** 2026-06-10
+**Kontekst:** Forberedelse til open source-publisering (issue #296, OS-fase 5). Lisens: MIT. Publisering skjer i nytt, rent repo uten historikk.
+
+---
+
+## 1. Row Level Security (RLS)
+
+Alle 31 tabeller i `public`-schema har RLS aktivert. Default-holdningen er deny-by-default: ingen rad leses eller skrives uten en eksplisitt policy som tillater det.
+
+**Admin-policies** bruker funksjonen `er_admin()` (definert i mig. 041, search_path-låst i mig. 097) i stedet for inline `rolle = 'admin'`-sjekker. Det gjør at rollen `generalsekretaer` automatisk arver admin-rettigheter uten at hver policy må oppdateres.
+
+**Bevisste INSERT-only-via-service_role-tabeller:**
+
+| Tabell | Begrunnelse |
+|--------|-------------|
+| `varsel_logg` | Har kun SELECT-policy for eier + admin. INSERT skjer via service_role i `sendVarsel()` — brukere kan ikke selv skrive varsler til seg selv eller andre. |
+| `vitals_logg` | Har kun SELECT-policy for admin. INSERT skjer via service_role i `/api/vitals`-ruta — ingen innlogget bruker kan manipulere ytelsesdataene. |
+
+Disse er ikke hull — deny-by-default er tilsiktet for skrive-tilgang.
+
+---
+
+## 2. Autorisasjon i server actions og API-ruter
+
+**Server actions** bruker `ensureAdmin()` eller `ensureInnlogget()` fra `lib/auth.ts`. Disse kaster ved manglende autentisering eller utilstrekkelig rolle. RLS er fortsatt sannheten — server action-sjekken gir raskere feilmelding og bedre brukeropplevelse, men er ikke det eneste sikkerhetslaget.
+
+**API-ruter med egne secrets:**
+
+| Rute | Beskyttelsesmekanisme |
+|------|-----------------------|
+| `/api/cron/paaminne` | `CRON_SECRET` i Authorization-header — verifiseres mot env-variabel før noe annet skjer |
+| `/api/github/webhook` | HMAC-SHA256 signatur (`X-Hub-Signature-256`) — verifiseres mot `GITHUB_WEBHOOK_SECRET` |
+
+Begge rutene returnerer 401 umiddelbart ved feil/manglende hemmelighet, uten å røpe detaljer om hva som feilet.
+
+---
+
+## 3. Bevisst eksponering: profil-data
+
+Alle innloggede medlemmer kan lese alle profiler — navn, e-post, rolle, profilbilde. Dette er et bevisst valg for en lukket single-tenant-klubb med ~17 brukere som kjenner hverandre. Det finnes ingen offentlige flater: `anon`-rollen har ikke SELECT-policy på `profiles`.
+
+---
+
+## 4. Rate-limiting
+
+Supabase Auth har innebygd rate-limiting på innlogging og passordtilbakestilling (konfigurerbart i Supabase Dashboard). Ingen egne rate-limiting-tiltak er innført utover det.
+
+**Vurdering:** Appen har ~17 brukere og ingen selvregistrering. Alle API-ruter som kan gjøre ekte arbeid er beskyttet enten av middleware-auth (Supabase session) eller dedikerte secrets (se §2). Risikoen for misbruk fra ikke-innloggede aktører er svært lav. Ekstra rate-limiting er ikke innført og anses som unødvendig på dette brukervolumet.
+
+---
+
+## 5. Dependency-lisenser
+
+Kjørt med `npx license-checker --production --summary` (2026-06-10):
+
+| Lisens | Antall pakker |
+|--------|--------------|
+| MIT | 132 |
+| Apache-2.0 | 9 |
+| ISC | 5 |
+| BSD-3-Clause | 3 |
+| MPL-2.0 | 3 |
+| Apache-2.0 AND LGPL-3.0-or-later | 1 |
+| CC-BY-4.0 | 1 |
+| Unlicense | 1 |
+| UNLICENSED | 1 |
+| MIT-0 | 1 |
+| 0BSD | 1 |
+
+**Totalt:** 158 produksjonsavhengigheter.
+
+### Merknad: MPL-2.0
+
+Tre pakker er lisensiert under Mozilla Public License 2.0: `web-push`, `lightningcss` og `lightningcss-win32-x64-msvc`. MPL-2.0 er en svak copyleft-lisens med fil-nivå copyleft — endringer i de MPL-dekkede filene selv må deles under MPL. Bruk som avhengighet (uten å modifisere disse filenes kildekode) krever ingen copyleft-forpliktelse fra oss. Godkjent for MIT-lisensiert prosjekt i denne bruksformen.
+
+### Merknad: Apache-2.0 AND LGPL-3.0-or-later
+
+`@img/sharp-win32-x64` (den Windows-spesifikke binæren for `sharp`/`next/image`-optimalisering). LGPL-3.0 med "or-later" brukes som avhengighet, ikke innbygget. Standard LGPL-tolkning tillater linking mot LGPL-biblioteker uten copyleft-krav på eget arbeid. Godkjent.
+
+### Merknad: CC-BY-4.0
+
+`caniuse-lite` — data-pakke med nettleserkompabilitetsinformasjon, ikke kode. CC-BY-4.0 for data er standardpraksis for dette prosjektet. Krever bare navngivelse, ingen copyleft. Godkjent.
+
+### Merknad: UNLICENSED
+
+`herreklubben@3.2.0` — det er selve dette prosjektet som rapporteres av `license-checker` (leser sin egen `package.json`). Ikke en ekstern avhengighet.
+
+**Konklusjon:** Ingen avhengigheter med GPL, AGPL eller andre venstrehånds-copyleft-lisenser som ville kontaminert prosjektets MIT-lisensiering. Alle avhengigheter er kompatible med publisering under MIT.

--- a/docs/sikkerhetsgjennomgang-2026-06.md
+++ b/docs/sikkerhetsgjennomgang-2026-06.md
@@ -86,7 +86,7 @@ Tre pakker er lisensiert under Mozilla Public License 2.0: `web-push`, `lightnin
 
 ### Merknad: CC-BY-4.0
 
-`caniuse-lite` — data-pakke med nettleserkompabilitetsinformasjon, ikke kode. CC-BY-4.0 for data er standardpraksis for dette prosjektet. Krever bare navngivelse, ingen copyleft. Godkjent.
+`caniuse-lite` — data-pakke med nettleserkompatibilitetsinformasjon, ikke kode. CC-BY-4.0 for data er standardpraksis for dette prosjektet. Krever bare navngivelse, ingen copyleft. Godkjent.
 
 ### Merknad: UNLICENSED
 

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 17,
-  "versjon": "V3.2.17"
+  "nummer": 18,
+  "versjon": "V3.2.18"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 16,
-  "versjon": "V3.2.16"
+  "nummer": 17,
+  "versjon": "V3.2.17"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 18,
-  "versjon": "V3.2.18"
+  "nummer": 19,
+  "versjon": "V3.2.19"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.2.17'
+const CACHE_VERSION = 'V3.2.18'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.2.18'
+const CACHE_VERSION = 'V3.2.19'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.2.16'
+const CACHE_VERSION = 'V3.2.17'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/supabase/migrations/097_security_definer_search_path.sql
+++ b/supabase/migrations/097_security_definer_search_path.sql
@@ -9,9 +9,18 @@
 -- mig. 094 (sett_generalsekretaer, fjern_generalsekretaer).
 -- Tracker: issue #301.
 --
--- VIKTIG: ingen semantiske endringer — kun search_path = public tillegget.
+-- VIKTIG: search_path = public-tillegget er den primære endringen. I tillegg
+-- hardes er_admin() til å returnere en total boolean (NULL → false) — se under.
 
 -- 1) er_admin() — opprinnelig fra mig. 041, sist sett uten search_path
+--
+-- NULL-hardning lagt til etter Copilot-funn: tidligere kropp
+-- (`select rolle in (...) from profiles where id = auth.uid()`) returnerer NULL
+-- når SELECT-en ikke gir treff (f.eks. auth.uid() peker på rad som ikke finnes).
+-- I RLS-policies (`using (er_admin())`) tolkes NULL som false og er trygt, men
+-- i plpgsql-RPC-er som `sett_generalsekretaer` (mig. 094) brukes mønsteret
+-- `if not er_admin() then raise` — og `not NULL` er NULL, så raise-grenen
+-- hoppes over og admin-guarden omgås. `exists (...)` gir alltid true/false.
 create or replace function er_admin()
 returns boolean
 language sql
@@ -19,7 +28,11 @@ security definer
 stable
 set search_path = public
 as $$
-  select rolle in ('admin', 'generalsekretaer') from profiles where id = auth.uid()
+  select exists (
+    select 1 from profiles
+    where id = auth.uid()
+      and rolle in ('admin', 'generalsekretaer')
+  )
 $$;
 
 -- 2) handle_ny_bruker() — opprinnelig fra mig. 001, sist redigert i mig. 071 (btrim-forsvar mot whitespace i e-post)

--- a/supabase/migrations/097_security_definer_search_path.sql
+++ b/supabase/migrations/097_security_definer_search_path.sql
@@ -1,0 +1,42 @@
+-- Sikkerhetsfiks: lås search_path på er_admin() og handle_ny_bruker().
+--
+-- SECURITY DEFINER-funksjoner uten eksplisitt search_path er sårbare for
+-- search_path-hijacking via pg_temp: en angriper kan plassere egne objekter
+-- (tabeller, funksjoner) i et schema som dukker opp foran 'public' i søkestien,
+-- og dermed omgå logikken inni funksjonen.
+--
+-- Mønsteret er det samme som ble brukt i mig. 091 (get_statistikk) og
+-- mig. 094 (sett_generalsekretaer, fjern_generalsekretaer).
+-- Tracker: issue #301.
+--
+-- VIKTIG: ingen semantiske endringer — kun search_path = public tillegget.
+
+-- 1) er_admin() — opprinnelig fra mig. 041, sist sett uten search_path
+create or replace function er_admin()
+returns boolean
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select rolle in ('admin', 'generalsekretaer') from profiles where id = auth.uid()
+$$;
+
+-- 2) handle_ny_bruker() — opprinnelig fra mig. 071 (btrim-forsvar mot whitespace i e-post)
+create or replace function handle_ny_bruker()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.profiles (id, epost, navn, visningsnavn)
+  values (
+    new.id,
+    new.email,
+    btrim(split_part(new.email, '@', 1)),
+    btrim(split_part(new.email, '@', 1))
+  );
+  return new;
+end;
+$$;

--- a/supabase/migrations/097_security_definer_search_path.sql
+++ b/supabase/migrations/097_security_definer_search_path.sql
@@ -22,7 +22,7 @@ as $$
   select rolle in ('admin', 'generalsekretaer') from profiles where id = auth.uid()
 $$;
 
--- 2) handle_ny_bruker() — opprinnelig fra mig. 071 (btrim-forsvar mot whitespace i e-post)
+-- 2) handle_ny_bruker() — opprinnelig fra mig. 001, sist redigert i mig. 071 (btrim-forsvar mot whitespace i e-post)
 create or replace function handle_ny_bruker()
 returns trigger
 language plpgsql

--- a/supabase/migrations/098_regler_historikk_seed_fix.sql
+++ b/supabase/migrations/098_regler_historikk_seed_fix.sql
@@ -1,0 +1,28 @@
+-- Fixup: erstatt literal \n-sekvenser i regler- og historikk-seedradene.
+--
+-- Bakgrunn (issue #302): migrasjon 005 sådde alle tre vedtekter-radene med
+-- vanlige singlequote-strenger, der \n ikke tolkes som linjeskift men lagres
+-- som to bokstavelige tegn ('\' + 'n'). Vedtekter-raden er allerede rettet
+-- til ekte innhold i prod, men regler og historikk har aldri blitt redigert
+-- og inneholder fortsatt den originale seed-teksten med literal \n.
+--
+-- Løsning: exact-match-guard — vi oppdaterer BARE raden hvis innholdet er
+-- identisk med det som ble sådd i mig. 005. Dvs. migrasjonen er idempotent
+-- og no-op hvis innholdet allerede er redigert.
+--
+-- Mønster fra mig. 096 (vedtekter-fixup).
+-- Tracker: issue #302.
+
+-- regler: seed fra 005 var '# Regler\n\n_Ingen regler lagt inn ennå._'
+-- med literal backslash-n (to tegn, ikke linjeskift).
+-- Vi bytter til E-streng (Postgres escape-streng) som tolker \n riktig.
+update public.vedtekter
+   set innhold = E'# Regler\n\n_Ingen regler lagt inn ennå._'
+ where slug = 'regler'
+   and innhold = '# Regler\n\n_Ingen regler lagt inn ennå._';
+
+-- historikk: seed fra 005 var '# Historikk\n\n_Ingen historikk lagt inn ennå._'
+update public.vedtekter
+   set innhold = E'# Historikk\n\n_Ingen historikk lagt inn ennå._'
+ where slug = 'historikk'
+   and innhold = '# Historikk\n\n_Ingen historikk lagt inn ennå._';


### PR DESCRIPTION
Del av #291 (open source-klargjøring). Løser #296, inkludert småfunnene #301 og #302.

## Innhold

- **Migrasjon 097:** `set search_path = public` på SECURITY DEFINER-funksjonene `er_admin()` og `handle_ny_bruker()` (#301). Gjeninnfører også `stable` på `er_admin()` som 041 mistet.
- **Migrasjon 098:** retter literal `\n` i `regler`/`historikk`-seedradene fra 005 med exact-match-guard (#302). Verifisert read-only mot prod: begge rader har fortsatt original seed-tekst, så migrasjonen vil faktisk rette dem.
- **Webhook fail-closed:** `/api/github/webhook` avviste tidligere INGEN kall hvis `GITHUB_WEBHOOK_SECRET` manglet (fail-open) — funnet under gjennomgangen, nå 503 fail-closed.
- **`docs/sikkerhetsgjennomgang-2026-06.md`:** audit-notat — RLS-modell (31/31 tabeller, verifisert mot prod), authz-modell, bevisst eksponering, rate-limiting-vurdering, dependency-lisensaudit (158 prod-deps, alle MIT-kompatible, ingen GPL/AGPL).

## Beslutninger underveis

- Intern reviewer fant 2 MAJOR (docs feilfremstilte `/api/vitals` som beskyttet; webhook fail-open) — begge rettet. Webhook-bugen ble fikset i denne PR-en i stedet for eget issue siden den ble avdekket av selve sikkerhetsgjennomgangen.
- Tabellantall 31 forsvart etter verifisering mot prod (31 tabeller, alle med RLS).
- Inline `getUser()`-konsolidering i 7 action-filer (hygiene, ikke hull) holdes utenfor — vurderes som eget issue.

🤖 Generert med [Claude Code](https://claude.com/claude-code)