### PR TITLE
Konsolider inline getUser() til ensureInnlogget()/ensureAdmin() (#305)

### DIFF
--- a/app/api/admin/opprett-medlem/route.ts
+++ b/app/api/admin/opprett-medlem/route.ts
@@ -1,8 +1,7 @@
 import { createClient } from '@supabase/supabase-js'
-import { createServerClient } from '@/lib/supabase/server'
 import { sendEpost, velkommenEpostHtml } from '@/lib/epost'
 import { NextResponse } from 'next/server'
-import { kanAdministrere } from '@/lib/roller'
+import { ensureAdmin } from '@/lib/auth'
 import { BASE_URL } from '@/lib/config'
 import { KLUBB_NAVN } from '@/lib/klubb-config'
 
@@ -12,13 +11,15 @@ function genererPassord() {
 }
 
 export async function POST(request: Request) {
-  // Verifiser at kaller er admin
-  const supabase = await createServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) return NextResponse.json({ feil: 'Ikke innlogget' }, { status: 401 })
-
-  const { data: profil } = await supabase.from('profiles').select('rolle').eq('id', user.id).single()
-  if (!kanAdministrere(profil?.rolle)) return NextResponse.json({ feil: 'Ikke admin' }, { status: 403 })
+  // Verifiser at kaller er admin — ensureAdmin kaster ved manglende auth/rolle,
+  // vi fanger og returnerer riktig HTTP-status
+  try {
+    await ensureAdmin()
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'Feil'
+    if (msg === 'Ikke innlogget') return NextResponse.json({ feil: msg }, { status: 401 })
+    return NextResponse.json({ feil: msg }, { status: 403 })
+  }
 
   const { navn: rawNavn, epost: rawEpost } = await request.json()
   const navn = (rawNavn ?? '').trim()

--- a/lib/actions/arrangementer.ts
+++ b/lib/actions/arrangementer.ts
@@ -58,9 +58,7 @@ async function losne(
 }
 
 export async function opprettArrangement(data: ArrangementInput) {
-  const supabase = await createServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error('Ikke innlogget')
+  const { supabase, user } = await ensureInnlogget()
 
   const { data: arrangement, error } = await supabase
     .from('arrangementer')
@@ -175,9 +173,7 @@ export async function oppdaterArrangement(id: string, data: Partial<ArrangementI
 // hilsen er valgfri fri tekst fra avsender — valideres server-side mot
 // VARSLE_MAKS_LENGDE slik at klient-maxLength aldri er eneste sperre. Se #282.
 export async function varslOmArrangement(arrangementId: string, hilsen?: string) {
-  const supabase = await createServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error('Ikke innlogget')
+  const { supabase, user } = await ensureInnlogget()
 
   const trimmetHilsen = hilsen?.trim()
 

--- a/lib/actions/chat.ts
+++ b/lib/actions/chat.ts
@@ -5,6 +5,7 @@ import { sendChatMentionVarsler, sendVarsel } from '@/lib/varsler'
 import { BASE_URL } from '@/lib/config'
 import { CHAT_MIN_LENGDE, INNLEGG_MIN_LENGDE } from '@/lib/konstanter'
 import { konfigFor, type ChatScope } from '@/lib/chat-konfig'
+import { ensureInnlogget } from '@/lib/auth'
 
 // Trimmer og validerer chat-innhold for et gitt scope. Bruker scope-spesifikk
 // charLimit (privat = INNLEGG_MAKS_LENGDE = 2000, øvrige = CHAT_MAKS_LENGDE
@@ -111,9 +112,7 @@ export async function sendChatMelding(
   const k = konfigFor(scope)
   const { tekst } = validerInnhold(innhold, bildeUrl, k.charLimit)
 
-  const supabase = await createServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error('Ikke innlogget')
+  const { supabase, user } = await ensureInnlogget()
 
   const fkData = k.fkFelt ? { [k.fkFelt]: k.scopeId(scope) } : {}
   const { error } = await supabase
@@ -179,9 +178,7 @@ export async function slettChatMelding(
 // melding_id peker til id-en i den underliggende chat-tabellen (RLS
 // håndhever at brukeren kun kan legge til/fjerne egne reaksjoner).
 export async function leggTilReaksjon(meldingId: string, emoji: string) {
-  const supabase = await createServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error('Ikke innlogget')
+  const { supabase, user } = await ensureInnlogget()
 
   const { error } = await supabase
     .from('chat_reaksjoner')
@@ -194,9 +191,7 @@ export async function leggTilReaksjon(meldingId: string, emoji: string) {
 }
 
 export async function fjernReaksjon(meldingId: string, emoji: string) {
-  const supabase = await createServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error('Ikke innlogget')
+  const { supabase, user } = await ensureInnlogget()
 
   const { error } = await supabase
     .from('chat_reaksjoner')

--- a/lib/actions/meldinger.ts
+++ b/lib/actions/meldinger.ts
@@ -142,9 +142,7 @@ export async function oppdaterMeldingPost(meldingId: string, innhold: string) {
 // Reaksjoner på selve innlegget. Egen tabell `melding_reaksjon` for å
 // holde dem adskilt fra chat_reaksjoner som er på kommentar-nivå.
 export async function leggTilMeldingReaksjon(meldingId: string, emoji: string) {
-  const supabase = await createServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error('Ikke innlogget')
+  const { supabase, user } = await ensureInnlogget()
 
   const { error } = await supabase
     .from('melding_reaksjon')
@@ -157,9 +155,7 @@ export async function leggTilMeldingReaksjon(meldingId: string, emoji: string) {
 }
 
 export async function fjernMeldingReaksjon(meldingId: string, emoji: string) {
-  const supabase = await createServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error('Ikke innlogget')
+  const { supabase, user } = await ensureInnlogget()
 
   const { error } = await supabase
     .from('melding_reaksjon')

--- a/lib/actions/paameldinger.ts
+++ b/lib/actions/paameldinger.ts
@@ -1,16 +1,14 @@
 'use server'
 
-import { createServerClient } from '@/lib/supabase/server'
 import { revalidatePath } from 'next/cache'
 import { naa } from '@/lib/dato'
+import { ensureInnlogget } from '@/lib/auth'
 
 export async function oppdaterPaamelding(
   arrangementId: string,
   status: 'ja' | 'nei' | 'kanskje'
 ) {
-  const supabase = await createServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error('Ikke innlogget')
+  const { supabase, user } = await ensureInnlogget()
 
   const { error } = await supabase
     .from('paameldinger')

--- a/lib/actions/pass.ts
+++ b/lib/actions/pass.ts
@@ -1,11 +1,11 @@
 'use server'
 
-import { createServerClient } from '@/lib/supabase/server'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { sendVarsel } from '@/lib/varsler'
 import { BASE_URL } from '@/lib/config'
 import { naa } from '@/lib/dato'
 import { PASS_TILGANG_TIMER } from '@/lib/konstanter'
+import { ensureInnlogget } from '@/lib/auth'
 
 /**
  * Lagre eller oppdatere passinfo for innlogget bruker. Validerer ikke
@@ -17,9 +17,7 @@ export async function lagrePassInfo(input: { nummer: string; utloper: string }) 
   const utloper = input.utloper // YYYY-MM-DD fra date input
   if (!nummer || !utloper) throw new Error('Både nummer og utløpsdato må fylles ut')
 
-  const supabase = await createServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error('Ikke innlogget')
+  const { supabase, user } = await ensureInnlogget()
 
   const { error } = await supabase
     .from('pass_info')
@@ -34,9 +32,7 @@ export async function lagrePassInfo(input: { nummer: string; utloper: string }) 
  * Generalsekretæren får varsel og må godkjenne.
  */
 export async function bePassTilgang(input: { eier_id: string; arrangement_id: string }) {
-  const supabase = await createServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error('Ikke innlogget')
+  const { supabase, user } = await ensureInnlogget()
 
   const { data: ny, error } = await supabase
     .from('pass_tilgang_forespørsel')
@@ -102,9 +98,7 @@ export async function bePassTilgang(input: { eier_id: string; arrangement_id: st
  * gyldig_til til nå + 24 timer. Sender varsel til søkeren.
  */
 export async function godkjennPassTilgang(forespørselId: string) {
-  const supabase = await createServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error('Ikke innlogget')
+  const { supabase, user } = await ensureInnlogget()
 
   const naDate = new Date()
   const utloper = new Date(naDate.getTime() + PASS_TILGANG_TIMER * 60 * 60 * 1000)
@@ -146,9 +140,7 @@ export async function godkjennPassTilgang(forespørselId: string) {
 }
 
 export async function avslaaPassTilgang(forespørselId: string) {
-  const supabase = await createServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error('Ikke innlogget')
+  const { supabase, user } = await ensureInnlogget()
 
   const { data: oppdatert, error } = await supabase
     .from('pass_tilgang_forespørsel')

--- a/lib/actions/poll.ts
+++ b/lib/actions/poll.ts
@@ -4,6 +4,7 @@ import { createServerClient } from '@/lib/supabase/server'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { sendNyPollVarsler } from '@/lib/varsler'
+import { ensureInnlogget } from '@/lib/auth'
 
 export type PollInput = {
   spoersmaal: string
@@ -22,9 +23,7 @@ export type PollInput = {
  * også for å gi ordentlige feilmeldinger til brukeren.
  */
 export async function opprettPoll(data: PollInput) {
-  const supabase = await createServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error('Ikke innlogget')
+  const { supabase, user } = await ensureInnlogget()
 
   const spoersmaal = data.spoersmaal.trim()
   if (spoersmaal.length < 1 || spoersmaal.length > 200) {
@@ -89,9 +88,7 @@ export async function opprettPoll(data: PollInput) {
  * — hvis den er det, vil insert feile og brukeren får beskjed.
  */
 export async function stemPaaPoll(pollId: string, valgIds: string[]) {
-  const supabase = await createServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error('Ikke innlogget')
+  const { supabase, user } = await ensureInnlogget()
 
   if (valgIds.length === 0) throw new Error('Velg minst ett alternativ')
 

--- a/lib/actions/samtaler.ts
+++ b/lib/actions/samtaler.ts
@@ -3,6 +3,7 @@
 import { createServerClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 import { revalidatePath } from 'next/cache'
+import { ensureInnlogget } from '@/lib/auth'
 
 /**
  * Finn eller opprett samtalen mellom innlogget bruker og motpart.
@@ -10,9 +11,7 @@ import { revalidatePath } from 'next/cache'
  * a < b. Returnerer samtaleId eller redirecter til samtalesiden.
  */
 export async function aapneSamtale(motpartId: string) {
-  const supabase = await createServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error('Ikke innlogget')
+  const { supabase, user } = await ensureInnlogget()
   if (motpartId === user.id) throw new Error('Kan ikke åpne samtale med deg selv')
 
   // Sorter ID-ene så constraint-en (profil_a < profil_b) holder uavhengig
@@ -51,6 +50,7 @@ export async function aapneSamtale(motpartId: string) {
  * andres meldinger (mottatte) — ikke egne.
  */
 export async function markerSamtaleLest(samtaleId: string) {
+  // se #305 — bevisst silent no-op, ikke ensureInnlogget (som kaster ved uinnlogget)
   const supabase = await createServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return

--- a/lib/actions/samtaler.ts
+++ b/lib/actions/samtaler.ts
@@ -50,7 +50,8 @@ export async function aapneSamtale(motpartId: string) {
  * andres meldinger (mottatte) — ikke egne.
  */
 export async function markerSamtaleLest(samtaleId: string) {
-  // se #305 — bevisst silent no-op, ikke ensureInnlogget (som kaster ved uinnlogget)
+  // se #305 — bevisst silent no-op, ikke ensureInnlogget: kalles som background-
+  // effekt ved sidelast, og en utløpt sesjon skal ikke kaste feil til klienten
   const supabase = await createServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -8,6 +8,10 @@ import { kanAdministrere, loeserTiebreak } from '@/lib/roller'
 // Returnerer den samme supabase-klienten som ble brukt til auth-sjekken,
 // slik at videre spørringer går mot brukerens RLS-kontekst og ikke krever
 // en ny createServerClient()-runde.
+//
+// NB: Feilmeldingen 'Ikke innlogget' er en kontrakt — route handlers
+// (f.eks. /api/admin/opprett-medlem) streng-matcher den for å velge
+// 401 vs 403. Endres teksten, må de oppdateres samtidig.
 export async function ensureAdmin() {
   const supabase = await createServerClient()
   const {

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 23,
-  "versjon": "V3.2.23"
+  "nummer": 24,
+  "versjon": "V3.2.24"
 }

--- a/lib/versjon.json
+++ b/lib/versjon.json
@@ -1,4 +1,4 @@
 {
-  "nummer": 24,
-  "versjon": "V3.2.24"
+  "nummer": 25,
+  "versjon": "V3.2.25"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.2.24'
+const CACHE_VERSION = 'V3.2.25'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 //
 // PAGE_CACHE er versjonert fordi HTML ikke er innholdshashet — nye builds
 // kan ha samme URL men forskjellig output.
-const CACHE_VERSION = 'V3.2.23'
+const CACHE_VERSION = 'V3.2.24'
 const STATIC_CACHE = 'herreklubben-static'
 const PAGE_CACHE = `herreklubben-pages-${CACHE_VERSION}`
 


### PR DESCRIPTION
## Sammendrag

- Erstatter duplisert `createServerClient()` + `getUser()` + throw-mønster med `ensureInnlogget()` i 7 action-filer (chat, pass, arrangementer, meldinger, poll, samtaler, paameldinger) — jf. Policy: Auth.
- `app/api/admin/opprett-medlem`: inline admin-sjekk erstattet med `ensureAdmin()` i try/catch som bevarer 401/403-statuskoder.
- `markerSamtaleLest` beholdes bevisst som silent no-op (background-effekt, skal ikke kaste) — dokumentert med kommentar.

## Beslutninger underveis

- Intern review: 1 MINOR (statuskode-valg streng-matcher 'Ikke innlogget' — skjør kobling) → rettet med kontrakt-kommentar i `lib/auth.ts`; egen feilklasse vurdert som overkill for ett kallested. 2 NIT-er: kommentar utdypet, ubrukt-import-sjekk bekreftet grønn.
- `varsel-preferanser` og `push/subscribe` har også inline getUser, men er utenfor issue-scope — lar stå.

Lukker ikke automatisk; issue #305 lukkes manuelt etter merge.