### PR TITLE
OS-fase 4: dokumentasjon for open source-publisering (#295)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Detaljert brukerbehovsspesifikasjon (use cases, roller, scope, avklarte beslutni
 ## Roller
 
 - **Admin** (2): oppretter medlemmer, styrer kåringer, redigerer klubbinfo, kan redigere/slette alle arrangementer.
-- **Generalsekretær** (1, André Heede): har admin-rettigheter, men mottar ikke issue-varsler og markeres med gul glød på profilbildet.
+- **Generalsekretær** (1): har admin-rettigheter, men mottar ikke issue-varsler og markeres med gul glød på profilbildet.
 - **Medlem** (~15): oppretter egne arrangementer, melder seg på (Ja/Nei/Kanskje), leser alt innhold.
 
 Admins og generalsekretær er også medlemmer. Tilgang håndheves i RLS — ikke bare i UI. Se **Policy: Roller** nedenfor for hvordan sjekker skal gjøres i kode.

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ Disse er bevisste pragmatiske valg for et hobbyprosjekt med én utvikler — men
 - **Mest styling som inline-style** (objekt-literaler), ikke CSS-moduler eller klasser. Tailwind er installert men brukes lite. Det er pragmatisk for AI-assistert utvikling fordi diff-bredden blir mindre, men det er ikke skalerbart for større team.
 - **Test-dekning er overflate-tynn.** Kun helpers (`dato`, `roller`, `mention-regex`, `varsler`) har enhetstester. Komponenter, server actions og integrasjoner er ikke dekket. End-to-end er ikke automatisert.
 - **Migrasjoner kjøres manuelt** uten CI-validering. En glemt `db push` mellom merge og deploy = sjanse for runtime-feil.
-- **`scripts/`-mappen inneholder engangsimport-scripts** fra Facebook-dataeksport. Noen av disse har hatt klartekst-passord og datafiler med personopplysninger. Mappen er ikke kopieres til et nytt repo uten individuell audit av hvert script.
+- **`scripts/`-mappen inneholder engangsimport-scripts** fra Facebook-dataeksport. Noen av disse har hatt klartekst-passord og datafiler med personopplysninger. Mappen skal ikke kopieres til et nytt repo uten individuell audit av hvert script.
 - **`lib/actions/`-filer har lett gjenværende dupliserte mønstre** (varsel-sending etter insert, error-håndtering). Konsolidering er gjort der det betalte seg, ikke pedantisk overalt.
 - **Ingen automatisert kodegjennomgang** i CI utover Vercels build-sjekk. Code review skjer ad-hoc via Copilot/ultrareview ved PR.
 - **Et lite antall `as unknown as`-casts** der Supabase-genererte typer ikke matcher faktiske join-resultater. Type-løgner, men avgrenset.
@@ -330,4 +330,4 @@ For en privat klubb på 15–20 medlemmer er dette overkill. For en kommersiell 
 
 ## Lisens
 
-[MIT](LICENSE) — se LICENSE-filen.
+MIT. LICENSE-filen legges inn ved publisering i det nye repoet (OS-fase 6).

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Skjermbilder kommer — anonymiserte versjoner under arbeid.
 | Hosting | Vercel (Hobby), region Dublin (referanse-instans) |
 | Domene | Valgfritt — referanse-instans bruker Domeneshop |
 
-286 kildefiler (`.ts`, `.tsx`, `.sql`, `.css`, `.mjs`), 64 SQL-migrasjoner.
+286 kildefiler (`.ts`, `.tsx`, `.sql`, `.css`, `.mjs`), ~100 nummererte SQL-migrasjoner.
 
 ---
 
@@ -161,7 +161,7 @@ Alle tabeller har RLS slått på. Policy-mønsteret er typisk:
 - `insert`: `auth.uid() = profil_id` + aktiv
 - `update`/`delete`: eier eller `er_admin()`
 
-Migrasjonene ligger i `supabase/migrations/` nummerert sekvensielt (000–064). Kjøres med `npx supabase db push`.
+Migrasjonene ligger i `supabase/migrations/` nummerert sekvensielt. Kjøres med `npx supabase db push`.
 
 ---
 
@@ -236,7 +236,7 @@ lib/
   r2.ts            # Cloudflare R2 upload/slett
   bilde-utils.ts   # Klient-side komprimering, kategorisering
 
-supabase/migrations/  # 64 nummererte SQL-filer
+supabase/migrations/  # ~100 nummererte SQL-filer
 
 scripts/         # Engangs-importer (FB-arrangementer, album), versjon-stamping
                  # NB: scripts/-mappen må auditeres individuelt før open source-kopiering

--- a/README.md
+++ b/README.md
@@ -1,23 +1,26 @@
-# Mortensrud Herreklubb
+# Herreklubben-appen
 
-Privat web-app som erstatter Facebook for arrangementspåmelding, klubbchat og kåringer i en gruppe på ca. 17 venner. Lever på [mortensrudherreklubb.no](https://mortensrudherreklubb.no).
+> **This project is intentionally in Norwegian** — UI text, code identifiers, table/column names, commit messages, and documentation are all in Norwegian. It was built for a Norwegian-speaking private club and is published as-is. English speakers are welcome to use it, but localisation is out of scope for this repository.
 
-> Dette er et privat hobby-prosjekt, ikke en publikt distribuert produkt. Det er bygget med kraftig AI-assistanse (Claude Code, Anthropic). README-en dekker både hva som er gjennomtenkt og hva som er pragmatiske snarveier — se [Kritisk vurdering](#kritisk-vurdering) nederst.
+Privat web-app for vennegjenger som vil ha et felles sted for arrangementspåmelding, klubbchat og kåringer — uten å være avhengig av Facebook. Referanse-instans: [mortensrudherreklubb.no](https://mortensrudherreklubb.no).
+
+Appen er bygget med kraftig AI-assistanse (Claude Code, Anthropic). README-en dekker både hva som er gjennomtenkt og hva som er pragmatiske snarveier — se [Kritisk vurdering](#kritisk-vurdering) nederst.
 
 ---
 
 ## Innhold
 
 - [Funksjonalitet](#funksjonalitet)
+- [Skjermbilder](#skjermbilder)
 - [Stack](#stack)
+- [Kom i gang](#kom-i-gang)
 - [Arkitektur](#arkitektur)
 - [Datamodell](#datamodell)
 - [Sentrale designvalg](#sentrale-designvalg)
 - [Mappe-struktur](#mappe-struktur)
 - [Drift og deploy](#drift-og-deploy)
-- [Lokalt utviklingsmiljø](#lokalt-utviklingsmiljø)
-- [Oppsett fra scratch](docs/oppsett.md)
 - [Kritisk vurdering](#kritisk-vurdering)
+- [Lisens](#lisens)
 
 ---
 
@@ -31,10 +34,16 @@ Privat web-app som erstatter Facebook for arrangementspåmelding, klubbchat og k
 - **Privatmeldinger** — én-til-én-samtaler.
 - **Album** — bildedelinger knyttet til arrangementer eller stå-alone. Cover-velger, lightbox med swipe og pil-navigering.
 - **Roller og ansvar** — arrangøransvar per år, kåringer (årets vinnere innen ulike kategorier).
-- **Klubbinfo** — vedtekter, medlemsliste, statistikk, historikk siden 2007.
+- **Klubbinfo** — vedtekter, medlemsliste, statistikk, historikk.
 - **Bursdager og klubbjubileum** dukker opp automatisk på agendaen.
 - **Push-varsler** og **e-post-påminnelser** for nye arrangementer, kommentarer, mentions og påminnelser om RSVP.
 - **PWA** — installerbar på mobil (Safari/Chrome), service worker for offline-fallback.
+
+---
+
+## Skjermbilder
+
+Skjermbilder kommer — anonymiserte versjoner under arbeid.
 
 ---
 
@@ -51,10 +60,30 @@ Privat web-app som erstatter Facebook for arrangementspåmelding, klubbchat og k
 | E-post | Resend |
 | Push | Web Push (VAPID) via `web-push` |
 | Cron | GitHub Actions (`paaminne.yml`, daglig 06:00 UTC) |
-| Hosting | Vercel (Hobby), region Dublin |
-| Domene | mortensrudherreklubb.no via Domeneshop |
+| Hosting | Vercel (Hobby), region Dublin (referanse-instans) |
+| Domene | Valgfritt — referanse-instans bruker Domeneshop |
 
 286 kildefiler (`.ts`, `.tsx`, `.sql`, `.css`, `.mjs`), 64 SQL-migrasjoner.
+
+---
+
+## Kom i gang
+
+For å sette opp din egen instans:
+
+1. **[docs/oppsett.md](docs/oppsett.md)** — steg-for-steg fra klon til kjørende instans (Supabase, R2, VAPID, Resend, Vercel, GitHub Actions).
+2. **[docs/klubb-tilpasning.md](docs/klubb-tilpasning.md)** — bytt navn, ikoner, farger og konfigurer rollene for din klubb.
+3. **[docs/drift.md](docs/drift.md)** — legge til medlemmer, feilsøke varsler, kjøre migrasjoner og backup.
+
+```bash
+git clone <ditt-repo-url>
+cd <ditt-repo>
+npm install
+cp .env.example .env.local
+# fyll inn verdiene
+npm run sjekk-miljo
+npm run dev
+```
 
 ---
 
@@ -87,6 +116,8 @@ Privat web-app som erstatter Facebook for arrangementspåmelding, klubbchat og k
 ```
 
 **Sikkerhetsmodellen** sentrerer rundt Postgres RLS. Server Actions kjører som innlogget bruker (Supabase auth-cookie sendes med). Det betyr at selv om en server action skulle ha en logikkfeil, kan ikke en bruker lese eller skrive data RLS-policyene ikke tillater. `er_admin()`-SQL-funksjonen brukes konsekvent i policies; klient-siden har egen `kanAdministrere(rolle)`-helper for UI-rendering.
+
+En fullstendig gjennomgang av sikkerhetsmodellen er dokumentert i [docs/sikkerhetsgjennomgang-2026-06.md](docs/sikkerhetsgjennomgang-2026-06.md).
 
 **Privat-bilder via R2.** Cloudflare R2 valgt foran Supabase Storage av to grunner: kostnad ($0 egress) og at bucket lever i EU-jurisdiksjon. URL-er er public (krever ingen signering), men sti inneholder UUID-prefix som gjør dem upraktiske å gjette.
 
@@ -136,7 +167,7 @@ Migrasjonene ligger i `supabase/migrations/` nummerert sekvensielt (000–064). 
 
 ## Sentrale designvalg
 
-Alle disse er kodifisert som «policies» i [`CLAUDE.md`](./CLAUDE.md) — refereransen for AI-assistert utvikling fremover.
+Alle disse er kodifisert som «policies» i [`CLAUDE.md`](./CLAUDE.md) — referansen for AI-assistert utvikling fremover.
 
 ### Sentralisering der det betaler seg
 
@@ -146,6 +177,7 @@ Alle disse er kodifisert som «policies» i [`CLAUDE.md`](./CLAUDE.md) — refer
 - **Roller:** `lib/roller.ts` har sentral matrise. Aldri `rolle === 'admin'`-sammenligning i kode — bruk `kanAdministrere()`. Speilet i SQL via `er_admin()`-funksjonen.
 - **Konstanter:** tegnegrenser og dag-vinduer i `lib/konstanter.ts`. Ingen hardkodede magiske tall.
 - **Konfig:** miljø-avhengige verdier (BASE_URL, R2_PUBLIC_URL, GitHub-repo, VAPID-kontakt) i `lib/config.ts`.
+- **Klubbidentitet:** navn, stiftelsesdato, rolletitler i `lib/klubb-config.ts` med env-override — se [docs/klubb-tilpasning.md](docs/klubb-tilpasning.md).
 - **Bildelagring:** server actions i `lib/actions/bilde-opplasting.ts` + `lib/r2.ts`. Klient komprimerer (1600px / q0.85) før upload.
 - **Avatar:** `<Avatar>`-komponenten er bevisst enkel (kun `name`, `size`, `src`, `rolle`). Spesialtilfeller løses med lokale wrappere, ikke ved å utvide kjerne-komponenten.
 
@@ -200,12 +232,14 @@ lib/
   dato.ts          # Tidssone-trygge helpere
   konstanter.ts    # Domene-konstanter
   config.ts        # Miljø-avhengige verdier
+  klubb-config.ts  # Klubbidentitet (navn, stiftelsesdato, rollekonfig)
   r2.ts            # Cloudflare R2 upload/slett
   bilde-utils.ts   # Klient-side komprimering, kategorisering
 
 supabase/migrations/  # 64 nummererte SQL-filer
 
 scripts/         # Engangs-importer (FB-arrangementer, album), versjon-stamping
+                 # NB: scripts/-mappen må auditeres individuelt før open source-kopiering
 
 __tests__/       # Vitest — fokuserte enhets-tester på utvalgte helpers
                  # (dato, roller, mention-regex, varsler)
@@ -247,35 +281,11 @@ Skriptet sjekker tre nivåer:
 
 **APP_URL** settes kun som GitHub Actions-secret (peker workflow-en til prod-URL) — den brukes ikke av appen i runtime og hører ikke hjemme i `.env.local`.
 
-## Lokalt utviklingsmiljø
-
-```bash
-# Forutsetter Node 20+ og Supabase CLI
-
-git clone https://github.com/reidarei/Herreklubben.git
-cd Herreklubben
-npm install
-
-# Hent miljøvariabler fra Vercel (krever vercel-login)
-npx vercel link
-npx vercel env pull .env.local --environment=production
-
-npm run sjekk-miljo  # verifiser miljøet
-npm run dev          # http://localhost:3000
-npm run build        # Produksjonsbygg
-npm run lint         # ESLint
-npm test             # Vitest
-
-# Når du har lagt til en migrasjon:
-npx supabase db push
-npx supabase gen types typescript --project-id <id> > lib/supabase/database.types.ts
-```
-
 ---
 
 ## Kritisk vurdering
 
-Denne seksjonen er for IT-folk som vurderer kodebasen profesjonelt. Den er bevisst usminket.
+Denne seksjonen er for teknisk kyndige som vurderer kodebasen. Den er bevisst usminket.
 
 ### Hva er gjennomtenkt og solid
 
@@ -290,17 +300,17 @@ Denne seksjonen er for IT-folk som vurderer kodebasen profesjonelt. Den er bevis
 
 Disse er bevisste pragmatiske valg for et hobbyprosjekt med én utvikler — men en gjennomgang fra tradisjonell vinkel ville flagget dem.
 
-- **`Chat.tsx` er 1300+ linjer.** Konsolidert mye via CHAT_KONFIG-refactoren, men selve komponenten er fortsatt en katedral. Sub-komponenter og custom hooks står uendret som "fase B" i issue #100.
+- **`Chat.tsx` er 1300+ linjer.** Konsolidert mye via CHAT_KONFIG-refactoren, men selve komponenten er fortsatt en katedral. Sub-komponenter og custom hooks står uendret som «fase B» i issue #100.
 - **Mest styling som inline-style** (objekt-literaler), ikke CSS-moduler eller klasser. Tailwind er installert men brukes lite. Det er pragmatisk for AI-assistert utvikling fordi diff-bredden blir mindre, men det er ikke skalerbart for større team.
 - **Test-dekning er overflate-tynn.** Kun helpers (`dato`, `roller`, `mention-regex`, `varsler`) har enhetstester. Komponenter, server actions og integrasjoner er ikke dekket. End-to-end er ikke automatisert.
 - **Migrasjoner kjøres manuelt** uten CI-validering. En glemt `db push` mellom merge og deploy = sjanse for runtime-feil.
-- **DB-passord står i klartekst** i scripts/-filer (engangsimporter). For et privat hobbyprosjekt er det greit; i et selskap ville det vært en flagget brudd.
+- **`scripts/`-mappen inneholder engangsimport-scripts** fra Facebook-dataeksport. Noen av disse har hatt klartekst-passord og datafiler med personopplysninger. Mappen er ikke kopieres til et nytt repo uten individuell audit av hvert script.
 - **`lib/actions/`-filer har lett gjenværende dupliserte mønstre** (varsel-sending etter insert, error-håndtering). Konsolidering er gjort der det betalte seg, ikke pedantisk overalt.
 - **Ingen automatisert kodegjennomgang** i CI utover Vercels build-sjekk. Code review skjer ad-hoc via Copilot/ultrareview ved PR.
 - **Et lite antall `as unknown as`-casts** der Supabase-genererte typer ikke matcher faktiske join-resultater. Type-løgner, men avgrenset.
 - **iOS Safari-quirks håndteres med flere lag samtidig** (visualViewport-poll + focus-tracking + pathname-reset). Hver er logget med begrunnelse, men aggregert kompleksitet er reell.
 - **Versjons-stamping er manuell.** Lett å glemme.
-- **«Vibe-stamping» av enkelte beslutninger.** Noen designvalg er tatt fordi de føltes rett i øyeblikket og holdt seg fordi de ikke skapte problemer — ikke fordi de er resultat av eksplisitt avveiing. Dette er en iboende risiko ved AI-flow: koden blir produsert raskere enn man rekker å tvile på den. Refaktorerings-runden over (PR #112 / issue #100) var én slik korreksjon i etterkant.
+- **«Vibe-stamping» av enkelte beslutninger.** Noen designvalg er tatt fordi de føltes rett i øyeblikket og holdt seg fordi de ikke skapte problemer — ikke fordi de er resultat av eksplisitt avveiing. Dette er en iboende risiko ved AI-flow: koden blir produsert raskere enn man rekker å tvile på den.
 
 ### Hva en profesjonell modning ville krevd
 
@@ -314,10 +324,10 @@ For et selskap eller team:
 6. **Backup/restore-rutiner.** Supabase tar daglig backup, men det er ikke testet å restore.
 7. **Skikkelig rollebasert tilgang i CI** + secrets via OIDC, ikke long-lived tokens.
 
-For klubben på 17 medlemmer er dette overkill. For en kommersiell SaaS er det baseline.
+For en privat klubb på 15–20 medlemmer er dette overkill. For en kommersiell SaaS er det baseline.
 
 ---
 
 ## Lisens
 
-Privat kode. Ikke distribuert under åpen lisens.
+[MIT](LICENSE) — se LICENSE-filen.

--- a/docs/drift.md
+++ b/docs/drift.md
@@ -1,0 +1,144 @@
+# Driftsguide
+
+Denne guiden er for den som administrerer klubb-instansen løpende. Den forutsetter at appen allerede er satt opp — se [docs/oppsett.md](oppsett.md) for førstegangs-oppsett.
+
+---
+
+## 1. Legge til og administrere medlemmer
+
+### Legge til nytt medlem
+
+1. Logg inn som admin.
+2. Gå til **Innstillinger** → **Medlemmer** → «Legg til medlem».
+3. Fyll inn navn og e-postadresse. Appen oppretter brukeren og sender en velkomst-e-post via Resend med en midlertidig lenke der den nye brukeren setter passord.
+4. Etter første innlogging kan brukeren selv redigere profilen (profilbilde, fødselsdato, varsel-innstillinger).
+
+### Deaktivere et medlem
+
+Appen har ikke en «slett»-funksjon — det er bevisst for å bevare historikk i kåringer, påmeldinger og chat. I stedet deaktiveres brukeren:
+
+1. Innstillinger → Medlemmer → velg personen → Rediger.
+2. Kryss av «Inaktiv».
+
+En inaktiv bruker vises ikke i listen over påmeldte og kan ikke logge inn, men historiske data beholdes.
+
+### Sette generalsekretær
+
+Bare én person kan ha generalsekretær-rollen. Den settes via Innstillinger → Medlemmer → velg person → Rediger → «Generalsekretær»-toggle. Databasen avviser forsøk på å sette rollen på to personer samtidig.
+
+---
+
+## 2. Testmodus for varsler
+
+Testmodus begrenser varsel-utsendelse til én bestemt e-postadresse i stedet for alle aktive brukere. Nyttig når du vil teste et oppsett uten å sende til hele klubben.
+
+### Slå på testmodus
+
+I Supabase Dashboard → SQL-editor:
+
+```sql
+UPDATE varsel_innstillinger
+SET aktiv = true,
+    beskrivelse = 'din@epost.no'
+WHERE noekkel = 'test_modus';
+```
+
+Erstatt `din@epost.no` med e-postadressen varsler skal sendes til. Nå vil `sendVarsel()` kun sende til den adressen, uansett hvem som faktisk skal varsles.
+
+### Slå av testmodus
+
+```sql
+UPDATE varsel_innstillinger
+SET aktiv = false
+WHERE noekkel = 'test_modus';
+```
+
+### Lokalt utviklingsmiljø
+
+Apper som kjører mot `localhost` blokkerer varsler automatisk (for å unngå at testdataene dukker opp på ekte mobiler). Denne sperren overstyres ved å sette `ALLOW_LOCAL_NOTIFICATIONS=true` i `.env.local` — men bruk det med omhu.
+
+---
+
+## 3. Varsel-feilsøking
+
+### varsel_logg-tabellen
+
+Alle utsendte push-varsler og e-poster logges i `varsel_logg`-tabellen. Kolonner av interesse:
+
+| Kolonne | Innhold |
+|---|---|
+| `profil_id` | Hvem varselet ble sendt til |
+| `type` | Varseltype (f.eks. `paaminne_7`, `ny_kommentar`, `purring`) |
+| `kanal` | `push`, `epost`, eller `begge` |
+| `tittel` / `melding` | Innholdet som ble sendt |
+| `arrangement_id` | Koblet arrangement, om relevant |
+| `opprettet` | Tidspunkt for utsendelse |
+
+Spørring i SQL-editor for å se de siste varslene:
+
+```sql
+SELECT * FROM varsel_logg
+ORDER BY opprettet DESC
+LIMIT 50;
+```
+
+### Vanlige feil
+
+**Push-varsler ankommer ikke:**
+- Sjekk at `NEXT_PUBLIC_VAPID_PUBLIC_KEY` og `VAPID_PRIVATE_KEY` er satt og stemmer overens (de genereres som par).
+- Sjekk at brukeren har godkjent push-tillatelse i nettleseren og slått på varsler under Profil → Innstillinger → Varsler.
+- Push-abonnementer har begrenset levetid — brukeren må åpne appen for å fornye abonnementet.
+
+**E-poster ankommer ikke:**
+- Sjekk at `RESEND_API_KEY` er satt.
+- Sjekk at domenet ditt er verifisert i Resend Dashboard.
+- Resend har sending-kvote på gratis-plan — sjekk om kvoten er nådd.
+
+**Cron-påminnelser kjører ikke:**
+- Gå til GitHub → Actions → fanen for `paaminne.yml` og se loggene for siste kjøring.
+- `401`-feil betyr at `CRON_SECRET` i GitHub Actions-secrets ikke stemmer med Vercel env-var `CRON_SECRET`.
+- Sjekk at `APP_URL` i GitHub Actions-secrets peker til riktig prod-URL uten trailing slash.
+
+---
+
+## 4. Migrasjoner ved oppgradering
+
+Når du oppdaterer kodebasen fra repoet, sjekk alltid om det er nye migrasjoner:
+
+```bash
+# Se om det er nye filer i supabase/migrations/ siden forrige kjøring
+git log --oneline supabase/migrations/
+
+# Kjør migrasjoner mot prod-databasen
+npx supabase db push
+
+# Regenerer TypeScript-typer (nødvendig hvis nye tabeller/kolonner er lagt til)
+npx supabase gen types typescript --project-id <prosjekt-id> > lib/supabase/database.types.ts
+```
+
+Migrasjoner kjøres sekvensielt og er idempotente — det er trygt å kjøre `db push` selv om ingen nye filer er lagt til.
+
+Se [docs/oppsett.md](oppsett.md) for full referanse til oppsett-kommandoene.
+
+---
+
+## 5. Backup
+
+Supabase tar automatisk daglig backup av databasen. Slik finner du dem:
+
+1. Supabase Dashboard → ditt prosjekt → **Database** → **Backups**.
+2. Her vises daglige backups med mulighet for restore-on-demand (krever Pro-plan eller høyere) og point-in-time recovery.
+
+Backup av bilder (Cloudflare R2) er ikke automatisk — R2 har ingen innebygd snapshot-funksjon på fri-tier. Kritiske bilder bør kopieres manuelt ved behov.
+
+> Merk: automatisk backup finnes, men restore er ikke testet for denne appen. Test restore-prosessen på en dev-instans før du trenger den i krise.
+
+---
+
+## 6. Sikkerhet
+
+En fullstendig gjennomgang av sikkerhetsmodellen er dokumentert i [docs/sikkerhetsgjennomgang-2026-06.md](sikkerhetsgjennomgang-2026-06.md). Viktigste punkter for løpende drift:
+
+- Roter `VAPID_PRIVATE_KEY`, `RESEND_API_KEY`, `CRON_SECRET` og R2-nøklene ved mistanke om lekkasje — alle er enkle å regenerere.
+- `SUPABASE_SERVICE_ROLE_KEY` omgår RLS. Oppbevar den som «Sensitive» i Vercel og aldri i kildekode.
+- Admin-rettigheter i appen er ikke det samme som tilgang til Supabase Dashboard eller Vercel. Kontroller hvem som er invitert til disse tjenestene separat.

--- a/docs/drift.md
+++ b/docs/drift.md
@@ -9,22 +9,22 @@ Denne guiden er for den som administrerer klubb-instansen løpende. Den forutset
 ### Legge til nytt medlem
 
 1. Logg inn som admin.
-2. Gå til **Innstillinger** → **Medlemmer** → «Legg til medlem».
-3. Fyll inn navn og e-postadresse. Appen oppretter brukeren og sender en velkomst-e-post via Resend med en midlertidig lenke der den nye brukeren setter passord.
-4. Etter første innlogging kan brukeren selv redigere profilen (profilbilde, fødselsdato, varsel-innstillinger).
+2. Gå til **Klubbinfo** → **Medlemmer** → «Legg til medlem».
+3. Fyll inn navn og e-postadresse. Appen oppretter brukeren og genererer et **midlertidig passord**, som både vises i admin-UI-et og sendes til medlemmet i velkomst-e-post via Resend.
+4. Etter første innlogging kan brukeren selv endre passord og redigere profilen (profilbilde, fødselsdato, varsel-innstillinger) under «Rediger profil».
 
 ### Deaktivere et medlem
 
-Appen har ikke en «slett»-funksjon — det er bevisst for å bevare historikk i kåringer, påmeldinger og chat. I stedet deaktiveres brukeren:
+Appen har bevisst en svært tilbakeholden slettings-modell for å bevare historikk i kåringer, påmeldinger og chat. Hard delete er ikke eksponert som vanlig drifts-handling — det finnes en «Slett medlem»-knapp i admin-redigering, men i praksis brukes deaktivering:
 
-1. Innstillinger → Medlemmer → velg personen → Rediger.
-2. Kryss av «Inaktiv».
+1. Klubbinfo → Medlemmer → velg personen → Rediger.
+2. Under «Tilgang» → **Status**, velg segmentet **Deaktivert**.
 
-En inaktiv bruker vises ikke i listen over påmeldte og kan ikke logge inn, men historiske data beholdes.
+En deaktivert bruker vises ikke i listen over påmeldte og kan ikke logge inn, men historiske data beholdes. Faktisk sletting (hard delete) av en profil bør gjøres via SQL hvis det noen gang trengs — kontakt utvikler.
 
 ### Sette generalsekretær
 
-Bare én person kan ha generalsekretær-rollen. Den settes via Innstillinger → Medlemmer → velg person → Rediger → «Generalsekretær»-toggle. Databasen avviser forsøk på å sette rollen på to personer samtidig.
+Bare én person kan ha generalsekretær-rollen. Den settes via Klubbinfo → Medlemmer → velg person → Rediger → «Generalsekretær»-toggle. Databasen avviser forsøk på å sette rollen på to personer samtidig.
 
 ---
 
@@ -44,6 +44,8 @@ WHERE noekkel = 'test_modus';
 ```
 
 Erstatt `din@epost.no` med e-postadressen varsler skal sendes til. Nå vil `sendVarsel()` kun sende til den adressen, uansett hvem som faktisk skal varsles.
+
+> **Viktig:** e-postadressen må tilhøre en eksisterende profil i `profiles`-tabellen — ellers finner ikke `sendVarsel()` en mottaker og varselet droppes stille uten feilmelding. Bruk gjerne din egen admin-profils e-post under test.
 
 ### Slå av testmodus
 

--- a/docs/klubb-tilpasning.md
+++ b/docs/klubb-tilpasning.md
@@ -1,0 +1,109 @@
+# Klubb-tilpasning
+
+Denne guiden beskriver hva som må (eller bør) endres for å tilpasse appen til din egen klubb. Alt som er spesifikt for Mortensrud Herreklubb er gjort konfigurerbart via env-vars eller enkel fil-erstatning.
+
+---
+
+## 1. Klubbidentitet
+
+Alle klubb-spesifikke tekstverdier samles i `lib/klubb-config.ts`. Verdiene leses fra `NEXT_PUBLIC_`-env-vars med hardkodede defaults som fallback. Det betyr at eksisterende deploy ikke endrer seg om du ikke setter env-varsene — men du bør sette dem alle for din instans.
+
+| Env-var | Default | Beskrivelse | Eksempel |
+|---|---|---|---|
+| `NEXT_PUBLIC_KLUBB_NAVN` | `Mortensrud Herreklubb` | Fullt navn, brukes i titler og e-postutsendelser | `Bygdøy Vinterklubb` |
+| `NEXT_PUBLIC_KLUBB_KORTNAVN` | `Herreklubben` | Kort navn, brukes i navigasjon og push-varsler | `Vinterkubben` |
+| `NEXT_PUBLIC_KLUBB_NAVN_LINJE_1` | `Mortensrud` | Første linje i to-linjers hero-typografi (klubbinfo-siden, jubileumskort) | `Bygdøy` |
+| `NEXT_PUBLIC_KLUBB_NAVN_LINJE_2` | `Herreklubb` | Andre linje i to-linjers hero-typografi | `Vinterklubb` |
+| `NEXT_PUBLIC_KLUBB_BESKRIVELSE` | `Privat klubbapp for <KLUBB_NAVN>` | PWA-beskrivelse (manifest og meta-tags) | `Privat klubbapp for Bygdøy Vinterklubb` |
+| `NEXT_PUBLIC_KLUBB_DOMENE` | `mortensrudherreklubb.no` | Kun hostname — brukes som base for prod-URL og i ICS-UID/PRODID. Må være ASCII, ingen mellomrom eller skråstrek. | `bygdoyvinterklubb.no` |
+| `NEXT_PUBLIC_KLUBB_STIFTET_AAR` | `2007` | Stiftelsesår — brukes til å beregne jubileum på agendaen | `2015` |
+| `NEXT_PUBLIC_KLUBB_STIFTET_MAANED` | `11` | Stiftelsesmåned (1–12) | `3` |
+| `NEXT_PUBLIC_KLUBB_STIFTET_DAG` | `24` | Stiftelsedag (1–31) | `17` |
+| `NEXT_PUBLIC_KLUBB_STED` | `Søndre Nordstrand` | Stiftelsessted, vises på klubbinfo-siden | `Frogner` |
+| `NEXT_PUBLIC_ROLLE_TITTEL_GENERALSEKRETAER` | `Generalsekretær` | Visningsnavn for den særegne rollen med gul glød. Rolle-koden i DB (`generalsekretaer`) endres ikke. | `Æresmedlem` |
+
+Sett disse i `.env.local` lokalt og som Vercel Environment Variables i produksjon.
+
+> Merk at `NEXT_PUBLIC_KLUBB_DOMENE` kun er en identifikator — den brukes ikke til å generere live lenker. `BASE_URL` i `lib/config.ts` håndterer actual-URL.
+
+---
+
+## 2. Ikoner og favicon
+
+Disse filene i `public/` må byttes ut med dine egne bilder:
+
+| Fil | Dimensjoner | Bruk |
+|---|---|---|
+| `public/favicon-16.png` | 16 × 16 px | Browser-fane (liten) |
+| `public/favicon-32.png` | 32 × 32 px | Browser-fane (normal) |
+| `public/icon-192.png` | 192 × 192 px | PWA-ikon, hjemskjerm (standard) |
+| `public/icon-512.png` | 512 × 512 px | PWA-ikon, splash-screen |
+| `public/icon-maskable-192.png` | 192 × 192 px | PWA-ikon med «safe zone» for adaptiv maskering (Android) |
+| `public/icon-maskable-512.png` | 512 × 512 px | PWA-ikon med «safe zone» for adaptiv maskering (Android) |
+| `public/icon-1024.png` | 1024 × 1024 px | Høyoppløselig master (brukes bl.a. av iOS ved installasjon) |
+| `public/icon-180.png` | 180 × 180 px | Apple Touch Icon (iOS hjemskjerm) |
+| `public/bakgrunn.jpg` | Fri størrelse | Bakgrunnsbilde brukt på login-siden |
+
+PWA-manifestet (`app/manifest.ts`) er allerede koblet til klubbnavnet via env-vars og peker på de fire PWA-ikonene. Du trenger ikke endre kode — bare bytt bildefilene med samme filnavn.
+
+For maskable-ikonene: selve motivet bør holdes innenfor en sirkel på ca. 80 % av bildeflaten («safe zone»). Verktøy som [maskable.app](https://maskable.app) lar deg forhåndsvise resultatet.
+
+---
+
+## 3. Farger og tema
+
+Det finnes ikke ett sentralt sted som styrer alle farger. Det er verdt å si usminket: appen bruker overveiende inline-styles (objekt-literaler) fremfor CSS-variabler eller et Tailwind-tema.
+
+Grep-søk for å finne farge-verdier:
+
+```bash
+grep -r "#060608\|#18181b\|#a855f7" --include="*.tsx" --include="*.ts" .
+```
+
+Noen ankerpunkter:
+
+- **`app/globals.css`** — liten CSS-fil med noen CSS custom properties og base-stiler. Inneholder ikke hele temaet.
+- **`app/manifest.ts`** — `background_color` og `theme_color` er hardkodet til `#060608` (mørk bakgrunn). Endre disse om du vil et annet PWA-splash-tema.
+- **Tailwind-konfig (`tailwind.config.ts`)** — installert, men brukes lite. Fargepalett er ikke utvidet der.
+
+Skal du endre fargetema gjennomgående, er det en manuell jobb. Det finnes ingen enkel «bytt primærfarge»-knapp i denne kodebasen.
+
+---
+
+## 4. Roller
+
+### De tre rollene
+
+Appen har tre faste roller definert i `lib/roller.ts`:
+
+| Rollekode (i DB) | Standardtittel | Har admin-rettigheter | Gul glød | Løser tiebreak |
+|---|---|---|---|---|
+| `medlem` | Medlem | Nei | Nei | Nei |
+| `admin` | Admin | Ja | Nei | Nei |
+| `generalsekretaer` | Generalsekretær | Ja | Ja | Ja |
+
+Tittelen for `generalsekretaer`-rollen kan overstyres via env-var `NEXT_PUBLIC_ROLLE_TITTEL_GENERALSEKRETAER` (se tabell i seksjon 1). Rolle-koden i databasen endres ikke.
+
+### Viktig: nye roller krever migrasjon
+
+Rettighetsmatrisen i `lib/roller.ts` er kun kode-siden. Databasen har sin egen `er_admin()`-SQL-funksjon som brukes i alle RLS-policies. Denne returnerer `true` for `admin` og `generalsekretaer` — ingen andre roller. Hvis du legger til en ny rolle med admin-rettigheter i matrisen, **må du også oppdatere `er_admin()` i en ny migrasjon**. Uten dette vil RLS blokkere den nye rollen uansett hva kode-siden sier.
+
+### Generalsekretær settes via UI
+
+Etter opprettelse av et medlem settes generalsekretær-rollen via Innstillinger → Medlemmer → Rediger → «Generalsekretær»-toggle. Databasen håndhever at maks én person har rollen (partial unique index, migrasjon 094).
+
+---
+
+## 5. Arrangement-maler og arrangøransvar
+
+Hvilke faste arrangementer som finnes (møter, turer, o.l.) og hvem som er ansvarlig for dem hvert år, er **data** i databasen — ikke hardkodet i koden.
+
+Dette styres i `arrangoransvar`-tabellen. Kolonnene `aar`, `arrangement_navn` og `type` (moete|tur) bestemmer hva som vises i nedtrekk-menyen «Type arrangement» når en bruker oppretter et nytt arrangement.
+
+For å sette opp ditt eget årshjul:
+
+1. Logg inn som admin.
+2. Gå til **Arrangoransvar** i menyen.
+3. Opprett ansvar for hvert fast arrangement per år — hvem som er ansvarlig og for hva.
+
+Arrangement-navnene du skriver der, vises som valg i nedtrekk-menyen. Det er ingen forhåndsdefinert liste i koden.

--- a/docs/klubb-tilpasning.md
+++ b/docs/klubb-tilpasning.md
@@ -18,7 +18,7 @@ Alle klubb-spesifikke tekstverdier samles i `lib/klubb-config.ts`. Verdiene lese
 | `NEXT_PUBLIC_KLUBB_DOMENE` | `mortensrudherreklubb.no` | Kun hostname — brukes som base for prod-URL og i ICS-UID/PRODID. Må være ASCII, ingen mellomrom eller skråstrek. | `bygdoyvinterklubb.no` |
 | `NEXT_PUBLIC_KLUBB_STIFTET_AAR` | `2007` | Stiftelsesår — brukes til å beregne jubileum på agendaen | `2015` |
 | `NEXT_PUBLIC_KLUBB_STIFTET_MAANED` | `11` | Stiftelsesmåned (1–12) | `3` |
-| `NEXT_PUBLIC_KLUBB_STIFTET_DAG` | `24` | Stiftelsedag (1–31) | `17` |
+| `NEXT_PUBLIC_KLUBB_STIFTET_DAG` | `24` | Stiftelsesdag (1–31) | `17` |
 | `NEXT_PUBLIC_KLUBB_STED` | `Søndre Nordstrand` | Stiftelsessted, vises på klubbinfo-siden | `Frogner` |
 | `NEXT_PUBLIC_ROLLE_TITTEL_GENERALSEKRETAER` | `Generalsekretær` | Visningsnavn for den særegne rollen med gul glød. Rolle-koden i DB (`generalsekretaer`) endres ikke. | `Æresmedlem` |
 
@@ -34,17 +34,18 @@ Disse filene i `public/` må byttes ut med dine egne bilder:
 
 | Fil | Dimensjoner | Bruk |
 |---|---|---|
-| `public/favicon-16.png` | 16 × 16 px | Browser-fane (liten) |
-| `public/favicon-32.png` | 32 × 32 px | Browser-fane (normal) |
-| `public/icon-192.png` | 192 × 192 px | PWA-ikon, hjemskjerm (standard) |
-| `public/icon-512.png` | 512 × 512 px | PWA-ikon, splash-screen |
+| `public/favicon-16.png` | 16 × 16 px | Browser-fane (liten) — referert fra `app/layout.tsx` og `public/sw.js` |
+| `public/favicon-32.png` | 32 × 32 px | Browser-fane (normal) — referert fra `app/layout.tsx` og `public/sw.js` |
+| `public/icon-192.png` | 192 × 192 px | PWA-ikon, hjemskjerm — referert fra `manifest.ts`, `layout.tsx`, `sw.js` (også som push-badge) |
+| `public/icon-512.png` | 512 × 512 px | PWA-ikon, splash-screen — referert fra `manifest.ts`, `layout.tsx`, `sw.js` og login-siden som logo |
+| `public/icon-180.png` | 180 × 180 px | Apple Touch Icon (iOS hjemskjerm) — referert fra `app/layout.tsx` og `sw.js` |
 | `public/icon-maskable-192.png` | 192 × 192 px | PWA-ikon med «safe zone» for adaptiv maskering (Android) |
 | `public/icon-maskable-512.png` | 512 × 512 px | PWA-ikon med «safe zone» for adaptiv maskering (Android) |
-| `public/icon-1024.png` | 1024 × 1024 px | Høyoppløselig master (brukes bl.a. av iOS ved installasjon) |
-| `public/icon-180.png` | 180 × 180 px | Apple Touch Icon (iOS hjemskjerm) |
 | `public/bakgrunn.jpg` | Fri størrelse | Bakgrunnsbilde brukt på login-siden |
 
-PWA-manifestet (`app/manifest.ts`) er allerede koblet til klubbnavnet via env-vars og peker på de fire PWA-ikonene. Du trenger ikke endre kode — bare bytt bildefilene med samme filnavn.
+Filene `public/icon-1024.png` og `public/icon-2000.png` ligger i repoet som høyoppløselige master-bilder for fremtidig bruk (App Store-ikon, marketing), men refereres ikke i kode i dag. Du kan ignorere dem eller fjerne dem.
+
+PWA-manifestet (`app/manifest.ts`) er allerede koblet til klubbnavnet via env-vars og peker på de to PWA-ikonene (192 og 512). Du trenger ikke endre kode — bare bytt bildefilene med samme filnavn.
 
 For maskable-ikonene: selve motivet bør holdes innenfor en sirkel på ca. 80 % av bildeflaten («safe zone»). Verktøy som [maskable.app](https://maskable.app) lar deg forhåndsvise resultatet.
 
@@ -107,3 +108,20 @@ For å sette opp ditt eget årshjul:
 3. Opprett ansvar for hvert fast arrangement per år — hvem som er ansvarlig og for hva.
 
 Arrangement-navnene du skriver der, vises som valg i nedtrekk-menyen. Det er ingen forhåndsdefinert liste i koden.
+
+---
+
+## 6. Andre miljø-avhengige verdier
+
+Utover klubbidentiteten i seksjon 1 har `lib/config.ts` flere verdier med hardkodede defaults som peker på **referanse-instansen** (Mortensrud Herreklubb). **Disse må overstyres med dine egne verdier i Vercel-env-vars og `.env.local`** før din instans tas i bruk — ellers sender appen kontakt-headere og lenker som peker tilbake til referanse-oppsettet.
+
+| Env-var | Default i koden | Hva den styrer | Når må den settes? |
+|---|---|---|---|
+| `NEXT_PUBLIC_BASE_URL` | Auto: `VERCEL_URL`, ellers `https://mortensrudherreklubb.no` i prod, ellers `http://localhost:3000` | Absolutte URL-er i push-/e-postvarsler, ICS-filer, GitHub-webhook-lenker | Sett til din prod-URL hvis du ikke vil arve referanse-defaulten i prod. På Vercel arves `VERCEL_URL` automatisk for preview-deploys. |
+| `VAPID_CONTACT_EMAIL` | `reidar.haavik@gmail.com` | Kontakt-e-post i VAPID-headere — push-tjenester (Apple/Google) bruker den ved misbruk eller tekniske problemer. Ingen e-post sendes via denne — kun metadata. | **Må settes** for din instans. Bruk en e-post du faktisk leser. |
+| `NEXT_PUBLIC_GITHUB_REPO` | `reidarei/Herreklubben` | Hvilket GitHub-repo «innspill»-funksjonen leser issues fra | Sett til ditt eget repo (`brukernavn/reponavn`) hvis du bruker innspill-funksjonen. |
+| `NEXT_PUBLIC_GITHUB_ONSKE_LABEL` | `ønske` | Hvilken issue-label som regnes som brukerønske | Bytt hvis du vil bruke en annen label-konvensjon. |
+| `NEXT_PUBLIC_R2_PUBLIC_URL` (eller `R2_PUBLIC_URL`) | `''` (tom) | Public CDN-URL hvor bilder hentes fra (`https://<din-pub-id>.r2.dev` eller custom domain) | **Må settes** — bilder vises ikke uten. |
+| `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET` | Ingen | R2-credentials og bucket-navn (server-side; ALDRI med `NEXT_PUBLIC_`-prefiks) | **Må settes** for bildelagring. Marker som «Sensitive» i Vercel. |
+
+> Defaults i `lib/config.ts` er bevart med hensikt — å fjerne dem i kodebasen ville krevd koordinert env-var-setting på referanse-instansen samme dag. Etter at din instans har env-varsene satt, kan defaults nøytraliseres i en senere PR uten å bryte produksjonen.

--- a/docs/oppsett.md
+++ b/docs/oppsett.md
@@ -1,6 +1,6 @@
 # Oppsett fra scratch
 
-Denne guiden beskriver hvordan du setter opp en ny instans av Mortensrud Herreklubb-appen fra bunnen av. Bruk den ved nytt Supabase-prosjekt, testinstans eller katastrofegjenoppretting.
+Denne guiden beskriver hvordan du setter opp en ny instans av appen fra bunnen av. Bruk den ved nytt Supabase-prosjekt, testinstans eller katastrofegjenoppretting.
 
 ---
 
@@ -29,8 +29,8 @@ Denne guiden beskriver hvordan du setter opp en ny instans av Mortensrud Herrekl
 ## 1. Klon og installer
 
 ```bash
-git clone https://github.com/reidarei/Herreklubben.git
-cd Herreklubben
+git clone <ditt-repo-url>
+cd <ditt-repo>
 npm install
 ```
 
@@ -157,7 +157,7 @@ For at daglig påminnelsesjobb (`.github/workflows/paaminne.yml`) skal virke:
 | Secret | Verdi |
 |---|---|
 | `CRON_SECRET` | Samme som Vercel env-var `CRON_SECRET` |
-| `APP_URL` | Prod-URL uten trailing slash, f.eks. `https://mortensrudherreklubb.no` |
+| `APP_URL` | Prod-URL uten trailing slash, f.eks. `https://din-klubb.example.com` |
 
 Se `.github/workflows/paaminne.yml` for secret-oppsett-referanse.
 
@@ -195,3 +195,9 @@ Betyr at Data API-rollen mangler `GRANT` på tabellen. Kjør `npx supabase db pu
 
 - Sjekk at `NEXT_PUBLIC_R2_PUBLIC_URL` peker til riktig R2-bucket-URL.
 - Sjekk at bucketen har «Public access» aktivert i Cloudflare Dashboard.
+
+---
+
+## Neste steg
+
+Etter at appen er oppe og første admin er innlogget, se **[docs/klubb-tilpasning.md](klubb-tilpasning.md)** for å bytte navn, ikoner og annen klubbidentitet. Drifts-guiden for løpende vedlikehold finnes i **[docs/drift.md](drift.md)**.

--- a/docs/publisert-til-nytt-repo.md
+++ b/docs/publisert-til-nytt-repo.md
@@ -1,0 +1,101 @@
+# Manifest for publisering til nytt repo (fase 6)
+
+Sjekkliste over hva som kopieres til det nye, rene open source-repoet og hva som ikke gjør det. Fase 6 tar selve repo-opprettelsen, LICENSE og SECURITY.md.
+
+---
+
+## Kopieres
+
+### Dokumentasjon
+- `README.md` (omskrevet for eksternt publikum — denne versjonen)
+- `docs/oppsett.md`
+- `docs/klubb-tilpasning.md`
+- `docs/drift.md`
+- `docs/sikkerhetsgjennomgang-2026-06.md`
+- `HK-app_kravspesifikasjon.md`
+- `HK-app_losningsdesign.md`
+- `CLAUDE.md` (sanitert — eget avsnitt nedenfor)
+
+### Kildekode
+- `app/` — hele Next.js-applikasjonen
+- `components/` — alle komponenter
+- `lib/` — alle helpere, actions, supabase-clients
+- `supabase/migrations/` — alle SQL-migrasjoner
+- `__tests__/` — enhets-tester
+- `e2e/` — Playwright-tester
+
+### Konfig og infra
+- `package.json`, `package-lock.json`
+- `next.config.ts`, `tailwind.config.ts`, `tsconfig.json`
+- `postcss.config.mjs`, `eslint.config.mjs`
+- `vitest.config.ts`, `playwright.config.ts`
+- `.env.example`
+- `.gitignore`, `.gitattributes`
+- `.github/workflows/paaminne.yml`
+
+### Design (deler av)
+- `Design/` — mapper og filer **unntatt** `Design/skjermbilder/` (se nedenfor)
+
+### Public-assets
+- `public/` — alle filer (ikoner, bakgrunn, sw.js)
+
+---
+
+## Kopieres IKKE
+
+### Git-historikk
+Nytt repo starter rent uten historikk. Historikken i det private repoet kan inneholde midlertidige debug-commits med sensitiv info, og ekte profilbilder/skjermbilder sjekket inn som binærfiler.
+
+### Design/skjermbilder/
+Skjermbildemappen inneholder bilder tatt av appen i produksjon med ekte medlemsnavn og ansikter. Anonymiserte versjoner skal lages separat og legges inn etter publisering.
+
+### .claude/
+Lokal Claude Code-konfimasjon, minnefiler og feedback-notater. Inneholder prosjektintern kontekst som ikke er relevant for eksterne og potensielt interne referanser som ikke bør publiseres.
+
+### scripts/ — AUDIT PÅKREVD
+**Hvert script i `scripts/`-mappen må auditeres individuelt** før det eventuelt kopieres:
+
+- Engangsimport-scripts (`fb-*`, `import-*.mjs`, `import-messenger-klubbchat.mjs`) er kjørt én gang og er ikke relevante for en ny instans. De inneholder logikk tett koblet til Facebook-dataeksport-formatet og data-filpaths som er spesifikke for det opprinnelige oppsettet.
+- Noen scripts i denne mappen har tidligere hatt klartekst database-passord eller klartekst Supabase service-role-nøkler i kommentarer eller hardkodet. En historikk-sjekk viste at disse er fjernet fra nåværende versjon, men scripts i seg selv har ikke verdi for en ny instans.
+- **Scripts som er relevante for en ny instans** og kan kopieres etter review: `init-admin.mjs`, `sjekk-miljo.mjs`, `stamp-versjon.mjs`.
+- `r2-browser.mjs` og `foreslaa-messenger-mapping.mjs` er nyttige verktøy — vurder individuelt.
+
+### scripts/data/
+Datafiler fra Facebook-import (JSON-eksporter, bildemapping). Inneholder historiske personopplysninger.
+
+### fb-arrangementer.json, fb-import.sql m.fl.
+Alle filer i `scripts/` med `fb-`-prefiks og tilhørende SQL-dumps er persondata-spesifikk for den opprinnelige instansen.
+
+---
+
+## Filer som lages i fase 6
+
+Disse eksisterer ikke ennå og opprettes i det nye repoet:
+
+- `LICENSE` — MIT med Reidars navn og 2025-startår
+- `SECURITY.md` — ansvarlig avsløring, kontaktadresse, scope
+- `CLAUDE.md` (sanitert versjon) — uten prosjektintern kontekst (se nedenfor)
+
+---
+
+## CLAUDE.md-sanitering
+
+Nåværende `CLAUDE.md` inneholder:
+
+- Referanser til det private repo-URLen og Supabase-prosjekt-IDen i kommando-eksempler — byttes til plassholdere.
+- Sparekonto-referansen i «Prosjekt»-avsnittet er intern og kuttes.
+- Ellers er CLAUDE.md verdifull for eksterne som vil bruke AI-assistert utvikling — behold policies, arkitektur-oversikt og konvensjoner.
+
+---
+
+## Sjekkliste før fase 6
+
+- [ ] Grep-sjekk for ekte navn (se navneliste i CLAUDE.md-policies)
+- [ ] Grep-sjekk for hardkodede e-postadresser
+- [ ] Grep-sjekk for `mortensrudherreklubb.no` — disse skal være via `lib/klubb-config.ts` eller `lib/config.ts`, ikke hardkodet
+- [ ] Bekreft at `Design/skjermbilder/` IKKE er med
+- [ ] Bekreft at `.claude/` IKKE er med
+- [ ] Bekreft at scripts-audit er gjort
+- [ ] LICENSE opprettet
+- [ ] SECURITY.md opprettet
+- [ ] README-en peker til `<ditt-repo-url>` og ikke til privat repo

--- a/docs/publisert-til-nytt-repo.md
+++ b/docs/publisert-til-nytt-repo.md
@@ -29,9 +29,14 @@ Sjekkliste over hva som kopieres til det nye, rene open source-repoet og hva som
 - `next.config.ts`, `tailwind.config.ts`, `tsconfig.json`
 - `postcss.config.mjs`, `eslint.config.mjs`
 - `vitest.config.ts`, `playwright.config.ts`
+- `middleware.ts` — Next.js auth-guard, krevd ved kjøring
+- `vercel.json` — Vercel-region/build-konfig
 - `.env.example`
 - `.gitignore`, `.gitattributes`
 - `.github/workflows/paaminne.yml`
+
+### Genererte/build-artifakter — kopieres med?
+- `lib/supabase/database.types.ts` — **kopieres med** som utgangspunkt. Fila er generert per Supabase-instans (`npx supabase gen types`), men `next build` krever at den finnes. Nytt repo bør levere én versjon som matcher migrasjoner i `supabase/migrations/`, og dokumentere at den må regenereres etter første `db push` mot egen instans.
 
 ### Design (deler av)
 - `Design/` — mapper og filer **unntatt** `Design/skjermbilder/` (se nedenfor)
@@ -50,21 +55,31 @@ Nytt repo starter rent uten historikk. Historikken i det private repoet kan inne
 Skjermbildemappen inneholder bilder tatt av appen i produksjon med ekte medlemsnavn og ansikter. Anonymiserte versjoner skal lages separat og legges inn etter publisering.
 
 ### .claude/
-Lokal Claude Code-konfimasjon, minnefiler og feedback-notater. Inneholder prosjektintern kontekst som ikke er relevant for eksterne og potensielt interne referanser som ikke bør publiseres.
+Lokal Claude Code-konfigurasjon, minnefiler og feedback-notater. Inneholder prosjektintern kontekst som ikke er relevant for eksterne og potensielt interne referanser som ikke bør publiseres.
 
 ### scripts/ — AUDIT PÅKREVD
 **Hvert script i `scripts/`-mappen må auditeres individuelt** før det eventuelt kopieres:
 
 - Engangsimport-scripts (`fb-*`, `import-*.mjs`, `import-messenger-klubbchat.mjs`) er kjørt én gang og er ikke relevante for en ny instans. De inneholder logikk tett koblet til Facebook-dataeksport-formatet og data-filpaths som er spesifikke for det opprinnelige oppsettet.
 - Noen scripts i denne mappen har tidligere hatt klartekst database-passord eller klartekst Supabase service-role-nøkler i kommentarer eller hardkodet. En historikk-sjekk viste at disse er fjernet fra nåværende versjon, men scripts i seg selv har ikke verdi for en ny instans.
-- **Scripts som er relevante for en ny instans** og kan kopieres etter review: `init-admin.mjs`, `sjekk-miljo.mjs`, `stamp-versjon.mjs`.
+- **Whitelistede scripts som kopieres til nytt repo** (verifisert relevante for ny instans, ingen historiske persondata):
+  - `init-admin.mjs` — interaktivt verktøy for å opprette første admin etter migrasjoner er kjørt
+  - `sjekk-miljo.mjs` — miljøvariabel-validering brukt av `npm run sjekk-miljo`
+  - `stamp-versjon.mjs` — versjons-stamping brukt av `npm run stamp-versjon`
 - `r2-browser.mjs` og `foreslaa-messenger-mapping.mjs` er nyttige verktøy — vurder individuelt.
+- Alle øvrige `fb-*.mjs`/`fb-*.json`/`fb-*.sql`, `import-album.mjs`, `import-messenger-klubbchat.mjs` og `scripts/data/` utelates.
 
 ### scripts/data/
 Datafiler fra Facebook-import (JSON-eksporter, bildemapping). Inneholder historiske personopplysninger.
 
 ### fb-arrangementer.json, fb-import.sql m.fl.
 Alle filer i `scripts/` med `fb-`-prefiks og tilhørende SQL-dumps er persondata-spesifikk for den opprinnelige instansen.
+
+### Lokale build-/dev-artifakter og hemmeligheter
+- `.env.local` — inneholder hemmeligheter, ALDRI med
+- `.next/` — Next.js build-output, regenereres
+- `node_modules/` — regenereres med `npm install`
+- `.cache/`, `.vercel/`, `test-results/`, `tsconfig.tsbuildinfo` — lokale artifakter, ikke relevante
 
 ---
 
@@ -76,6 +91,10 @@ Disse eksisterer ikke ennå og opprettes i det nye repoet:
 - `SECURITY.md` — ansvarlig avsløring, kontaktadresse, scope
 - `CLAUDE.md` (sanitert versjon) — uten prosjektintern kontekst (se nedenfor)
 
+### Andre leveranser i fase 6
+
+- **Nøytraliser personlige defaults i `lib/config.ts`** (`VAPID_CONTACT_EMAIL`, `GITHUB_REPO`) — endres til generiske placeholder-verdier eller fjernes til fordel for «kreves satt». **Koordineres** med at env-varsene settes i referanse-instansens Vercel-prosjekt først, slik at produksjons-instansen ikke mister VAPID-kontakt eller innspill-funksjonen i overgangen. Defaults beholdes derfor i denne PR-en.
+
 ---
 
 ## CLAUDE.md-sanitering
@@ -83,7 +102,7 @@ Disse eksisterer ikke ennå og opprettes i det nye repoet:
 Nåværende `CLAUDE.md` inneholder:
 
 - Referanser til det private repo-URLen og Supabase-prosjekt-IDen i kommando-eksempler — byttes til plassholdere.
-- Sparekonto-referansen i «Prosjekt»-avsnittet er intern og kuttes.
+- Sparekonto-referansen i «Prosjekt»-avsnittet kuttes for å redusere prosjekt-spesifikk støy som ikke er relevant for eksterne lesere.
 - Ellers er CLAUDE.md verdifull for eksterne som vil bruke AI-assistert utvikling — behold policies, arkitektur-oversikt og konvensjoner.
 
 ---

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 19,
-  "versjon": "V3.2.19"
+  "nummer": 20,
+  "versjon": "V3.2.20"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 21,
-  "versjon": "V3.2.21"
+  "nummer": 22,
+  "versjon": "V3.2.22"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 20,
-  "versjon": "V3.2.20"
+  "nummer": 21,
+  "versjon": "V3.2.21"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.2.20'
+const CACHE_VERSION = 'V3.2.21'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.2.21'
+const CACHE_VERSION = 'V3.2.22'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.2.19'
+const CACHE_VERSION = 'V3.2.20'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Del av #291 (open source-klargjøring). Løser #295.

## Innhold

- **README.md** omskrevet for eksternt publikum: engelsk preamble (norsk by design), generiske plassholdere, MIT-referanse, «Kom i gang»-pekere, skjermbilde-TODO (anonymiserte versjoner gjenstår)
- **docs/oppsett.md** generalisert (plassholdere i stedet for repo-/domene-spesifikt)
- **docs/klubb-tilpasning.md** (ny): alle klubb-env-vars, ikoner, farger (usminket), roller, arrangement-maler + miljøverdier fra lib/config.ts som MÅ overstyres
- **docs/drift.md** (ny): medlemshåndtering, testmodus, varsel-feilsøking, migrasjoner, backup
- **docs/publisert-til-nytt-repo.md** (ny): manifest/sjekkliste for fase 6 — hva kopieres til nytt rent repo, scripts-audit-krav, config-default-nøytralisering
- **CLAUDE.md**: medlemsnavn fjernet fra generalsekretær-linjen

## Beslutninger underveis

- Intern reviewer fant 5 MAJOR (faktafeil i drift-guide om UI-stier/medlemsflyt, stale migrasjonstall, manglende config.ts-env-dokumentasjon) — alle rettet etter verifisering mot kodebasen.
- lib/config.ts-defaults (personlig e-post/repo) endres IKKE her — kan brekke prod hvis env-vars mangler i Vercel. Nøytralisering lagt som fase 6-leveranse med koordineringskrav.
- Språkvalg (regissør): norsk hoveddokumentasjon + engelsk preamble.
- Skjermbilder holdt utenfor README — Design/skjermbilder/ viser ekte medlemsnavn; anonymiserte versjoner er manuelt Reidar-steg.

🤖 Generert med [Claude Code](https://claude.com/claude-code)