### PR TITLE
bli-utvikler: degrader pent uten GITHUB_TOKEN (#299)

### DIFF
--- a/app/api/bli-utvikler/route.ts
+++ b/app/api/bli-utvikler/route.ts
@@ -2,9 +2,18 @@ import { createServerClient } from '@/lib/supabase/server'
 import { NextResponse } from 'next/server'
 import { GITHUB_REPO, GITHUB_ONSKE_LABEL } from '@/lib/config'
 
-const GITHUB_TOKEN = process.env.GITHUB_TOKEN!
+// Ingen non-null assertion: GITHUB_TOKEN er en valgfri integrasjon, og en
+// instans uten den skal degradere pent — ikke krasje (#299).
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN
 
 export async function POST(request: Request) {
+  if (!GITHUB_TOKEN) {
+    return NextResponse.json(
+      { feil: 'Innspill-funksjonen er ikke konfigurert (GITHUB_TOKEN mangler)' },
+      { status: 503 }
+    )
+  }
+
   const supabase = await createServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ feil: 'Ikke innlogget' }, { status: 401 })

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 22,
-  "versjon": "V3.2.22"
+  "nummer": 23,
+  "versjon": "V3.2.23"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.2.22'
+const CACHE_VERSION = 'V3.2.23'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
Løser #299 (funnet under review av #293, relevant for OS-klargjøring #291).

## Innhold

- Fjernet non-null assertion på `process.env.GITHUB_TOKEN` i `/api/bli-utvikler`
- Guard øverst i POST: returnerer 503 med tydelig melding hvis token mangler — en fersk instans uten innspill-integrasjonen degraderer nå pent i stedet for å krasje

## Beslutninger underveis

- Triviell endring — kjørt via snarvei (regissør-fiks + lint/build grønt), uten full agentpipeline.

🤖 Generert med [Claude Code](https://claude.com/claude-code)